### PR TITLE
feat: cut off MaskPlacer when it is possible

### DIFF
--- a/src/SkiaSharp.QrCode.Benchmark/QRCodeEncodeEndToEnd.cs
+++ b/src/SkiaSharp.QrCode.Benchmark/QRCodeEncodeEndToEnd.cs
@@ -9,6 +9,7 @@ using System.Text;
 ///   Numeric_V1_L : version 1, numeric mode (digits only)
 ///   Alphanumeric_V1_M : version 1, alphanumeric mode (uppercase / punctuation subset)
 ///   Byte_Url_V6_M : version 6, byte mode (typical URL with lowercase)
+///   Byte_V20_M : version 20-M, byte mode (mid-size, exercises the 2-word SoA mask tier)
 ///   Byte_V40_L : version 40-L, byte mode (largest data blocks)
 ///   Byte_V40_H : version 40-H, byte mode (81 blocks x 30 ecc, max ECC share)
 /// </summary>
@@ -17,6 +18,7 @@ public class QRCodeEncodeEndToEnd
     private string _numeric = default!;
     private string _alphanumeric = default!;
     private string _byteUrl = default!;
+    private string _byteMidM = default!;
     private string _byteLongL = default!;
     private string _byteLongH = default!;
     private byte[] _spanDestination = default!;
@@ -27,6 +29,7 @@ public class QRCodeEncodeEndToEnd
         _numeric = "0123456789"; // version 1-L, numeric mode
         _alphanumeric = "HELLO WORLD 2026"; // version 1-M, alphanumeric mode
         _byteUrl = "https://github.com/guitarrapc/SkiaSharp.QrCode/blob/main/README.md?foo=sample&bar=dummy"; // version 6-M, byte mode
+        _byteMidM = BuildDeterministicText(620); // version 20-M byte mode (max 666)
         _byteLongL = BuildDeterministicText(2900); // version 40-L byte mode (max 2953)
         _byteLongH = BuildDeterministicText(1200); // version 40-H byte mode (max 1273)
         _spanDestination = new byte[Math.Max(
@@ -52,6 +55,12 @@ public class QRCodeEncodeEndToEnd
     public QRCodeData QR_Byte_Url_V6_M_Encode()
     {
         return QRCodeGenerator.CreateQrCode(_byteUrl.AsSpan(), ECCLevel.M);
+    }
+
+    [Benchmark]
+    public QRCodeData QR_Byte_V20_M_Encode()
+    {
+        return QRCodeGenerator.CreateQrCode(_byteMidM.AsSpan(), ECCLevel.M);
     }
 
     [Benchmark]

--- a/src/SkiaSharp.QrCode/Internals/StandardQR/ModulePlacer.Masking.Simd.cs
+++ b/src/SkiaSharp.QrCode/Internals/StandardQR/ModulePlacer.Masking.Simd.cs
@@ -33,9 +33,11 @@ namespace SkiaSharp.QrCode.Internals.StandardQr;
 /// - Abort: no per-row threshold (measured, reduction cost eats the win), but
 ///   each scorer checkpoints once before the column-rule-3 loop — the partial
 ///   score is a lower bound (the remaining terms are non-negative), so a pattern
-///   already above the best total skips that loop without changing the selection.
-///   Evaluation order stays 0..7: mask totals sit too close together for
-///   win-frequency ordering to matter (measured, mask-order findings log).
+///   already above the best total skips that loop without changing the selection
+///   (the lane-per-pattern tier skips only when all four candidates in the
+///   group are above). Evaluation order stays 0..7: mask totals sit too close
+///   together for win-frequency ordering to matter (measured, mask-order
+///   findings log).
 ///
 /// This file only executes under Avx2.IsSupported (x86/x64), so memory order is
 /// always little-endian and the SWAR tail reads skip endianness normalization.
@@ -856,7 +858,10 @@ internal static partial class ModulePlacer
 
         // Checkpoint: the remaining rule-3-column and balance terms are non-negative,
         // so the partial is a lower bound — a pattern already above the best total
-        // cannot win or tie, and the heaviest loop below is skipped.
+        // cannot win or tie, and the heaviest loop below is skipped. The first
+        // pattern has no bound yet (abortAbove == int.MaxValue), so skip the
+        // reductions too.
+        if (abortAbove != int.MaxValue)
         {
             var partial = score1 + score2 + score3
                         + (int)Vector256.Sum(accOnes) + 2 * (int)Vector256.Sum(accTwos)
@@ -1274,7 +1279,10 @@ internal static partial class ModulePlacer
 
         // Checkpoint: the remaining rule-3-column and balance terms are non-negative,
         // so the partial is a lower bound — a pattern already above the best total
-        // cannot win or tie, and the heaviest loop below is skipped.
+        // cannot win or tie, and the heaviest loop below is skipped. The first
+        // pattern has no bound yet (abortAbove == int.MaxValue), so skip the
+        // reductions too.
+        if (abortAbove != int.MaxValue)
         {
             var partial = score1 + score2 + score3
                         + (int)Vector256.Sum(accOnes) + 2 * (int)Vector256.Sum(accTwos)

--- a/src/SkiaSharp.QrCode/Internals/StandardQR/ModulePlacer.Masking.Simd.cs
+++ b/src/SkiaSharp.QrCode/Internals/StandardQR/ModulePlacer.Masking.Simd.cs
@@ -30,8 +30,12 @@ namespace SkiaSharp.QrCode.Internals.StandardQr;
 /// - Byte&lt;-&gt;bit edges are native SIMD: packing 0/1 bytes is pcmpeqb+pmovmskb
 ///   (32 modules per step), unpacking the winner's XOR delta is
 ///   broadcast+vpshufb+vpcmpeqb (32 modules per step).
-/// - No abort threshold: measured, raw 4-lane throughput beats the scalar
-///   scorer's early-exit at every size (v1 1.33x, v10 2.03x, v40 1.47x).
+/// - Abort: no per-row threshold (measured, reduction cost eats the win), but
+///   each scorer checkpoints once before the column-rule-3 loop — the partial
+///   score is a lower bound (the remaining terms are non-negative), so a pattern
+///   already above the best total skips that loop without changing the selection.
+///   Evaluation order stays 0..7: mask totals sit too close together for
+///   win-frequency ordering to matter (measured, mask-order findings log).
 ///
 /// This file only executes under Avx2.IsSupported (x86/x64), so memory order is
 /// always little-endian and the SWAR tail reads skip endianness normalization.
@@ -421,7 +425,7 @@ internal static partial class ModulePlacer
             {
                 rows4[y] = (Vector256.Create(packed[y]) ^ Unsafe.Add(ref pre, preBase + y)) | Unsafe.Add(ref fmt, fmtBase + y);
             }
-            var scores = ScoreLanes64(rows4, nrows4, eq4, size);
+            var scores = ScoreLanes64(rows4, nrows4, eq4, size, g == 0 ? int.MaxValue : bestScore);
             for (var lane = 0; lane < 4; lane++)
             {
                 var s = scores.GetElement(lane);
@@ -472,10 +476,12 @@ internal static partial class ModulePlacer
     /// Lane-per-pattern penalty scorer: <paramref name="rows"/>[y] holds row y of four
     /// candidates; returns their four ISO/IEC 18004 penalty scores. Same rule
     /// derivations as <see cref="CalculateScorePacked"/>; the accumulators are per
-    /// lane, so no horizontal reduction happens until the end.
+    /// lane, so no horizontal reduction happens until the end. When all four lanes'
+    /// partials exceed <paramref name="abortAbove"/> at the checkpoint, every lane
+    /// reports int.MaxValue (pass int.MaxValue to disable, as for the first group).
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-    internal static Vector128<int> ScoreLanes64(Span<Vector256<ulong>> rows, Span<Vector256<ulong>> nrows, Span<Vector256<ulong>> eq, int size)
+    internal static Vector128<int> ScoreLanes64(Span<Vector256<ulong>> rows, Span<Vector256<ulong>> nrows, Span<Vector256<ulong>> eq, int size, int abortAbove)
     {
         var rowMaskV = Vector256.Create(size == 64 ? ulong.MaxValue : (1ul << size) - 1);
         var startMaskV = Vector256.Create((1ul << (size - 10)) - 1);
@@ -533,6 +539,21 @@ internal static partial class ModulePlacer
             accOnes += Pop256(cur);
             accTwos += Pop256(Vector256.AndNot(cur, prev));
             prev = cur;
+        }
+
+        // Checkpoint (second group only): the remaining rule-3-column and balance
+        // terms are non-negative, so the partial is a lower bound of each lane's
+        // total — if every lane already exceeds the best total, skip the loop.
+        if (abortAbove != int.MaxValue)
+        {
+            var partial = accOnes + Vector256.ShiftLeft(accTwos, 1)
+                        + accP2 + Vector256.ShiftLeft(accP2, 1)
+                        + Vector256.ShiftLeft(accP3, 5) + Vector256.ShiftLeft(accP3, 3);
+            var gt = Vector256.GreaterThan(partial.AsInt64(), Vector256.Create((long)abortAbove));
+            if (gt == Vector256<long>.AllBitsSet)
+            {
+                return Vector128.Create(int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue);
+            }
         }
 
         // Column rule 3: 11-row windows.
@@ -594,7 +615,7 @@ internal static partial class ModulePlacer
                 }
                 PokeFormatBitsSoA2(mw0, mw1, size, QRCodeConstants.GetFormatBits(eccLevel, patternIndex));
 
-                var score = CalculateScore128Vec(mw0, mw1, nw0, nw1, eq0, eq1, v50, v51, size);
+                var score = CalculateScore128Vec(mw0, mw1, nw0, nw1, eq0, eq1, v50, v51, size, bestScore);
                 if (score < bestScore)
                 {
                     bestPatternIndex = patternIndex;
@@ -684,13 +705,15 @@ internal static partial class ModulePlacer
         public Vector256<ulong> Pop() => Pop256(A) + Pop256(B);
     }
 
-    /// <summary>Two-word SoA Vector256 penalty scorer (structure mirrors the single-word scorer, lane-per-row layout).</summary>
+    /// <summary>Two-word SoA Vector256 penalty scorer (structure mirrors the single-word scorer, lane-per-row layout).
+    /// Returns int.MaxValue without running the column-rule-3 loop once the partial score
+    /// provably exceeds <paramref name="abortAbove"/> (see the checkpoint note in the file header).</summary>
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
     internal static int CalculateScore128Vec(
         Span<ulong> rw0, Span<ulong> rw1,
         Span<ulong> nw0, Span<ulong> nw1,
         Span<ulong> eq0, Span<ulong> eq1,
-        Span<ulong> v50, Span<ulong> v51, int size)
+        Span<ulong> v50, Span<ulong> v51, int size, int abortAbove)
     {
         var rowMaskR = Row192.MaskLow(size);
         var startMaskR = Row192.MaskLow(size - 10);
@@ -831,6 +854,19 @@ internal static partial class ModulePlacer
             score1 += v5.PopCount() + 2 * v5.AndNotWith(prev).PopCount();
         }
 
+        // Checkpoint: the remaining rule-3-column and balance terms are non-negative,
+        // so the partial is a lower bound — a pattern already above the best total
+        // cannot win or tie, and the heaviest loop below is skipped.
+        {
+            var partial = score1 + score2 + score3
+                        + (int)Vector256.Sum(accOnes) + 2 * (int)Vector256.Sum(accTwos)
+                        + 3 * (int)Vector256.Sum(accP2) + 40 * (int)Vector256.Sum(accP3);
+            if (partial > abortAbove)
+            {
+                return int.MaxValue;
+            }
+        }
+
         var b0 = 0;
         for (; b0 + 4 <= size - 10; b0 += 4)
         {
@@ -927,7 +963,7 @@ internal static partial class ModulePlacer
                 }
                 PokeFormatBitsSoA3(mw0, mw1, mw2, size, QRCodeConstants.GetFormatBits(eccLevel, patternIndex));
 
-                var score = CalculateScore192Vec(mw0, mw1, mw2, nw0, nw1, nw2, eq0, eq1, eq2, v50, v51, v52, size);
+                var score = CalculateScore192Vec(mw0, mw1, mw2, nw0, nw1, nw2, eq0, eq1, eq2, v50, v51, v52, size, bestScore);
                 if (score < bestScore)
                 {
                     bestPatternIndex = patternIndex;
@@ -1078,13 +1114,15 @@ internal static partial class ModulePlacer
         public Vector256<ulong> Pop() => Pop256(A) + Pop256(B) + Pop256(C);
     }
 
-    /// <summary>Three-word SoA Vector256 penalty scorer (structure mirrors the single-word scorer, lane-per-row layout).</summary>
+    /// <summary>Three-word SoA Vector256 penalty scorer (structure mirrors the single-word scorer, lane-per-row layout).
+    /// Returns int.MaxValue without running the column-rule-3 loop once the partial score
+    /// provably exceeds <paramref name="abortAbove"/> (see the checkpoint note in the file header).</summary>
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
     internal static int CalculateScore192Vec(
         Span<ulong> rw0, Span<ulong> rw1, Span<ulong> rw2,
         Span<ulong> nw0, Span<ulong> nw1, Span<ulong> nw2,
         Span<ulong> eq0, Span<ulong> eq1, Span<ulong> eq2,
-        Span<ulong> v50, Span<ulong> v51, Span<ulong> v52, int size)
+        Span<ulong> v50, Span<ulong> v51, Span<ulong> v52, int size, int abortAbove)
     {
         var rowMaskR = Row192.MaskLow(size);
         var startMaskR = Row192.MaskLow(size - 10);
@@ -1232,6 +1270,19 @@ internal static partial class ModulePlacer
             var v5 = new Row192(v50[y], v51[y], v52[y]);
             var prev = new Row192(v50[y - 1], v51[y - 1], v52[y - 1]);
             score1 += v5.PopCount() + 2 * v5.AndNotWith(prev).PopCount();
+        }
+
+        // Checkpoint: the remaining rule-3-column and balance terms are non-negative,
+        // so the partial is a lower bound — a pattern already above the best total
+        // cannot win or tie, and the heaviest loop below is skipped.
+        {
+            var partial = score1 + score2 + score3
+                        + (int)Vector256.Sum(accOnes) + 2 * (int)Vector256.Sum(accTwos)
+                        + 3 * (int)Vector256.Sum(accP2) + 40 * (int)Vector256.Sum(accP3);
+            if (partial > abortAbove)
+            {
+                return int.MaxValue;
+            }
         }
 
         var b0 = 0;


### PR DESCRIPTION
## Summary

Add a monotone abort checkpoint to the AVX2 mask-selection scorers (`ModulePlacer.Masking.Simd.cs`). Right before the column-rule-3 loop — the heaviest scoring pass — each scorer now compares its partial score against the best total seen so far and skips the loop when the pattern provably cannot win.

- Versions 12-29 / 30-40 (SoA tiers): one horizontal reduction + compare per pattern.
- Versions 1-11 (lane-per-pattern tier): a single vector compare for the second group; the loop is skipped only when all four lanes exceed the bound.
- Adds a `QR_Byte_V20_M_Encode` scenario to `QRCodeEncodeEndToEnd` — the 2-word SoA tier (versions 12-29) previously had no E2E coverage.

## Why this is safe

The partial score at the checkpoint is a lower bound of the pattern's total: the only remaining terms (rule-3 column matches and the balance score) are non-negative. A pattern is skipped only when `partial > best`, so it can neither win nor tie — mask selection and output matrices are byte-identical. `ModulePlacerMaskSimdParityTest` and `ModulePlacerMaskPackedParityTest` gate this; the full suite (16,253 tests, net8.0 + net10.0) is green.

Per-row abort was previously measured and rejected for these vectorized scorers; this checkpoint fires once per pattern instead of once per row, which is why it pays where the per-row form did not. Pattern evaluation order stays 0..7 — penalty totals of the eight masks sit close together, so reordering adds nothing measurable.

## Benchmarks

`QRCodeEncodeEndToEnd` (public API, warmup 3 × 15 iterations × 3 launches, Ryzen 9 7950X3D, .NET 10):

| Benchmark | Before | After | Delta |
|---|---:|---:|---:|
| QR_Numeric_V1_L_Encode | 848.6 ns | 753.0 ns | -11% |
| QR_Alphanumeric_V1_M_Encode | 838.1 ns | 797.4 ns | -4.9% |
| QR_Byte_Url_V6_M_Encode | 2,086.7 ns | 1,977.2 ns | -5.2% |
| QR_Byte_V20_M_Encode (new) | 24,997.3 ns | 21,793.1 ns | **-12.8%** |
| QR_Byte_V40_L_Encode | 81,689.2 ns | 77,575.6 ns | within launch noise |
| QR_Byte_V40_H_Encode | 72,349.8 ns | 74,791.0 ns | within launch noise |
| MicroQR_Numeric_M2_Encode (control) | 138.1 ns | 139.2 ns | 0% |
