### PR TITLE
chore: compression no referenced and should be obsolete

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -4,6 +4,7 @@
 - **v1.2.0 adds generator options structs and version ranges.** Purely additive for Standard QR and Micro QR: every existing overload keeps its signature, exceptions and output. See [generator options](#generator-options) below.
 - **v1.2.0 introduces rMQR**, whose generator takes `RmQRCodeGeneratorOptions` rather than a parameter list. New in this release, so there is nothing to migrate from. See [rMQR](#rmqr) below.
 - **v1.2.0 makes buffer sizing `Try`-only.** `TryGetRequiredBufferSize` is on all three generators; `GetRequiredBufferSize` is `[Obsolete]` on Standard QR and Micro QR and will be removed in 2.0.0. A warning, not a break. See [sizing is Try-only](#sizing-is-try-only) below.
+- **v1.2.0 deprecates the `Compression` enum.** No API has ever accepted or returned it: the serialization feature it named was removed before 1.0.0 and the enum was left behind. `[Obsolete]` now, removed in 2.0.0. Compress the bytes from `GetRawData()` yourself, as shown under [removed features](#-removed-features).
 - **After v1.1.0, the image builders share a common base class.** Source compatible; recompile if you referenced the binary. See [image builder base class](#image-builder-base-class) below.
 - **v1.0.0 removes the obsolete `QrCode` class.** If you still use `QrCode`, see [from before v1.0.0 to v1.0.0](#from-before-v100-to-v100) below.
 - v0.11.0 introduces further improvements to Icon handling. See the IconData section below.
@@ -373,7 +374,7 @@ If you were using these features, you'll need to adjust your code accordingly.
 
 - `forceUtf8`: SkiaSharp.QrCode now automatically selects UTF-8 when needed.
 - ISO-8859-2 and Kanji: not supported for ENCODING; UTF-8 is recommended for most use cases. Kanji segments produced by other encoders are read since v1.2.0, see [Kanji mode decoding](#kanji-mode-decoding).
-- Compression: Removed to simplify the API and improve performance. Please handle compression externally if needed.
+- Compression: Removed to simplify the API and improve performance. Please handle compression externally if needed. The `Compression` enum itself outlived the feature and shipped unused through 1.1.1; it is `[Obsolete]` as of 1.2.0 and will be removed in 2.0.0.
 
 Here's an example of how to handle compression externally using [NativeCompressions](https://github.com/Cysharp/NativeCompressions):
 

--- a/src/SkiaSharp.QrCode/Compression.cs
+++ b/src/SkiaSharp.QrCode/Compression.cs
@@ -3,6 +3,13 @@ namespace SkiaSharp.QrCode;
 /// <summary>
 /// Compression mode for QR code data serialization.
 /// </summary>
+/// <remarks>
+/// No API in this library accepts or returns this type. The serialization feature it
+/// described was removed before 1.0.0; the enum was left behind and shipped in 1.1.1,
+/// which is the only reason it still exists. Compress the bytes from
+/// <c>GetRawData()</c> yourself, as shown in docs/migration.md.
+/// </remarks>
+[Obsolete("The serialization feature this enum described was removed before 1.0.0, and no API accepts or returns it. Compress the bytes from GetRawData() with the compressor of your choice instead, as shown in docs/migration.md. This type will be removed in 2.0.0.")]
 public enum Compression
 {
     /// <summary>

--- a/tests/SkiaSharp.QrCode.Tests/Shared/VestigialSurfaceTest.cs
+++ b/tests/SkiaSharp.QrCode.Tests/Shared/VestigialSurfaceTest.cs
@@ -1,0 +1,85 @@
+using System.Reflection;
+
+namespace SkiaSharp.QrCode.Tests;
+
+/// <summary>
+/// <see cref="Compression"/> names a serialization feature that no longer exists:
+/// docs/migration.md has told callers since 1.0.0 to compress the bytes from
+/// <c>GetRawData()</c> themselves. The enum outlived the feature it described, and
+/// survives 1.2.0 only because 1.1.1 exported it, so it is deprecated until 2.0.0.
+/// </summary>
+/// <remarks>
+/// A shape test, not a behaviour test. It pins the two facts that make the deprecation
+/// honest: the marker is the only notice a 1.1.1 caller gets before the removal, and the
+/// enum is safe to remove precisely because nothing in the assembly consumes it. The
+/// second half is what would have caught this type years ago.
+/// </remarks>
+public class VestigialSurfaceTest
+{
+#pragma warning disable CS0618 // Compression is the subject of these tests, not a caller of it
+
+    /// <summary>
+    /// Deprecated rather than deleted: 1.2.0 is a minor release, and package validation
+    /// against the 1.1.1 baseline holds us to that.
+    /// </summary>
+    [Test]
+    public async Task Compression_IsObsolete_AndScheduledForRemoval()
+    {
+        var obsolete = typeof(Compression).GetCustomAttribute<ObsoleteAttribute>();
+        await Assert.That(obsolete).IsNotNull();
+
+        // A warning, not an error: a caller who named the type must still be able to
+        // build while they migrate.
+        await Assert.That(obsolete!.IsError).IsFalse();
+        await Assert.That(obsolete.Message!).Contains("2.0.0");
+    }
+
+    /// <summary>
+    /// The justification for removing it. If anything ever consumes this enum again the
+    /// deprecation is wrong, and this test says so before the 2.0.0 removal does.
+    /// </summary>
+    [Test]
+    public async Task Compression_IsReferencedByNothing_InTheAssembly()
+    {
+        const BindingFlags all = BindingFlags.Public | BindingFlags.NonPublic
+            | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;
+
+        var users = new List<string>();
+        foreach (var type in typeof(Compression).Assembly.GetTypes())
+        {
+            // The enum declares its own members as Compression; everything else is a user.
+            if (type == typeof(Compression)) continue;
+
+            foreach (var method in type.GetMethods(all))
+            {
+                if (Mentions(method.ReturnType) || method.GetParameters().Any(p => Mentions(p.ParameterType)))
+                    users.Add($"{type.FullName}.{method.Name}");
+            }
+            foreach (var ctor in type.GetConstructors(all))
+            {
+                if (ctor.GetParameters().Any(p => Mentions(p.ParameterType)))
+                    users.Add($"{type.FullName}..ctor");
+            }
+            foreach (var property in type.GetProperties(all))
+            {
+                if (Mentions(property.PropertyType)) users.Add($"{type.FullName}.{property.Name}");
+            }
+            foreach (var field in type.GetFields(all))
+            {
+                if (Mentions(field.FieldType)) users.Add($"{type.FullName}.{field.Name}");
+            }
+        }
+
+        await Assert.That(users).IsEmpty()
+            .Because($"Compression is deprecated as unused, but is referenced by: {string.Join(", ", users)}");
+    }
+
+    private static bool Mentions(Type type)
+    {
+        var bare = type.HasElementType ? type.GetElementType()! : type;
+        if (bare == typeof(Compression)) return true;
+        return bare.IsGenericType && bare.GetGenericArguments().Any(Mentions);
+    }
+
+#pragma warning restore CS0618
+}


### PR DESCRIPTION
## Summary

This is a garbage enum and won't reference from Library. remove in 2.0.0