### PR TITLE
chore: add xml document to package

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -6,6 +6,7 @@
 - **v1.2.0 makes buffer sizing `Try`-only.** `TryGetRequiredBufferSize` is on all three generators; `GetRequiredBufferSize` is `[Obsolete]` on Standard QR and Micro QR and will be removed in 2.0.0. A warning, not a break. See [sizing is Try-only](#sizing-is-try-only) below.
 - **v1.2.0 deprecates the `Compression` enum.** No API has ever accepted or returned it: the serialization feature it named was removed before 1.0.0 and the enum was left behind. `[Obsolete]` now, removed in 2.0.0. Compress the bytes from `GetRawData()` yourself, as shown under [removed features](#-removed-features).
 - **v1.2.0 removes the `EciModeExtensions` class from the public API.** It was public through 1.1.1 with every member internal, so nothing could be called on it and nothing can break. It is internal now rather than deprecated.
+- **v1.2.0 ships XML documentation in the package.** Editors now show summaries, parameter help and exceptions for every public type, where earlier releases showed only signatures. Nothing to migrate. Documentation for types under `Internals` is removed before packing, so only what you can call is described.
 - **After v1.1.0, the image builders share a common base class.** Source compatible; recompile if you referenced the binary. See [image builder base class](#image-builder-base-class) below.
 - **v1.0.0 removes the obsolete `QrCode` class.** If you still use `QrCode`, see [from before v1.0.0 to v1.0.0](#from-before-v100-to-v100) below.
 - v0.11.0 introduces further improvements to Icon handling. See the IconData section below.

--- a/src/SkiaSharp.QrCode/ECCLevel.cs
+++ b/src/SkiaSharp.QrCode/ECCLevel.cs
@@ -1,5 +1,9 @@
 namespace SkiaSharp.QrCode;
 
+/// <summary>
+/// How much of a QR code can be damaged, dirty or covered and still scan.
+/// Higher levels leave less room for content, so the same text may need a larger symbol.
+/// </summary>
 public enum ECCLevel
 {
     /// <summary>

--- a/src/SkiaSharp.QrCode/ECCLevel.cs
+++ b/src/SkiaSharp.QrCode/ECCLevel.cs
@@ -1,8 +1,9 @@
 namespace SkiaSharp.QrCode;
 
 /// <summary>
-/// How much of a QR code can be damaged, dirty or covered and still scan.
-/// Higher levels leave less room for content, so the same text may need a larger symbol.
+/// The error correction level: how much of a symbol can be damaged, dirty or covered
+/// while the code still scans. Higher levels leave less room for content, so the same
+/// text may need a larger symbol.
 /// </summary>
 public enum ECCLevel
 {

--- a/src/SkiaSharp.QrCode/Image/GradientOptions.cs
+++ b/src/SkiaSharp.QrCode/Image/GradientOptions.cs
@@ -15,6 +15,10 @@ namespace SkiaSharp.QrCode.Image;
 /// </remarks>
 public record class GradientOptions
 {
+    /// <summary>
+    /// A ready-made gradient: dark orange to firebrick, running from the top-left corner
+    /// to the bottom-right. Use it when you want a gradient without choosing colors.
+    /// </summary>
     public static readonly GradientOptions Default = new([SKColors.DarkOrange, SKColors.Firebrick], GradientDirection.TopLeftToBottomRight);
 
     /// <summary>

--- a/src/SkiaSharp.QrCode/Image/IconData.cs
+++ b/src/SkiaSharp.QrCode/Image/IconData.cs
@@ -1,5 +1,13 @@
 namespace SkiaSharp.QrCode.Image;
 
+/// <summary>
+/// A logo or image to place in the middle of a QR code, and how big to draw it.
+/// </summary>
+/// <remarks>
+/// The icon covers modules, so the code relies on error correction to stay readable.
+/// Use <see cref="ECCLevel.H"/> and keep the icon small; the builder rejects an icon
+/// that would cover more than <see cref="MaxCoreOccupancyPercent"/> of the symbol.
+/// </remarks>
 public class IconData
 {
     /// <summary>

--- a/src/SkiaSharp.QrCode/Image/IconData.cs
+++ b/src/SkiaSharp.QrCode/Image/IconData.cs
@@ -1,12 +1,14 @@
 namespace SkiaSharp.QrCode.Image;
 
 /// <summary>
-/// A logo or image to place in the middle of a QR code, and how big to draw it.
+/// The logo or image drawn at the center of a QR code, and its size.
 /// </summary>
 /// <remarks>
-/// The icon covers modules, so the code relies on error correction to stay readable.
-/// Use <see cref="ECCLevel.H"/> and keep the icon small; the builder rejects an icon
-/// that would cover more than <see cref="MaxCoreOccupancyPercent"/> of the symbol.
+/// The icon covers modules, so the symbol relies on error correction to stay readable.
+/// Use the highest error correction level (<see cref="ECCLevel.H"/>) and keep the icon
+/// small. When the size is given in modules, rendering throws if the icon and its border
+/// span more than <see cref="MaxCoreOccupancyPercent"/> percent of the core width; sizes
+/// given as a percentage of the image are not checked against the symbol at all.
 /// </remarks>
 public class IconData
 {

--- a/src/SkiaSharp.QrCode/Image/IconShape.cs
+++ b/src/SkiaSharp.QrCode/Image/IconShape.cs
@@ -46,7 +46,7 @@ public sealed class ImageIconShape : IconShape
     /// <summary>
     /// Creates an icon from an image.
     /// </summary>
-    /// <param name="image">The image to draw. It is scaled to fit the icon area, and the caller keeps ownership of it.</param>
+    /// <param name="image">The image to draw. It is stretched to fill the icon area, so its aspect ratio is not preserved. The caller keeps ownership of it.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="image"/> is null.</exception>
     public ImageIconShape(SKBitmap image)
     {

--- a/src/SkiaSharp.QrCode/Image/IconShape.cs
+++ b/src/SkiaSharp.QrCode/Image/IconShape.cs
@@ -43,6 +43,11 @@ public sealed class ImageIconShape : IconShape
 {
     private readonly SKBitmap _image;
 
+    /// <summary>
+    /// Creates an icon from an image.
+    /// </summary>
+    /// <param name="image">The image to draw. It is scaled to fit the icon area, and the caller keeps ownership of it.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="image"/> is null.</exception>
     public ImageIconShape(SKBitmap image)
     {
         _image = image ?? throw new ArgumentNullException(nameof(image));

--- a/src/SkiaSharp.QrCode/Image/MicroQRCodeImageBuilder.cs
+++ b/src/SkiaSharp.QrCode/Image/MicroQRCodeImageBuilder.cs
@@ -30,6 +30,12 @@ public class MicroQRCodeImageBuilder : QRCodeImageBuilderBase<MicroQRCodeImageBu
     private int? _maskPattern;
     private MicroQRSegmentation _segmentation = MicroQRSegmentation.Single;
 
+    /// <summary>
+    /// Starts a builder that will encode <paramref name="content"/> when you ask for an image.
+    /// Error correction, version and the rest keep their defaults until you set them.
+    /// </summary>
+    /// <param name="content">The text to encode. Micro QR holds very little, so keep it short.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="content"/> is empty or only whitespace.</exception>
     public MicroQRCodeImageBuilder(string content) : base(defaultQuietZoneSize: 2)
     {
         if (string.IsNullOrWhiteSpace(content))
@@ -38,6 +44,12 @@ public class MicroQRCodeImageBuilder : QRCodeImageBuilderBase<MicroQRCodeImageBu
         _content = content;
     }
 
+    /// <summary>
+    /// Starts a builder that draws a Micro QR code you have already generated. Nothing is
+    /// re-encoded, so the encoding options have no effect here; only the appearance does.
+    /// </summary>
+    /// <param name="microQrCodeData">The Micro QR code to draw.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="microQrCodeData"/> is null.</exception>
     public MicroQRCodeImageBuilder(MicroQRCodeData microQrCodeData) : base(defaultQuietZoneSize: 2)
     {
         if (microQrCodeData is null)

--- a/src/SkiaSharp.QrCode/Image/MicroQRCodeImageBuilder.cs
+++ b/src/SkiaSharp.QrCode/Image/MicroQRCodeImageBuilder.cs
@@ -32,7 +32,7 @@ public class MicroQRCodeImageBuilder : QRCodeImageBuilderBase<MicroQRCodeImageBu
 
     /// <summary>
     /// Starts a builder that will encode <paramref name="content"/> when you ask for an image.
-    /// Error correction, version and the rest keep their defaults until you set them.
+    /// Error correction, version and every other option keep their defaults until you set them.
     /// </summary>
     /// <param name="content">The text to encode. Micro QR holds very little, so keep it short.</param>
     /// <exception cref="ArgumentException">Thrown when <paramref name="content"/> is empty or only whitespace.</exception>
@@ -45,8 +45,9 @@ public class MicroQRCodeImageBuilder : QRCodeImageBuilderBase<MicroQRCodeImageBu
     }
 
     /// <summary>
-    /// Starts a builder that draws a Micro QR code you have already generated. Nothing is
-    /// re-encoded, so the encoding options have no effect here; only the appearance does.
+    /// Starts a builder that draws a Micro QR code you have already generated. The symbol is
+    /// used exactly as given, so only the appearance options apply. Every encoding option
+    /// throws <see cref="InvalidOperationException"/> on a builder created this way.
     /// </summary>
     /// <param name="microQrCodeData">The Micro QR code to draw.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="microQrCodeData"/> is null.</exception>

--- a/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs
+++ b/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs
@@ -45,6 +45,12 @@ public class QRCodeImageBuilder : QRCodeImageBuilderBase<QRCodeImageBuilder>
     private FinderPatternShape? _finderPatternShape;
     private IconData? _iconData;
 
+    /// <summary>
+    /// Starts a builder that will encode <paramref name="content"/> when you ask for an image.
+    /// Error correction, version and the rest keep their defaults until you set them.
+    /// </summary>
+    /// <param name="content">The text or URL to encode.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="content"/> is empty or only whitespace.</exception>
     public QRCodeImageBuilder(string content) : base(defaultQuietZoneSize: 4)
     {
         if (string.IsNullOrWhiteSpace(content))
@@ -53,6 +59,12 @@ public class QRCodeImageBuilder : QRCodeImageBuilderBase<QRCodeImageBuilder>
         _content = content;
     }
 
+    /// <summary>
+    /// Starts a builder that draws a QR code you have already generated. Nothing is
+    /// re-encoded, so the encoding options have no effect here; only the appearance does.
+    /// </summary>
+    /// <param name="qrCodeData">The QR code to draw.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="qrCodeData"/> is null.</exception>
     public QRCodeImageBuilder(QRCodeData qrCodeData) : base(defaultQuietZoneSize: 4)
     {
         if (qrCodeData is null)

--- a/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs
+++ b/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs
@@ -47,7 +47,7 @@ public class QRCodeImageBuilder : QRCodeImageBuilderBase<QRCodeImageBuilder>
 
     /// <summary>
     /// Starts a builder that will encode <paramref name="content"/> when you ask for an image.
-    /// Error correction, version and the rest keep their defaults until you set them.
+    /// Error correction, version and every other option keep their defaults until you set them.
     /// </summary>
     /// <param name="content">The text or URL to encode.</param>
     /// <exception cref="ArgumentException">Thrown when <paramref name="content"/> is empty or only whitespace.</exception>
@@ -60,8 +60,11 @@ public class QRCodeImageBuilder : QRCodeImageBuilderBase<QRCodeImageBuilder>
     }
 
     /// <summary>
-    /// Starts a builder that draws a QR code you have already generated. Nothing is
-    /// re-encoded, so the encoding options have no effect here; only the appearance does.
+    /// Starts a builder that draws a QR code you have already generated. The symbol is used
+    /// exactly as given, so only the appearance options apply. Most encoding options throw
+    /// <see cref="InvalidOperationException"/> on a builder created this way;
+    /// <see cref="WithErrorCorrection"/> and <see cref="WithEciMode"/> are accepted and then
+    /// ignored, because they shipped that way in 1.1.1.
     /// </summary>
     /// <param name="qrCodeData">The QR code to draw.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="qrCodeData"/> is null.</exception>

--- a/src/SkiaSharp.QrCode/Image/RmQRCodeImageBuilder.cs
+++ b/src/SkiaSharp.QrCode/Image/RmQRCodeImageBuilder.cs
@@ -50,7 +50,7 @@ public class RmQRCodeImageBuilder : QRCodeImageBuilderBase<RmQRCodeImageBuilder>
 
     /// <summary>
     /// Starts a builder that will encode <paramref name="content"/> when you ask for an image.
-    /// Error correction, symbol shape and the rest keep their defaults until you set them.
+    /// Error correction, version and fit keep their defaults until you set them.
     /// </summary>
     /// <param name="content">The text to encode.</param>
     /// <exception cref="ArgumentException">Thrown when <paramref name="content"/> is empty or only whitespace.</exception>
@@ -63,8 +63,9 @@ public class RmQRCodeImageBuilder : QRCodeImageBuilderBase<RmQRCodeImageBuilder>
     }
 
     /// <summary>
-    /// Starts a builder that draws an rMQR code you have already generated. Nothing is
-    /// re-encoded, so the encoding options have no effect here; only the appearance does.
+    /// Starts a builder that draws an rMQR code you have already generated. The symbol is
+    /// used exactly as given, so only the appearance options apply. Every encoding option
+    /// throws <see cref="InvalidOperationException"/> on a builder created this way.
     /// </summary>
     /// <param name="rmQrCodeData">The rMQR code to draw.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="rmQrCodeData"/> is null.</exception>

--- a/src/SkiaSharp.QrCode/Image/RmQRCodeImageBuilder.cs
+++ b/src/SkiaSharp.QrCode/Image/RmQRCodeImageBuilder.cs
@@ -48,6 +48,12 @@ public class RmQRCodeImageBuilder : QRCodeImageBuilderBase<RmQRCodeImageBuilder>
     private RmQRSegmentation _segmentation = RmQRSegmentation.Single;
     private int? _widthOnly;
 
+    /// <summary>
+    /// Starts a builder that will encode <paramref name="content"/> when you ask for an image.
+    /// Error correction, symbol shape and the rest keep their defaults until you set them.
+    /// </summary>
+    /// <param name="content">The text to encode.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="content"/> is empty or only whitespace.</exception>
     public RmQRCodeImageBuilder(string content) : base(defaultQuietZoneSize: RmQRConstants.QuietZoneModules)
     {
         if (string.IsNullOrWhiteSpace(content))
@@ -56,6 +62,12 @@ public class RmQRCodeImageBuilder : QRCodeImageBuilderBase<RmQRCodeImageBuilder>
         _content = content;
     }
 
+    /// <summary>
+    /// Starts a builder that draws an rMQR code you have already generated. Nothing is
+    /// re-encoded, so the encoding options have no effect here; only the appearance does.
+    /// </summary>
+    /// <param name="rmQrCodeData">The rMQR code to draw.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="rmQrCodeData"/> is null.</exception>
     public RmQRCodeImageBuilder(RmQRCodeData rmQrCodeData) : base(defaultQuietZoneSize: RmQRConstants.QuietZoneModules)
     {
         if (rmQrCodeData is null)

--- a/src/SkiaSharp.QrCode/Image/Vector2Slim.cs
+++ b/src/SkiaSharp.QrCode/Image/Vector2Slim.cs
@@ -19,8 +19,17 @@ public readonly record struct Vector2Slim
     /// </summary>
     public int Y { get; }
 
+    /// <summary>
+    /// Creates a vector with both components set to the same value.
+    /// </summary>
+    /// <param name="value">The value used for both X and Y.</param>
     public Vector2Slim(int value) : this(value, value) { }
 
+    /// <summary>
+    /// Creates a vector from its two components.
+    /// </summary>
+    /// <param name="x">The X component.</param>
+    /// <param name="y">The Y component.</param>
     public Vector2Slim(int x, int y) => (X, Y) = (x, y);
 
     /// <summary>

--- a/src/SkiaSharp.QrCode/Internals/BinaryDecoders/SegmentDecoders.cs
+++ b/src/SkiaSharp.QrCode/Internals/BinaryDecoders/SegmentDecoders.cs
@@ -165,7 +165,13 @@ internal static class SegmentDecoders
     /// Decodes a byte segment payload of <paramref name="count"/> bytes, resolving
     /// the effective charset (UTF-8 heuristic / BOM handling / ISO-8859-1 widening).
     /// </summary>
+    /// <param name="reader">Reader positioned at the first byte of the segment. It is advanced past them.</param>
+    /// <param name="totalBits">Length of the whole bitstream in bits, so a segment that runs off the end is rejected.</param>
+    /// <param name="count">Number of bytes in this segment.</param>
+    /// <param name="charset">The charset declared for the segment, or Unspecified to work it out from the bytes.</param>
     /// <param name="byteBuffer">Scratch buffer for the segment bytes; must hold at least <paramref name="count"/> bytes.</param>
+    /// <param name="destination">Receives the decoded text.</param>
+    /// <param name="charsWritten">How many characters <paramref name="destination"/> already holds. This call advances it.</param>
     public static QRCodeDecodeStatus DecodeBytePayload(ref BitReader reader, int totalBits, int count, ByteSegmentCharset charset, byte[] byteBuffer, Span<char> destination, ref int charsWritten)
     {
         if (totalBits - reader.BitPosition < count * 8)

--- a/src/SkiaSharp.QrCode/Internals/BinaryDecoders/SegmentDecoders.cs
+++ b/src/SkiaSharp.QrCode/Internals/BinaryDecoders/SegmentDecoders.cs
@@ -165,13 +165,13 @@ internal static class SegmentDecoders
     /// Decodes a byte segment payload of <paramref name="count"/> bytes, resolving
     /// the effective charset (UTF-8 heuristic / BOM handling / ISO-8859-1 widening).
     /// </summary>
-    /// <param name="reader">Reader positioned at the first byte of the segment. It is advanced past them.</param>
-    /// <param name="totalBits">Length of the whole bitstream in bits, so a segment that runs off the end is rejected.</param>
+    /// <param name="reader">Reader positioned at the first byte of the segment. It is advanced past the segment.</param>
+    /// <param name="totalBits">Length of the whole bitstream, in bits; used to reject a segment that runs past the end.</param>
     /// <param name="count">Number of bytes in this segment.</param>
-    /// <param name="charset">The charset declared for the segment, or Unspecified to work it out from the bytes.</param>
+    /// <param name="charset">The charset declared for the segment, or <see cref="ByteSegmentCharset.Unspecified"/> to infer it from the bytes.</param>
     /// <param name="byteBuffer">Scratch buffer for the segment bytes; must hold at least <paramref name="count"/> bytes.</param>
     /// <param name="destination">Receives the decoded text.</param>
-    /// <param name="charsWritten">How many characters <paramref name="destination"/> already holds. This call advances it.</param>
+    /// <param name="charsWritten">How many characters <paramref name="destination"/> already holds. This call advances the count.</param>
     public static QRCodeDecodeStatus DecodeBytePayload(ref BitReader reader, int totalBits, int count, ByteSegmentCharset charset, byte[] byteBuffer, Span<char> destination, ref int charsWritten)
     {
         if (totalBits - reader.BitPosition < count * 8)

--- a/src/SkiaSharp.QrCode/Internals/BinaryEncoders/BitReader.cs
+++ b/src/SkiaSharp.QrCode/Internals/BinaryEncoders/BitReader.cs
@@ -28,7 +28,7 @@ internal ref struct BitReader
     }
 
     /// <summary>
-    /// Read a single bit from the buffer, advancing the position by one.
+    /// Reads a single bit from the buffer, advancing the position by one.
     /// </summary>
     /// <returns><c>true</c> when the bit is set.</returns>
     /// <exception cref="InvalidOperationException">Thrown when there are no bits left to read.</exception>

--- a/src/SkiaSharp.QrCode/Internals/BinaryEncoders/BitReader.cs
+++ b/src/SkiaSharp.QrCode/Internals/BinaryEncoders/BitReader.cs
@@ -28,10 +28,10 @@ internal ref struct BitReader
     }
 
     /// <summary>
-    /// Read a single bit from the buffer
+    /// Read a single bit from the buffer, advancing the position by one.
     /// </summary>
-    /// <param name="value"></param>
-    /// <param name="bitCount"></param>
+    /// <returns><c>true</c> when the bit is set.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when there are no bits left to read.</exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool Read()
     {

--- a/src/SkiaSharp.QrCode/Internals/ImageDecoders/FinderPatternFinder.cs
+++ b/src/SkiaSharp.QrCode/Internals/ImageDecoders/FinderPatternFinder.cs
@@ -107,6 +107,10 @@ internal static class FinderPatternFinder
     /// in four is most of the rMQR image path: end to end the span decode of the widest
     /// symbol is 2.7x a strideless build's (see the plan's benchmark tables).
     /// </remarks>
+    /// <param name="luminance">Greyscale image, one byte per pixel, row by row.</param>
+    /// <param name="width">Image width in pixels.</param>
+    /// <param name="height">Image height in pixels.</param>
+    /// <param name="threshold">Greyscale value at or below which a pixel counts as dark.</param>
     /// <param name="candidates">Receives merged candidates; <see cref="MaxFinderCandidates"/> entries suffice.</param>
     /// <returns>The number of candidates written.</returns>
     internal static int FindCandidates(ReadOnlySpan<byte> luminance, int width, int height, byte threshold, Span<FinderPattern> candidates)
@@ -118,6 +122,10 @@ internal static class FinderPatternFinder
     /// produced nothing that decoded, which is what keeps the detection envelope from ever
     /// being narrower than a full sweep's.
     /// </summary>
+    /// <param name="luminance">Greyscale image, one byte per pixel, row by row.</param>
+    /// <param name="width">Image width in pixels.</param>
+    /// <param name="height">Image height in pixels.</param>
+    /// <param name="threshold">Greyscale value at or below which a pixel counts as dark.</param>
     /// <param name="candidates">Receives merged candidates; <see cref="MaxFinderCandidates"/> entries suffice.</param>
     /// <returns>The number of candidates written.</returns>
     internal static int FindCandidatesFullSweep(ReadOnlySpan<byte> luminance, int width, int height, byte threshold, Span<FinderPattern> candidates)

--- a/src/SkiaSharp.QrCode/Internals/ImageDecoders/FinderPatternFinder.cs
+++ b/src/SkiaSharp.QrCode/Internals/ImageDecoders/FinderPatternFinder.cs
@@ -107,10 +107,10 @@ internal static class FinderPatternFinder
     /// in four is most of the rMQR image path: end to end the span decode of the widest
     /// symbol is 2.7x a strideless build's (see the plan's benchmark tables).
     /// </remarks>
-    /// <param name="luminance">Greyscale image, one byte per pixel, row by row.</param>
+    /// <param name="luminance">Grayscale pixels, row-major, width × height bytes.</param>
     /// <param name="width">Image width in pixels.</param>
     /// <param name="height">Image height in pixels.</param>
-    /// <param name="threshold">Greyscale value at or below which a pixel counts as dark.</param>
+    /// <param name="threshold">Binarization threshold: a pixel is dark when luminance &lt; threshold.</param>
     /// <param name="candidates">Receives merged candidates; <see cref="MaxFinderCandidates"/> entries suffice.</param>
     /// <returns>The number of candidates written.</returns>
     internal static int FindCandidates(ReadOnlySpan<byte> luminance, int width, int height, byte threshold, Span<FinderPattern> candidates)
@@ -122,10 +122,10 @@ internal static class FinderPatternFinder
     /// produced nothing that decoded, which is what keeps the detection envelope from ever
     /// being narrower than a full sweep's.
     /// </summary>
-    /// <param name="luminance">Greyscale image, one byte per pixel, row by row.</param>
+    /// <param name="luminance">Grayscale pixels, row-major, width × height bytes.</param>
     /// <param name="width">Image width in pixels.</param>
     /// <param name="height">Image height in pixels.</param>
-    /// <param name="threshold">Greyscale value at or below which a pixel counts as dark.</param>
+    /// <param name="threshold">Binarization threshold: a pixel is dark when luminance &lt; threshold.</param>
     /// <param name="candidates">Receives merged candidates; <see cref="MaxFinderCandidates"/> entries suffice.</param>
     /// <returns>The number of candidates written.</returns>
     internal static int FindCandidatesFullSweep(ReadOnlySpan<byte> luminance, int width, int height, byte threshold, Span<FinderPattern> candidates)

--- a/src/SkiaSharp.QrCode/Internals/ImageDecoders/LuminanceInverter.cs
+++ b/src/SkiaSharp.QrCode/Internals/ImageDecoders/LuminanceInverter.cs
@@ -16,7 +16,7 @@ namespace SkiaSharp.QrCode.Internals.ImageDecoders;
 /// form is a single NOT per lane; measured 17-20x over the per-byte loop across
 /// 33k-922k pixels on AVX2. Two vector widths rather than one: 256-bit where it is
 /// accelerated, otherwise 128-bit, which keeps ARM64 (NEON is 128-bit, so
-/// <see cref="Vector256.IsHardwareAccelerated"/> is false there) off the scalar loop.
+/// <c>Vector256.IsHardwareAccelerated</c> is false there) off the scalar loop.
 /// </remarks>
 internal static class LuminanceInverter
 {

--- a/src/SkiaSharp.QrCode/Internals/RmQr/RmQRModulePlacer.cs
+++ b/src/SkiaSharp.QrCode/Internals/RmQr/RmQRModulePlacer.cs
@@ -26,7 +26,8 @@ namespace SkiaSharp.QrCode.Internals.RmQr;
 /// <see cref="PlaceData"/>). The function-module predicate
 /// (<see cref="IsFunctionModule"/>) and the mask (<see cref="GetMaskBit"/>) are the
 /// single source of truth the matrix decoder reuses, so both sides always agree.</item>
-/// <item><see cref="PlaceSymbol"/> — the fast path (benchmark-driven, 16-27x over the
+/// <item><see cref="PlaceSymbol(Span{byte}, RmQRVersion, RmQREccLevel, ReadOnlySpan{byte})"/> —
+/// the fast path (benchmark-driven, 16-27x over the
 /// reference). Everything derived from the version alone is built once and cached
 /// (<see cref="Layout"/>); placement is then a template copy, one vector pass that
 /// expands the message bits and XORs the masks, and a store pass. The store pass is

--- a/src/SkiaSharp.QrCode/Internals/RmQr/RmQRModulePlacer.cs
+++ b/src/SkiaSharp.QrCode/Internals/RmQr/RmQRModulePlacer.cs
@@ -628,8 +628,8 @@ internal static partial class RmQRModulePlacer
     /// <summary>
     /// Segmentation the ARM64 store tier consumes: transpose blocks, then the row runs
     /// the blocks did not take, then the isolated modules. Built only where that tier
-    /// can run (<see cref="System.Runtime.Intrinsics.Arm.AdvSimd.Arm64.IsSupported"/> is
-    /// a JIT constant, so other targets neither build nor carry these tables).
+    /// can run (<c>AdvSimd.Arm64.IsSupported</c> is a JIT constant, so other targets
+    /// neither build nor carry these tables).
     /// </summary>
     private static (BlockSegment[] Blocks, RunSegment[] Runs, int[] Singles, byte[] ReverseIndex) BuildNeonTables(RmQRVersion version, int height, int width, List<PairSegment> pairs, int positionCount)
     {

--- a/src/SkiaSharp.QrCode/Internals/RmQr/RmQRModulePlacer.cs
+++ b/src/SkiaSharp.QrCode/Internals/RmQr/RmQRModulePlacer.cs
@@ -26,9 +26,9 @@ namespace SkiaSharp.QrCode.Internals.RmQr;
 /// <see cref="PlaceData"/>). The function-module predicate
 /// (<see cref="IsFunctionModule"/>) and the mask (<see cref="GetMaskBit"/>) are the
 /// single source of truth the matrix decoder reuses, so both sides always agree.</item>
-/// <item><see cref="PlaceSymbol(Span{byte}, RmQRVersion, RmQREccLevel, ReadOnlySpan{byte})"/> —
-/// the fast path (benchmark-driven, 16-27x over the
-/// reference). Everything derived from the version alone is built once and cached
+/// <item><see cref="PlaceSymbol(Span{byte}, RmQRVersion, RmQREccLevel, ReadOnlySpan{byte})"/>
+/// is the fast path (benchmark-driven, 16-27x over the reference). Everything derived
+/// from the version alone is built once and cached
 /// (<see cref="Layout"/>); placement is then a template copy, one vector pass that
 /// expands the message bits and XORs the masks, and a store pass. The store pass is
 /// documented on <see cref="ScatterPairs"/>, its ARM64 tier in

--- a/src/SkiaSharp.QrCode/Internals/RmQr/RmQRVersionSelector.cs
+++ b/src/SkiaSharp.QrCode/Internals/RmQr/RmQRVersionSelector.cs
@@ -22,7 +22,8 @@ internal static class RmQRVersionSelector
     /// Priced in <see cref="long"/>: Byte mode costs <c>8 × dataLength</c>, which wraps
     /// <see cref="int"/> for a span past ~268M units and would read as a fit. Widening
     /// keeps the mode switch on every path, which a length fast-path in
-    /// <see cref="Fits"/> would skip for exactly the lengths that need it most.
+    /// <see cref="Fits(RmQRVersion, RmQREccLevel, EncodingMode, int)"/> would skip for
+    /// exactly the lengths that need it most.
     /// </remarks>
     public static long GetRequiredBits(RmQRVersion version, EncodingMode mode, int dataLength)
     {
@@ -65,7 +66,8 @@ internal static class RmQRVersionSelector
 
     /// <summary>
     /// Largest data length (digits / characters / bytes) that fits a version × ECC × mode,
-    /// the inverse of <see cref="GetRequiredBits"/> against the data bit capacity.
+    /// the inverse of <see cref="GetRequiredBits(RmQRVersion, EncodingMode, int)"/> against
+    /// the data bit capacity.
     /// </summary>
     public static int GetMaxDataLength(RmQRVersion version, RmQREccLevel eccLevel, EncodingMode mode)
     {

--- a/src/SkiaSharp.QrCode/Internals/StandardQR/ModulePlacer.cs
+++ b/src/SkiaSharp.QrCode/Internals/StandardQR/ModulePlacer.cs
@@ -16,6 +16,7 @@ internal static partial class ModulePlacer
     /// Fills modules in zigzag pattern from bottom-right to top-left.
     /// </summary>
     /// <param name="buffer">QR code data structure to populate.</param>
+    /// <param name="size">Side length of the matrix in modules, quiet zone excluded.</param>
     /// <param name="interleavedData">Interleaved data and ECC bytes.</param>
     /// <param name="blockedMask">blocked mask bytes.</param>
     /// <remarks>
@@ -339,6 +340,7 @@ internal static partial class ModulePlacer
     /// Two identical 15-bit sequences for redundancy.
     /// </summary>
     /// <param name="buffer">QR code matrix buffer.</param>
+    /// <param name="size">Side length of the matrix in modules, quiet zone excluded.</param>
     /// <param name="formatBits">15-bit format information (LSB first).</param>
     /// <remarks>
     /// Places two identical copies for redundancy (ISO/IEC 18004 Section 7.9):

--- a/src/SkiaSharp.QrCode/Internals/StandardQR/QRImageDecoder.cs
+++ b/src/SkiaSharp.QrCode/Internals/StandardQR/QRImageDecoder.cs
@@ -252,6 +252,13 @@ internal static class QRImageDecoder
     /// cuts the rotated rings diagonally). Instead it is measured along the actual
     /// finder-to-finder lines, which is rotation-invariant.
     /// </remarks>
+    /// <param name="luminance">Greyscale image, one byte per pixel, row by row.</param>
+    /// <param name="width">Image width in pixels.</param>
+    /// <param name="height">Image height in pixels.</param>
+    /// <param name="threshold">Greyscale value at or below which a pixel counts as dark.</param>
+    /// <param name="topLeft">The finder pattern at the top-left corner of the symbol.</param>
+    /// <param name="topRight">The finder pattern at the top-right corner of the symbol.</param>
+    /// <param name="bottomLeft">The finder pattern at the bottom-left corner of the symbol.</param>
     /// <param name="dimension">Nearest valid dimension to the estimate.</param>
     /// <param name="secondaryDimension">
     /// Second-nearest valid dimension when the estimate is also within one version

--- a/src/SkiaSharp.QrCode/Internals/StandardQR/QRImageDecoder.cs
+++ b/src/SkiaSharp.QrCode/Internals/StandardQR/QRImageDecoder.cs
@@ -252,10 +252,10 @@ internal static class QRImageDecoder
     /// cuts the rotated rings diagonally). Instead it is measured along the actual
     /// finder-to-finder lines, which is rotation-invariant.
     /// </remarks>
-    /// <param name="luminance">Greyscale image, one byte per pixel, row by row.</param>
+    /// <param name="luminance">Grayscale pixels, row-major, width × height bytes.</param>
     /// <param name="width">Image width in pixels.</param>
     /// <param name="height">Image height in pixels.</param>
-    /// <param name="threshold">Greyscale value at or below which a pixel counts as dark.</param>
+    /// <param name="threshold">Binarization threshold: a pixel is dark when luminance &lt; threshold.</param>
     /// <param name="topLeft">The finder pattern at the top-left corner of the symbol.</param>
     /// <param name="topRight">The finder pattern at the top-right corner of the symbol.</param>
     /// <param name="bottomLeft">The finder pattern at the bottom-left corner of the symbol.</param>

--- a/src/SkiaSharp.QrCode/Internals/StandardQR/QRMatrixDecoder.cs
+++ b/src/SkiaSharp.QrCode/Internals/StandardQR/QRMatrixDecoder.cs
@@ -165,7 +165,8 @@ internal static class QRMatrixDecoder
 
     /// <summary>
     /// Reads data/ECC codeword bits from the matrix in placement order (inverse of
-    /// <see cref="ModulePlacer.PlaceDataWords"/>), unmasking each module on the fly.
+    /// <see cref="ModulePlacer.PlaceDataWords(Span{byte}, int, ReadOnlySpan{byte}, ReadOnlySpan{byte})"/>),
+    /// unmasking each module on the fly.
     /// Remainder bits beyond the output capacity are ignored.
     /// </summary>
     private static void ExtractCodewords(ReadOnlySpan<byte> modules, int size, ReadOnlySpan<byte> blockedMask, int maskPattern, Span<byte> output)

--- a/src/SkiaSharp.QrCode/Internals/TextAnalyzer.cs
+++ b/src/SkiaSharp.QrCode/Internals/TextAnalyzer.cs
@@ -75,8 +75,9 @@ internal static class TextAnalyzer
     /// <summary>
     /// AVX2 optimized analysis (process 16 chars at once)
     /// </summary>
-    /// <param name="text"></param>
-    /// <returns></returns>
+    /// <param name="text">The text to inspect.</param>
+    /// <param name="requestedEciMode">The character encoding the caller asked for, or Default to choose one from the text.</param>
+    /// <returns>The narrowest encoding mode the text fits, its length in that mode's units, and the ECI mode to declare.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static TextAnalysisResult AnalyzeAvx2(ReadOnlySpan<char> text, EciMode requestedEciMode)
     {
@@ -238,8 +239,9 @@ internal static class TextAnalyzer
     /// <summary>
     /// SSE2 optimized analysis (process 8 chars at once)
     /// </summary>
-    /// <param name="text"></param>
-    /// <returns></returns>
+    /// <param name="text">The text to inspect.</param>
+    /// <param name="requestedEciMode">The character encoding the caller asked for, or Default to choose one from the text.</param>
+    /// <returns>The narrowest encoding mode the text fits, its length in that mode's units, and the ECI mode to declare.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static TextAnalysisResult AnalyzeSse2(ReadOnlySpan<char> text, EciMode requestedEciMode)
     {
@@ -406,8 +408,9 @@ internal static class TextAnalyzer
     /// ASCII/ISO detection keeps 16-bit precision via one UMAXV of the raw block,
     /// whose max answers both the &gt;127 and &gt;255 thresholds at once.
     /// </summary>
-    /// <param name="text"></param>
-    /// <returns></returns>
+    /// <param name="text">The text to inspect.</param>
+    /// <param name="requestedEciMode">The character encoding the caller asked for, or Default to choose one from the text.</param>
+    /// <returns>The narrowest encoding mode the text fits, its length in that mode's units, and the ECI mode to declare.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static TextAnalysisResult AnalyzeAdvSimd(ReadOnlySpan<char> text, EciMode requestedEciMode)
     {
@@ -596,8 +599,9 @@ internal static class TextAnalyzer
     /// <summary>
     /// Scalar fallback analysis (process 1 char at once)
     /// </summary>
-    /// <param name="text"></param>
-    /// <returns></returns>
+    /// <param name="text">The text to inspect.</param>
+    /// <param name="requestedEciMode">The character encoding the caller asked for, or Default to choose one from the text.</param>
+    /// <returns>The narrowest encoding mode the text fits, its length in that mode's units, and the ECI mode to declare.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static TextAnalysisResult AnalyzeScalar(ReadOnlySpan<char> text, EciMode requestedEciMode)
     {

--- a/src/SkiaSharp.QrCode/MicroQRCodeGenerator.cs
+++ b/src/SkiaSharp.QrCode/MicroQRCodeGenerator.cs
@@ -47,7 +47,10 @@ public static class MicroQRCodeGenerator
         => CreateMicroQRCode(plainText.AsSpan(), eccLevel, requestedVersion, quietZoneSize);
 
     /// <inheritdoc cref="CreateMicroQRCode(string, MicroQREccLevel, MicroQRVersion?, int)"/>
-    /// <param name="textSpan">The text span to encode.</param>
+    /// <param name="textSpan">The text to encode.</param>
+    /// <param name="eccLevel">How much damage the symbol can survive. M1 offers error detection only, and Q is available on M4 only.</param>
+    /// <param name="requestedVersion">The symbol size to use (M1 to M4), or null to pick the smallest size the text fits in.</param>
+    /// <param name="quietZoneSize">Width of the blank margin around the symbol, in modules. Scanners expect 2.</param>
     public static MicroQRCodeData CreateMicroQRCode(ReadOnlySpan<char> textSpan, MicroQREccLevel eccLevel, MicroQRVersion? requestedVersion = null, int quietZoneSize = DefaultQuietZone)
         => CreateMicroQRCodeCore(textSpan, eccLevel, requestedVersion, quietZoneSize, AutomaticMask);
 

--- a/src/SkiaSharp.QrCode/MicroQRCodeGenerator.cs
+++ b/src/SkiaSharp.QrCode/MicroQRCodeGenerator.cs
@@ -48,9 +48,9 @@ public static class MicroQRCodeGenerator
 
     /// <inheritdoc cref="CreateMicroQRCode(string, MicroQREccLevel, MicroQRVersion?, int)"/>
     /// <param name="textSpan">The text to encode.</param>
-    /// <param name="eccLevel">How much damage the symbol can survive. M1 offers error detection only, and Q is available on M4 only.</param>
-    /// <param name="requestedVersion">The symbol size to use (M1 to M4), or null to pick the smallest size the text fits in.</param>
-    /// <param name="quietZoneSize">Width of the blank margin around the symbol, in modules. Scanners expect 2.</param>
+    /// <param name="eccLevel">How much damage the symbol can survive. M1 accepts <see cref="MicroQREccLevel.ErrorDetectionOnly"/> alone, and Q is available on M4 alone.</param>
+    /// <param name="requestedVersion">The symbol size to use (M1 to M4), or <c>null</c> to pick the smallest size the text fits in.</param>
+    /// <param name="quietZoneSize">Quiet zone width in modules. ISO/IEC 18004 requires 2 for Micro QR.</param>
     public static MicroQRCodeData CreateMicroQRCode(ReadOnlySpan<char> textSpan, MicroQREccLevel eccLevel, MicroQRVersion? requestedVersion = null, int quietZoneSize = DefaultQuietZone)
         => CreateMicroQRCodeCore(textSpan, eccLevel, requestedVersion, quietZoneSize, AutomaticMask);
 

--- a/src/SkiaSharp.QrCode/QRCodeData.cs
+++ b/src/SkiaSharp.QrCode/QRCodeData.cs
@@ -239,7 +239,7 @@ public class QRCodeData
     /// </summary>
     /// <remarks>
     /// <para>
-    /// This constructor deserializes QR code data that was previously serialized using <see cref="GetRawData"/>.
+    /// This constructor deserializes QR code data that was previously serialized using <see cref="GetRawData()"/>.
     /// The raw data contains only the core QR code modules (excluding quiet zone).
     /// </para>
     /// <para>
@@ -249,7 +249,7 @@ public class QRCodeData
     /// The quiet zone (white border) can be added during deserialization by specifying the <paramref name="quietZoneSize"/> parameter.
     /// </para>
     /// </remarks>
-    /// <param name="rawData">The serialized QR code data. This data should be obtained from <see cref="GetRawData"/>.</param>
+    /// <param name="rawData">The serialized QR code data. This data should be obtained from <see cref="GetRawData()"/>.</param>
     /// <param name="quietZoneSize">
     /// The size of the quiet zone (white border) to add around the QR code matrix, in modules.
     /// This value is independent of the serialized data and can be different from the original quiet zone size used during serialization.
@@ -266,7 +266,7 @@ public class QRCodeData
     /// </summary>
     /// <remarks>
     /// <para>
-    /// This constructor deserializes QR code data that was previously serialized using <see cref="GetRawData"/>.
+    /// This constructor deserializes QR code data that was previously serialized using <see cref="GetRawData()"/>.
     /// The raw data contains only the core QR code modules (excluding quiet zone).
     /// </para>
     /// <para>
@@ -281,7 +281,7 @@ public class QRCodeData
     /// without allocating a new byte array.
     /// </para>
     /// </remarks>
-    /// <param name="rawDataSpan">The serialized QR code data span. This data should be obtained from <see cref="GetRawData"/>.</param>
+    /// <param name="rawDataSpan">The serialized QR code data span. This data should be obtained from <see cref="GetRawData()"/>.</param>
     /// <param name="quietZoneSize">
     /// The size of the quiet zone (white border) to add around the QR code matrix, in modules.
     /// This value is independent of the serialized data and can be different from the original quiet zone size used during serialization.

--- a/src/SkiaSharp.QrCode/QRCodeExtensions.cs
+++ b/src/SkiaSharp.QrCode/QRCodeExtensions.cs
@@ -3,9 +3,15 @@ using SkiaSharp.QrCode.Image;
 namespace SkiaSharp.QrCode;
 
 /// <summary>
-/// Draws a QR code straight onto an <see cref="SKCanvas"/> you already have,
-/// for when you are compositing it into a larger drawing rather than saving an image.
+/// Extension methods that render a QR, Micro QR or rMQR symbol onto an
+/// <see cref="SKCanvas"/> you already have, instead of producing an image file.
 /// </summary>
+/// <remarks>
+/// Each method clears the whole canvas before drawing, so anything already on it is
+/// lost. To place a symbol inside a larger drawing, wrap the call in
+/// <see cref="SKCanvas.Save"/> and <see cref="SKCanvas.ClipRect(SKRect, SKClipOperation, bool)"/>,
+/// or call <see cref="QRCodeRenderer"/> directly, which draws only the symbol.
+/// </remarks>
 public static class QRCodeExtensions
 {
     /// <summary>

--- a/src/SkiaSharp.QrCode/QRCodeExtensions.cs
+++ b/src/SkiaSharp.QrCode/QRCodeExtensions.cs
@@ -2,6 +2,10 @@ using SkiaSharp.QrCode.Image;
 
 namespace SkiaSharp.QrCode;
 
+/// <summary>
+/// Draws a QR code straight onto an <see cref="SKCanvas"/> you already have,
+/// for when you are compositing it into a larger drawing rather than saving an image.
+/// </summary>
 public static class QRCodeExtensions
 {
     /// <summary>

--- a/src/SkiaSharp.QrCode/QRCodeGenerator.cs
+++ b/src/SkiaSharp.QrCode/QRCodeGenerator.cs
@@ -496,12 +496,12 @@ public static class QRCodeGenerator
     /// <summary>
     /// Prepares QR configuration by determining encoding, ECI mode, and version.
     /// </summary>
-    /// <param name="textSpan"></param>
-    /// <param name="eccLevel"></param>
-    /// <param name="utf8Bom"></param>
-    /// <param name="eciMode"></param>
-    /// <param name="requestedVersion"></param>
-    /// <returns></returns>
+    /// <param name="textSpan">The text to encode.</param>
+    /// <param name="eccLevel">How much damage the symbol can survive.</param>
+    /// <param name="utf8BOM">Whether a UTF-8 byte order mark precedes the content. It takes capacity away from the text.</param>
+    /// <param name="eciMode">The character encoding to declare, or Default to pick one from the text.</param>
+    /// <param name="requestedVersion">The symbol size to use (1 to 40), or -1 to pick the smallest size the text fits in.</param>
+    /// <returns>The version, encoding mode, ECI mode and error correction layout to encode with.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static QRConfiguration PrepareConfiguration(ReadOnlySpan<char> textSpan, ECCLevel eccLevel, bool utf8BOM, EciMode eciMode, int requestedVersion)
     {
@@ -836,6 +836,8 @@ public static class QRCodeGenerator
     /// <param name="length">Data length (in characters or bytes).</param>
     /// <param name="encoding">Encoding mode being used.</param>
     /// <param name="eccLevel">Error correction level.</param>
+    /// <param name="eciMode">The character encoding declared in the symbol. Its header takes capacity away from the text.</param>
+    /// <param name="utf8BOM">Whether a UTF-8 byte order mark precedes the content. It also takes capacity away from the text.</param>
     /// <returns>Version number (1-40).</returns>
     private static int GetVersion(int length, EncodingMode encoding, ECCLevel eccLevel, EciMode eciMode, bool utf8BOM)
     {
@@ -1275,5 +1277,6 @@ public static class QRCodeGenerator
     /// <param name="EciMode">ECI mode specifying character encoding.</param>
     /// <param name="Utf8BOM">Indicates if UTF-8 BOM is included in the encoded data.</param>
     /// <param name="EccInfo">Error correction information for the selected version and ECC level.</param>
+    /// <param name="DataLength">How much content there is to encode, counted in the units the encoding mode uses.</param>
     private readonly record struct QRConfiguration(int Version, ECCLevel EccLevel, EncodingMode Encoding, EciMode EciMode, bool Utf8BOM, in ECCInfo EccInfo, int DataLength);
 }

--- a/src/SkiaSharp.QrCode/QRCodeGenerator.cs
+++ b/src/SkiaSharp.QrCode/QRCodeGenerator.cs
@@ -498,8 +498,8 @@ public static class QRCodeGenerator
     /// </summary>
     /// <param name="textSpan">The text to encode.</param>
     /// <param name="eccLevel">How much damage the symbol can survive.</param>
-    /// <param name="utf8BOM">Whether a UTF-8 byte order mark precedes the content. It takes capacity away from the text.</param>
-    /// <param name="eciMode">The character encoding to declare, or Default to pick one from the text.</param>
+    /// <param name="utf8BOM">Whether a UTF-8 byte order mark precedes the content. It costs three bytes of capacity, and only in Byte mode with UTF-8 ECI.</param>
+    /// <param name="eciMode">The character encoding to declare, or <see cref="EciMode.Default"/> to choose one from the text.</param>
     /// <param name="requestedVersion">The symbol size to use (1 to 40), or -1 to pick the smallest size the text fits in.</param>
     /// <returns>The version, encoding mode, ECI mode and error correction layout to encode with.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -836,8 +836,8 @@ public static class QRCodeGenerator
     /// <param name="length">Data length (in characters or bytes).</param>
     /// <param name="encoding">Encoding mode being used.</param>
     /// <param name="eccLevel">Error correction level.</param>
-    /// <param name="eciMode">The character encoding declared in the symbol. Its header takes capacity away from the text.</param>
-    /// <param name="utf8BOM">Whether a UTF-8 byte order mark precedes the content. It also takes capacity away from the text.</param>
+    /// <param name="eciMode">The character encoding declared in the symbol. Anything other than Default adds a 12-bit header, leaving less room for the text.</param>
+    /// <param name="utf8BOM">Whether a UTF-8 byte order mark precedes the content. It costs three bytes of capacity, and only in Byte mode with UTF-8 ECI.</param>
     /// <returns>Version number (1-40).</returns>
     private static int GetVersion(int length, EncodingMode encoding, ECCLevel eccLevel, EciMode eciMode, bool utf8BOM)
     {

--- a/src/SkiaSharp.QrCode/SkiaSharp.QrCode.csproj
+++ b/src/SkiaSharp.QrCode/SkiaSharp.QrCode.csproj
@@ -5,6 +5,11 @@
 
     <!-- NuGet -->
     <IsPackable>true</IsPackable>
+    <!-- Ships the XML documentation beside the assembly so consumers get IntelliSense.
+         This lives here rather than in Directory.Build.props because the doc-completeness
+         warnings it enables are only worth answering for the surface that ships: on the
+         whole solution it produces ~5,000 of them, almost all from public test classes. -->
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageId>SkiaSharp.QrCode</PackageId>
     <Description>QrCode for .NET Standard with Skia.Sharp. No GDI, no System.Drawing.</Description>
 

--- a/src/SkiaSharp.QrCode/SkiaSharp.QrCode.csproj
+++ b/src/SkiaSharp.QrCode/SkiaSharp.QrCode.csproj
@@ -33,41 +33,64 @@
     The compiler documents every member that carries a doc comment, internal ones included:
     more than half of this assembly's entries describe types under Internals, and no consumer
     can call any of them. Strip those entries while the file is still in obj, before it is
-    copied to the output directory, so the package ships only what a caller can use and the
-    internal design notes stay out of the distributed artifact.
+    copied to the output directory, so the bulk of the internal design notes stay out of the
+    distributed artifact.
+
+    This removes the Internals namespace and nothing else. Internal members that live outside
+    it, such as private helpers on public types, still ship; removing those as well would mean
+    reading visibility out of the compiled assembly rather than matching on a name.
   -->
   <UsingTask TaskName="StripInternalXmlDocs" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
     <ParameterGroup>
       <DocumentationFilePath ParameterType="System.String" Required="true" />
       <NamespacePrefix ParameterType="System.String" Required="true" />
+      <Reason ParameterType="System.String" Output="true" />
       <Removed ParameterType="System.Int32" Output="true" />
+      <Corrupt ParameterType="System.Boolean" Output="true" />
     </ParameterGroup>
     <Task>
       <Using Namespace="System" />
       <Using Namespace="System.Linq" />
       <Using Namespace="System.Xml.Linq" />
       <Code Type="Fragment" Language="cs"><![CDATA[
-        // Documentation IDs are "X:Full.Name", where X is T, M, P, F or E.
-        var document = XDocument.Load(DocumentationFilePath);
-        var internals = document.Descendants("member")
-            .Where(member =>
-            {
-                var name = (string)member.Attribute("name");
-                return name != null
-                    && name.Length > 2
-                    && name[1] == ':'
-                    && name.Substring(2).StartsWith(NamespacePrefix, StringComparison.Ordinal);
-            })
-            .ToList();
-
-        Removed = internals.Count;
-
-        // Only rewrite when there is something to remove, so a rebuild that changed nothing
-        // leaves the file, and its timestamp, alone.
-        if (Removed > 0)
+        // A half-written file (an interrupted build, a full disk) would otherwise fail this
+        // task with a raw stack trace, and because CoreCompile stays up to date the same
+        // failure would repeat on every later build. Delete it and say so: the build stops
+        // here rather than copying a broken file, and the next one regenerates it.
+        XDocument document = null;
+        try
         {
-            foreach (var member in internals) member.Remove();
-            document.Save(DocumentationFilePath);
+            document = XDocument.Load(DocumentationFilePath);
+        }
+        catch (System.Xml.XmlException e)
+        {
+            Corrupt = true;
+            Reason = e.Message;
+        }
+
+        if (document != null)
+        {
+            // Documentation IDs are "X:Full.Name", where X is T, M, P, F or E.
+            var internals = document.Descendants("member")
+                .Where(member =>
+                {
+                    var name = (string)member.Attribute("name");
+                    return name != null
+                        && name.Length > 2
+                        && name[1] == ':'
+                        && name.Substring(2).StartsWith(NamespacePrefix, StringComparison.Ordinal);
+                })
+                .ToList();
+
+            Removed = internals.Count;
+
+            // Only rewrite when there is something to remove, so a rebuild that changed
+            // nothing leaves the file, and its timestamp, alone.
+            if (Removed > 0)
+            {
+                foreach (var member in internals) member.Remove();
+                document.Save(DocumentationFilePath);
+            }
         }
       ]]></Code>
     </Task>
@@ -75,9 +98,21 @@
 
   <Target Name="StripInternalDocumentation" BeforeTargets="CopyFilesToOutputDirectory"
           Condition="'$(GenerateDocumentationFile)' == 'true' And Exists('$(DocumentationFile)')">
-    <StripInternalXmlDocs DocumentationFilePath="$(DocumentationFile)" NamespacePrefix="$(RootNamespace).Internals.">
+    <!-- Spelled out rather than built from $(RootNamespace): that property defaults to the
+         project file name, so renaming the project would turn this into a silent no-op and
+         the leak would only show up in a published package. -->
+    <StripInternalXmlDocs DocumentationFilePath="$(DocumentationFile)" NamespacePrefix="SkiaSharp.QrCode.Internals.">
       <Output TaskParameter="Removed" PropertyName="_RemovedInternalDocMembers" />
+      <Output TaskParameter="Corrupt" PropertyName="_DocumentationCorrupt" />
+      <Output TaskParameter="Reason" PropertyName="_DocumentationCorruptReason" />
     </StripInternalXmlDocs>
+
+    <!-- Deleting it is what makes the failure recoverable: the next build sees the missing
+         output, recompiles, and regenerates it. Erroring here stops the target before the
+         copy, so the caller gets this one message instead of a follow-on MSB3030. -->
+    <Delete Files="$(DocumentationFile)" Condition="'$(_DocumentationCorrupt)' == 'true'" />
+    <Error Condition="'$(_DocumentationCorrupt)' == 'true'"
+           Text="$(DocumentationFile) was not valid XML ($(_DocumentationCorruptReason)). It has been deleted; run the build again to regenerate it." />
     <Message Importance="normal" Text="$(MSBuildProjectName) ($(TargetFramework)): removed $(_RemovedInternalDocMembers) internal member(s) from the XML documentation." />
   </Target>
 

--- a/src/SkiaSharp.QrCode/SkiaSharp.QrCode.csproj
+++ b/src/SkiaSharp.QrCode/SkiaSharp.QrCode.csproj
@@ -29,6 +29,58 @@
     <SbomGenerationManifestInfo>SPDX:2.2</SbomGenerationManifestInfo>
   </PropertyGroup>
 
+  <!--
+    The compiler documents every member that carries a doc comment, internal ones included:
+    more than half of this assembly's entries describe types under Internals, and no consumer
+    can call any of them. Strip those entries while the file is still in obj, before it is
+    copied to the output directory, so the package ships only what a caller can use and the
+    internal design notes stay out of the distributed artifact.
+  -->
+  <UsingTask TaskName="StripInternalXmlDocs" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <ParameterGroup>
+      <DocumentationFilePath ParameterType="System.String" Required="true" />
+      <NamespacePrefix ParameterType="System.String" Required="true" />
+      <Removed ParameterType="System.Int32" Output="true" />
+    </ParameterGroup>
+    <Task>
+      <Using Namespace="System" />
+      <Using Namespace="System.Linq" />
+      <Using Namespace="System.Xml.Linq" />
+      <Code Type="Fragment" Language="cs"><![CDATA[
+        // Documentation IDs are "X:Full.Name", where X is T, M, P, F or E.
+        var document = XDocument.Load(DocumentationFilePath);
+        var internals = document.Descendants("member")
+            .Where(member =>
+            {
+                var name = (string)member.Attribute("name");
+                return name != null
+                    && name.Length > 2
+                    && name[1] == ':'
+                    && name.Substring(2).StartsWith(NamespacePrefix, StringComparison.Ordinal);
+            })
+            .ToList();
+
+        Removed = internals.Count;
+
+        // Only rewrite when there is something to remove, so a rebuild that changed nothing
+        // leaves the file, and its timestamp, alone.
+        if (Removed > 0)
+        {
+            foreach (var member in internals) member.Remove();
+            document.Save(DocumentationFilePath);
+        }
+      ]]></Code>
+    </Task>
+  </UsingTask>
+
+  <Target Name="StripInternalDocumentation" BeforeTargets="CopyFilesToOutputDirectory"
+          Condition="'$(GenerateDocumentationFile)' == 'true' And Exists('$(DocumentationFile)')">
+    <StripInternalXmlDocs DocumentationFilePath="$(DocumentationFile)" NamespacePrefix="$(RootNamespace).Internals.">
+      <Output TaskParameter="Removed" PropertyName="_RemovedInternalDocMembers" />
+    </StripInternalXmlDocs>
+    <Message Importance="normal" Text="$(MSBuildProjectName) ($(TargetFramework)): removed $(_RemovedInternalDocMembers) internal member(s) from the XML documentation." />
+  </Target>
+
   <ItemGroup>
     <InternalsVisibleTo Include="SkiaSharp.QrCode.Tests, PublicKey=00240000048000009400000006020000002400005253413100040000010001007de4a83ad446c6d7c9e85de8a1c654096808b127b9cfc0db4931e3062bffea0daa74fa7c584ee37c9d0dee5c86f42e3b88be303692712c9198ab19665680d2bca6d91f48a3c76980c8d0a90248c3b535a935612525b79b9bbc152e7e297a004bd17e2b24767fadde2a5174f9a50e297e724637f498777d14a62223f4db932dbc" />
   </ItemGroup>

--- a/tests/SkiaSharp.QrCode.Tests/Shared/ShippedDocumentationTest.cs
+++ b/tests/SkiaSharp.QrCode.Tests/Shared/ShippedDocumentationTest.cs
@@ -1,0 +1,74 @@
+using System.Reflection;
+using System.Xml.Linq;
+
+namespace SkiaSharp.QrCode.Tests;
+
+/// <summary>
+/// The XML documentation file that ships beside the assembly, which is what gives consumers
+/// IntelliSense. The build strips the <c>Internals</c> namespace out of it before it reaches
+/// the output directory, so what the test project receives is what NuGet packs.
+/// </summary>
+/// <remarks>
+/// A shape test, not a behaviour test. The strip runs in an MSBuild target keyed on a
+/// namespace string, and nothing else in the build would notice if it stopped matching:
+/// the build still succeeds, the package still validates, and the only symptom is internal
+/// design notes appearing in a published artifact.
+/// </remarks>
+public class ShippedDocumentationTest
+{
+    private static string DocumentationPath => Path.Combine(AppContext.BaseDirectory, "SkiaSharp.QrCode.xml");
+
+    private static IEnumerable<string> MemberIds()
+        => XDocument.Load(DocumentationPath)
+            .Descendants("member")
+            .Select(m => (string?)m.Attribute("name"))
+            .Where(name => name is not null)!;
+
+    /// <summary>
+    /// Without this file a consumer sees bare signatures and no documentation at all, which
+    /// is the state the library shipped in through 1.1.1.
+    /// </summary>
+    [Test]
+    public async Task DocumentationFile_ShipsBesideTheAssembly()
+    {
+        await Assert.That(File.Exists(DocumentationPath)).IsTrue()
+            .Because($"expected the XML documentation at {DocumentationPath}");
+    }
+
+    /// <summary>
+    /// The strip is keyed on a namespace prefix, so it fails silently: a renamed namespace or
+    /// a broken prefix removes nothing and the build stays green.
+    /// </summary>
+    [Test]
+    public async Task Documentation_CarriesNoInternalsEntries()
+    {
+        var internals = MemberIds()
+            .Where(name => name.Length > 2 && name[1] == ':'
+                && name[2..].StartsWith("SkiaSharp.QrCode.Internals.", StringComparison.Ordinal))
+            .ToArray();
+
+        await Assert.That(internals).IsEmpty()
+            .Because($"{internals.Length} Internals entries survived the strip, starting with: {string.Join(", ", internals.Take(3))}");
+    }
+
+    /// <summary>
+    /// The other direction: a strip that removed too much, or a public type that was never
+    /// documented, both leave a consumer hovering a name and seeing nothing.
+    /// </summary>
+    [Test]
+    public async Task EveryExportedType_IsDocumented()
+    {
+        var documented = MemberIds()
+            .Where(name => name.StartsWith("T:", StringComparison.Ordinal))
+            .Select(name => name[2..])
+            .ToHashSet(StringComparer.Ordinal);
+
+        var missing = typeof(QRCodeData).Assembly.GetExportedTypes()
+            .Select(t => (t.FullName ?? t.Name).Replace('+', '.'))
+            .Where(name => !documented.Contains(name))
+            .ToArray();
+
+        await Assert.That(missing).IsEmpty()
+            .Because($"exported but undocumented: {string.Join(", ", missing)}");
+    }
+}


### PR DESCRIPTION
## Summary

Ship XML documentation in the NuGet package so consumers get IntelliSense.

`GenerateDocumentationFile` was never enabled, so the package carried only assemblies and editors showed bare signatures. Enabling it surfaced 182 doc warnings, all of them are fixed rather than suppressed.