### PR TITLE
chore: add docs page in playground

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -134,6 +134,13 @@ jobs:
           dotnet-version: 10.0
       - name: Install wasm-tools workload
         run: dotnet workload install wasm-tools
+      # Public API listing for the Pages site. Written into the Playground wwwroot so the
+      # publish below copies it to /api/, which is also where it lands when the Playground
+      # is run locally. This publishes the surface, it never judges it: breaking changes are
+      # caught by package validation in build-dotnet, so nothing here can fail a release
+      # except the generator itself breaking.
+      - name: Generate public API page
+        run: dotnet run tools/public_api.cs -- --html -o src/SkiaSharp.QrCode.Playground/wwwroot/api/index.html
       # Version for the in-page badge (AssemblyInformationalVersion) comes from Directory.Build.props.
       # No -r browser-wasm: the WebAssembly SDK defaults to it, and passing it as a global
       # property would force the multi-targeted library reference to need wasm-tools-net8.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -139,8 +139,11 @@ jobs:
       # is run locally. This publishes the surface, it never judges it: breaking changes are
       # caught by package validation in build-dotnet, so nothing here can fail a release
       # except the generator itself breaking.
+      # --source-links only here: SourceLink pins the commit that was built, and this job builds
+      # at the tag, so every link resolves. A local build would pin whatever HEAD happens to be,
+      # which may never have been pushed, so the committed copy of the page carries no links.
       - name: Generate public API page
-        run: dotnet run tools/public_api.cs -- --html -o src/SkiaSharp.QrCode.Playground/wwwroot/api/index.html
+        run: dotnet run tools/public_api.cs -- --html --source-links -o src/SkiaSharp.QrCode.Playground/wwwroot/api/index.html
       # Version for the in-page badge (AssemblyInformationalVersion) comes from Directory.Build.props.
       # No -r browser-wasm: the WebAssembly SDK defaults to it, and passing it as a global
       # property would force the multi-targeted library reference to need wasm-tools-net8.

--- a/.gitignore
+++ b/.gitignore
@@ -410,6 +410,3 @@ tools/QRInteropFixtures/external/
 # Approval-test mismatch dumps (written next to goldens on failure)
 *.actual.png
 *.actual.pixels
-
-# Generated public API page (tools/public_api.cs --html); regenerated on demand and on release
-src/SkiaSharp.QrCode.Playground/wwwroot/api/

--- a/.gitignore
+++ b/.gitignore
@@ -410,3 +410,6 @@ tools/QRInteropFixtures/external/
 # Approval-test mismatch dumps (written next to goldens on failure)
 *.actual.png
 *.actual.pixels
+
+# Generated public API page (tools/public_api.cs --html); regenerated on demand and on release
+src/SkiaSharp.QrCode.Playground/wwwroot/api/

--- a/src/SkiaSharp.QrCode.Playground/README.md
+++ b/src/SkiaSharp.QrCode.Playground/README.md
@@ -27,6 +27,30 @@ dotnet serve -d publish/playground/wwwroot   # or: python -m http.server -d publ
 `-p:PlaygroundSoftFingerprint=true` emits both fingerprinted and plain filenames so the page
 works on hosts without import-map rewriting (GitHub Pages, plain static servers).
 
+## Public API page (`/api/`)
+
+The **API** link in the header opens a filterable listing of every public type, with the doc
+comments for each, generated from the built assembly by `tools/public_api.cs`. It is written
+into `wwwroot/api/index.html`, so one command covers both cases: the page is served when you
+run the Playground locally, and `dotnet publish` copies it into the Pages site.
+
+```bash
+dotnet run tools/public_api.cs -- --html -o src/SkiaSharp.QrCode.Playground/wwwroot/api/index.html
+```
+
+Run it **before** publishing; the release workflow does the same. The file is generated, so it is
+gitignored, and the API link 404s until you have run the command once. Drop `--html -o ...` for the
+plain-text listing on stdout, which is the form to diff.
+
+The doc text comes from an XML documentation file the tool builds for itself, because the library
+does not set `GenerateDocumentationFile`. That also means **the NuGet package ships no XML docs**,
+so consumers get no IntelliSense: worth fixing separately, along with the ~116 doc-completeness
+warnings (`CS1591`, `CS1573`, `CS0419`, `CS1572`) that turning it on reveals.
+
+Nothing validates the listing and no build fails when the surface changes. Breaking changes are
+caught by package validation against the released baseline, which is the only surface check worth
+failing a build over.
+
 Publish to a **clean output directory** (delete it between publishes). Re-publishing into the
 same `-o` directory leaves the previous build's fingerprinted files behind; the
 `_CopyDotnetJsFallback` target detects this and fails with an explicit "publish to a clean

--- a/src/SkiaSharp.QrCode.Playground/README.md
+++ b/src/SkiaSharp.QrCode.Playground/README.md
@@ -47,6 +47,20 @@ dotnet run tools/public_api.cs -- --html -o src/SkiaSharp.QrCode.Playground/wwwr
 The release workflow runs the same command before publishing, so the Pages site is always current
 even if the committed copy has drifted. Drop `--html -o ...` for the plain-text listing on stdout.
 
+### Source links
+
+Passing `--source-links` turns every type and member name into a link to its declaration on
+GitHub, line anchor included. The file and line come from the sequence points in the PDB, and the
+repository and commit from the SourceLink map the .NET SDK embeds there, so nothing needs to be
+configured and no package is added.
+
+**Only the release workflow passes it.** SourceLink pins the commit that was built: a page
+generated locally would link to whatever HEAD was at the time, which is often a commit that has
+never been pushed, and every link would 404. The header shows the commit the links point at.
+
+Members without IL have no sequence points, so fields and enum values are never links. A type has
+none of its own either, and links to the file its first member is in, without a line anchor.
+
 Committing a generated file is deliberate. Generating it during the build was tried and does not
 work: `wwwroot` is globbed when the project is evaluated, so a file written by a target is invisible
 to the static web asset pipeline, and the target that would write it runs in more than one project

--- a/src/SkiaSharp.QrCode.Playground/README.md
+++ b/src/SkiaSharp.QrCode.Playground/README.md
@@ -42,10 +42,10 @@ Run it **before** publishing; the release workflow does the same. The file is ge
 gitignored, and the API link 404s until you have run the command once. Drop `--html -o ...` for the
 plain-text listing on stdout, which is the form to diff.
 
-The doc text comes from an XML documentation file the tool builds for itself, because the library
-does not set `GenerateDocumentationFile`. That also means **the NuGet package ships no XML docs**,
-so consumers get no IntelliSense: worth fixing separately, along with the ~116 doc-completeness
-warnings (`CS1591`, `CS1573`, `CS0419`, `CS1572`) that turning it on reveals.
+The doc text is read from the XML documentation file the library ships, so the page shows exactly
+what a consumer sees in IntelliSense. `<summary>` is always visible; `<remarks>` folds behind a
+**Notes** toggle, because it usually runs several times longer than the summary it explains and
+would otherwise bury the signatures. Filtering opens only the Notes it matched inside.
 
 Nothing validates the listing and no build fails when the surface changes. Breaking changes are
 caught by package validation against the released baseline, which is the only surface check worth

--- a/src/SkiaSharp.QrCode.Playground/README.md
+++ b/src/SkiaSharp.QrCode.Playground/README.md
@@ -30,17 +30,25 @@ works on hosts without import-map rewriting (GitHub Pages, plain static servers)
 ## Public API page (`/api/`)
 
 The **API** link in the header opens a filterable listing of every public type, with the doc
-comments for each, generated from the built assembly by `tools/public_api.cs`. It is written
-into `wwwroot/api/index.html`, so one command covers both cases: the page is served when you
-run the Playground locally, and `dotnet publish` copies it into the Pages site.
+comments for each, generated from the built assembly by `tools/public_api.cs`.
+
+`wwwroot/api/index.html` **is committed**, so it is simply there: F5 in Visual Studio, `dotnet
+run`, and `dotnet publish` all serve it with no extra step, on a fresh clone included. Regenerate
+it after changing the public API:
 
 ```bash
 dotnet run tools/public_api.cs -- --html -o src/SkiaSharp.QrCode.Playground/wwwroot/api/index.html
 ```
 
-Run it **before** publishing; the release workflow does the same. The file is generated, so it is
-gitignored, and the API link 404s until you have run the command once. Drop `--html -o ...` for the
-plain-text listing on stdout, which is the form to diff.
+The release workflow runs the same command before publishing, so the Pages site is always current
+even if the committed copy has drifted. Drop `--html -o ...` for the plain-text listing on stdout.
+
+Committing a generated file is deliberate. Generating it during the build was tried and does not
+work: `wwwroot` is globbed when the project is evaluated, so a file written by a target is invisible
+to the static web asset pipeline, and the target that would write it runs in more than one project
+instance, which starts two generators at once over the same output. The listing is sorted and
+stable, so the committed file also gives every PR a readable diff of the public surface, without a
+CI gate that fails on intentional changes.
 
 The doc text is read from the XML documentation file the library ships, so the page shows exactly
 what a consumer sees in IntelliSense. `<summary>` is always visible; `<remarks>` folds behind a

--- a/src/SkiaSharp.QrCode.Playground/README.md
+++ b/src/SkiaSharp.QrCode.Playground/README.md
@@ -27,10 +27,14 @@ dotnet serve -d publish/playground/wwwroot   # or: python -m http.server -d publ
 `-p:PlaygroundSoftFingerprint=true` emits both fingerprinted and plain filenames so the page
 works on hosts without import-map rewriting (GitHub Pages, plain static servers).
 
-## Public API page (`/api/`)
+## Public API page (`/api/index.html`)
 
 The **API** link in the header opens a filterable listing of every public type, with the doc
 comments for each, generated from the built assembly by `tools/public_api.cs`.
+
+Link to it as `api/index.html`, never `api/`. The dev server behind F5 and `dotnet run` has no
+default document for a subdirectory and falls back to the Playground page instead, so `api/`
+answers 200 with the wrong page rather than a visible 404. GitHub Pages resolves either form.
 
 `wwwroot/api/index.html` **is committed**, so it is simply there: F5 in Visual Studio, `dotnet
 run`, and `dotnet publish` all serve it with no extra step, on a fresh clone included. Regenerate

--- a/src/SkiaSharp.QrCode.Playground/wwwroot/api/index.html
+++ b/src/SkiaSharp.QrCode.Playground/wwwroot/api/index.html
@@ -189,6 +189,9 @@
        carries the accent because that is what they are looking *for*. */
     .kind { color: var(--text-muted); font-weight: 400; }
     .name { color: var(--accent); }
+    a.name { text-decoration: none; }
+    a.name:hover { text-decoration: underline; }
+    a.name:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 
     /* Signatures wrap instead of scrolling: a horizontal scrollbar per signature hides
        the end of every long one and makes the reader work for it. C# breaks cleanly at
@@ -279,7 +282,7 @@
   <header class="bar">
     <a class="back" href="../">&#8592; Playground</a>
     <h1>SkiaSharp.QrCode API</h1>
-    <span class="meta">1.2.0.0 &middot; <span id="count">57 types</span></span>
+    <span class="meta">1.2.0.0 &middot; <span id="count">57 types</span> &middot; source bc073bc</span>
   </header>
 
   <div class="layout">
@@ -430,29 +433,29 @@
           </div>
         </article>
         <article class="type" id="SkiaSharp.QrCode.MicroQRCodeCalculatedSize" data-name="skiasharp.qrcode.microqrcodecalculatedsize" data-text="skiasharp.qrcode.microqrcodecalculatedsize public readonly struct microqrcodecalculatedsize result of trygetrequiredbuffersize : buffer size, matrix side length and selected version for a pending micro qr encode.  property public microqrversion version { get; } the micro qr version that will be produced.  property public int buffersize { get; } required destination buffer size in bytes (one byte per module, quiet zone included).  property public int qrsize { get; } matrix side length in modules, quiet zone included. ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.MicroQRCodeCalculatedSize" aria-label="Link to SkiaSharp.QrCode.MicroQRCodeCalculatedSize">#</a><span class="kind">struct</span> <span class="name">MicroQRCodeCalculatedSize</span></h3>
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.MicroQRCodeCalculatedSize" aria-label="Link to SkiaSharp.QrCode.MicroQRCodeCalculatedSize">#</a><span class="kind">struct</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeCalculatedSize.cs" title="View source file on GitHub" target="_blank" rel="noopener noreferrer">MicroQRCodeCalculatedSize</a></h3>
           <pre class="sig"><code>public readonly struct MicroQRCodeCalculatedSize</code></pre>
           <p class="doc">Result of TryGetRequiredBufferSize : buffer size, matrix side length and selected version for a pending Micro QR encode.</p>
           <div class="members">
             <div class="member" data-text="property public microqrversion version { get; } the micro qr version that will be produced. ">
-              <h4><span class="kind">property</span> <span class="name">Version</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeCalculatedSize.cs#L23" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Version</a></h4>
               <pre class="sig"><code>public MicroQRVersion Version { get; }</code></pre>
               <p class="doc">The Micro QR version that will be produced.</p>
             </div>
             <div class="member" data-text="property public int buffersize { get; } required destination buffer size in bytes (one byte per module, quiet zone included). ">
-              <h4><span class="kind">property</span> <span class="name">BufferSize</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeCalculatedSize.cs#L17" title="View source on GitHub" target="_blank" rel="noopener noreferrer">BufferSize</a></h4>
               <pre class="sig"><code>public int BufferSize { get; }</code></pre>
               <p class="doc">Required destination buffer size in bytes (one byte per module, quiet zone included).</p>
             </div>
             <div class="member" data-text="property public int qrsize { get; } matrix side length in modules, quiet zone included. ">
-              <h4><span class="kind">property</span> <span class="name">QrSize</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeCalculatedSize.cs#L20" title="View source on GitHub" target="_blank" rel="noopener noreferrer">QrSize</a></h4>
               <pre class="sig"><code>public int QrSize { get; }</code></pre>
               <p class="doc">Matrix side length in modules, quiet zone included.</p>
             </div>
           </div>
         </article>
         <article class="type" id="SkiaSharp.QrCode.MicroQRCodeData" data-name="skiasharp.qrcode.microqrcodedata" data-text="skiasharp.qrcode.microqrcodedata public class microqrcodedata represents micro qr code data as a 2d boolean matrix (versions m1-m4, 11×11 to 17×17 modules). storage mirrors qrcodedata : core modules only (no quiet zone), bit-packed msb-first in flat row-major order; the quiet zone is virtual and always reads light. serialization uses the &quot;qrx&quot; container: &quot;qrx&quot; + symbol type (1 byte) + width (1 byte) + height (1 byte) + packed core bits. the legacy &quot;qrr&quot; format remains exclusive to standard qr. constructor public microqrcodedata(microqrversion version, int quietzonesize); initializes an empty matrix for the specified version.  constructor public microqrcodedata(readonlyspan&lt;byte&gt; rawdata, int quietzonesize);  constructor public microqrcodedata(byte[] rawdata, int quietzonesize); deserializes micro qr data previously produced by getrawdata .  property public microqrversion version { get; } gets the micro qr version (m1-m4).  indexer public bool this[int row, int col] { get; } gets the module state at the specified position (quiet zone included). quiet zone positions always read false.  property public int size { get; } gets the matrix side length in modules, including the quiet zone.  method public modulerect[] getmodulerectangles(); gets the dark modules as merged rectangles in module coordinates, for rendering with any graphics api without skiasharp (svg path data, draw calls, vector output). coordinates use the same space as the indexer (this[row, col]): one unit is one module, origin at the top-left including the quiet zone, x is the column and y is the row. consumers scale by the pixel size of one module; size gives the total extent in modules. three properties are contractual: rectangles never overlap, cover only dark modules, and cover every dark module. the decomposition shape and ordering are unspecified and may change between versions (currently maximal horizontal runs in row-major order, the same merge the built-in renderer draws). method public bool trygetmodulerectangles(span&lt;modulerect&gt; destination, out int written); writes the dark modules as merged rectangles into a caller-provided buffer. same contract as getmodulerectangles without allocations.  method public byte[] getrawdata(); serializes the core modules (quiet zone excluded) to a new byte array.  method public int getmodulerectanglesmaxcount(); gets an upper bound on the number of rectangles getmodulerectangles can return, suitable for sizing a pooled buffer for trygetmodulerectangles . o(1), no matrix scan.  method public int getrawdata(ibufferwriter&lt;byte&gt; writer); writes the serialized data to the specified buffer writer without intermediate allocation.  method public int getrawdatasize(); gets the serialized size in bytes (&quot;qrx&quot; header + packed core bits). ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.MicroQRCodeData" aria-label="Link to SkiaSharp.QrCode.MicroQRCodeData">#</a><span class="kind">class</span> <span class="name">MicroQRCodeData</span></h3>
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.MicroQRCodeData" aria-label="Link to SkiaSharp.QrCode.MicroQRCodeData">#</a><span class="kind">class</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeData.cs" title="View source file on GitHub" target="_blank" rel="noopener noreferrer">MicroQRCodeData</a></h3>
           <pre class="sig"><code>public class MicroQRCodeData</code></pre>
           <p class="doc">Represents Micro QR code data as a 2D boolean matrix (versions M1-M4, 11×11 to 17×17 modules).</p>
           <details class="notes" data-text="storage mirrors qrcodedata : core modules only (no quiet zone), bit-packed msb-first in flat row-major order; the quiet zone is virtual and always reads light. serialization uses the &quot;qrx&quot; container: &quot;qrx&quot; + symbol type (1 byte) + width (1 byte) + height (1 byte) + packed core bits. the legacy &quot;qrr&quot; format remains exclusive to standard qr.">
@@ -461,36 +464,36 @@
           </details>
           <div class="members">
             <div class="member" data-text="constructor public microqrcodedata(microqrversion version, int quietzonesize); initializes an empty matrix for the specified version. ">
-              <h4><span class="kind">constructor</span> <span class="name">MicroQRCodeData</span></h4>
+              <h4><span class="kind">constructor</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeData.cs#L66" title="View source on GitHub" target="_blank" rel="noopener noreferrer">MicroQRCodeData</a></h4>
               <pre class="sig"><code>public MicroQRCodeData(MicroQRVersion version, int quietZoneSize);</code></pre>
               <p class="doc">Initializes an empty matrix for the specified version.</p>
             </div>
             <div class="member" data-text="constructor public microqrcodedata(readonlyspan&lt;byte&gt; rawdata, int quietzonesize); ">
-              <h4><span class="kind">constructor</span> <span class="name">MicroQRCodeData</span></h4>
+              <h4><span class="kind">constructor</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeData.cs#L92" title="View source on GitHub" target="_blank" rel="noopener noreferrer">MicroQRCodeData</a></h4>
               <pre class="sig"><code>public MicroQRCodeData(ReadOnlySpan&lt;byte&gt; rawData, int quietZoneSize);</code></pre>
             </div>
             <div class="member" data-text="constructor public microqrcodedata(byte[] rawdata, int quietzonesize); deserializes micro qr data previously produced by getrawdata . ">
-              <h4><span class="kind">constructor</span> <span class="name">MicroQRCodeData</span></h4>
+              <h4><span class="kind">constructor</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeData.cs#L87" title="View source on GitHub" target="_blank" rel="noopener noreferrer">MicroQRCodeData</a></h4>
               <pre class="sig"><code>public MicroQRCodeData(byte[] rawData, int quietZoneSize);</code></pre>
               <p class="doc">Deserializes Micro QR data previously produced by GetRawData .</p>
             </div>
             <div class="member" data-text="property public microqrversion version { get; } gets the micro qr version (m1-m4). ">
-              <h4><span class="kind">property</span> <span class="name">Version</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeData.cs#L30" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Version</a></h4>
               <pre class="sig"><code>public MicroQRVersion Version { get; }</code></pre>
               <p class="doc">Gets the Micro QR version (M1-M4).</p>
             </div>
             <div class="member" data-text="indexer public bool this[int row, int col] { get; } gets the module state at the specified position (quiet zone included). quiet zone positions always read false. ">
-              <h4><span class="kind">indexer</span> <span class="name">this[int row, int col]</span></h4>
+              <h4><span class="kind">indexer</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeData.cs#L43" title="View source on GitHub" target="_blank" rel="noopener noreferrer">this[int row, int col]</a></h4>
               <pre class="sig"><code>public bool this[int row, int col] { get; }</code></pre>
               <p class="doc">Gets the module state at the specified position (quiet zone included). Quiet zone positions always read false.</p>
             </div>
             <div class="member" data-text="property public int size { get; } gets the matrix side length in modules, including the quiet zone. ">
-              <h4><span class="kind">property</span> <span class="name">Size</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeData.cs#L27" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Size</a></h4>
               <pre class="sig"><code>public int Size { get; }</code></pre>
               <p class="doc">Gets the matrix side length in modules, including the quiet zone.</p>
             </div>
             <div class="member" data-text="method public modulerect[] getmodulerectangles(); gets the dark modules as merged rectangles in module coordinates, for rendering with any graphics api without skiasharp (svg path data, draw calls, vector output). coordinates use the same space as the indexer (this[row, col]): one unit is one module, origin at the top-left including the quiet zone, x is the column and y is the row. consumers scale by the pixel size of one module; size gives the total extent in modules. three properties are contractual: rectangles never overlap, cover only dark modules, and cover every dark module. the decomposition shape and ordering are unspecified and may change between versions (currently maximal horizontal runs in row-major order, the same merge the built-in renderer draws).">
-              <h4><span class="kind">method</span> <span class="name">GetModuleRectangles</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeData.cs#L201" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetModuleRectangles</a></h4>
               <pre class="sig"><code>public ModuleRect[] GetModuleRectangles();</code></pre>
               <p class="doc">Gets the dark modules as merged rectangles in module coordinates, for rendering with any graphics API without SkiaSharp (SVG path data, draw calls, vector output).</p>
               <details class="notes" data-text="coordinates use the same space as the indexer (this[row, col]): one unit is one module, origin at the top-left including the quiet zone, x is the column and y is the row. consumers scale by the pixel size of one module; size gives the total extent in modules. three properties are contractual: rectangles never overlap, cover only dark modules, and cover every dark module. the decomposition shape and ordering are unspecified and may change between versions (currently maximal horizontal runs in row-major order, the same merge the built-in renderer draws).">
@@ -499,34 +502,34 @@
               </details>
             </div>
             <div class="member" data-text="method public bool trygetmodulerectangles(span&lt;modulerect&gt; destination, out int written); writes the dark modules as merged rectangles into a caller-provided buffer. same contract as getmodulerectangles without allocations. ">
-              <h4><span class="kind">method</span> <span class="name">TryGetModuleRectangles</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeData.cs#L214" title="View source on GitHub" target="_blank" rel="noopener noreferrer">TryGetModuleRectangles</a></h4>
               <pre class="sig"><code>public bool TryGetModuleRectangles(Span&lt;ModuleRect&gt; destination, out int written);</code></pre>
               <p class="doc">Writes the dark modules as merged rectangles into a caller-provided buffer. Same contract as GetModuleRectangles without allocations.</p>
             </div>
             <div class="member" data-text="method public byte[] getrawdata(); serializes the core modules (quiet zone excluded) to a new byte array. ">
-              <h4><span class="kind">method</span> <span class="name">GetRawData</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeData.cs#L143" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetRawData</a></h4>
               <pre class="sig"><code>public byte[] GetRawData();</code></pre>
               <p class="doc">Serializes the core modules (quiet zone excluded) to a new byte array.</p>
             </div>
             <div class="member" data-text="method public int getmodulerectanglesmaxcount(); gets an upper bound on the number of rectangles getmodulerectangles can return, suitable for sizing a pooled buffer for trygetmodulerectangles . o(1), no matrix scan. ">
-              <h4><span class="kind">method</span> <span class="name">GetModuleRectanglesMaxCount</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeData.cs#L179" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetModuleRectanglesMaxCount</a></h4>
               <pre class="sig"><code>public int GetModuleRectanglesMaxCount();</code></pre>
               <p class="doc">Gets an upper bound on the number of rectangles GetModuleRectangles can return, suitable for sizing a pooled buffer for TryGetModuleRectangles . O(1), no matrix scan.</p>
             </div>
             <div class="member" data-text="method public int getrawdata(ibufferwriter&lt;byte&gt; writer); writes the serialized data to the specified buffer writer without intermediate allocation. ">
-              <h4><span class="kind">method</span> <span class="name">GetRawData</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeData.cs#L155" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetRawData</a></h4>
               <pre class="sig"><code>public int GetRawData(IBufferWriter&lt;byte&gt; writer);</code></pre>
               <p class="doc">Writes the serialized data to the specified buffer writer without intermediate allocation.</p>
             </div>
             <div class="member" data-text="method public int getrawdatasize(); gets the serialized size in bytes (&quot;qrx&quot; header + packed core bits). ">
-              <h4><span class="kind">method</span> <span class="name">GetRawDataSize</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeData.cs#L137" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetRawDataSize</a></h4>
               <pre class="sig"><code>public int GetRawDataSize();</code></pre>
               <p class="doc">Gets the serialized size in bytes (&quot;QRX&quot; header + packed core bits).</p>
             </div>
           </div>
         </article>
         <article class="type" id="SkiaSharp.QrCode.MicroQRCodeDecodeInfo" data-name="skiasharp.qrcode.microqrcodedecodeinfo" data-text="skiasharp.qrcode.microqrcodedecodeinfo public readonly struct microqrcodedecodeinfo diagnostic information produced by a micro qr code decode attempt. statuses are shared with the standard qr decoder ( qrcodedecodestatus ); version, ecc level and mask pattern use the micro qr domains. property public microqrecclevel ecclevel { get; } error correction level read from the format information.  property public microqrversion version { get; } micro qr version (m1-m4), or default (0) when the matrix was invalid.  property public qrcodedecodestatus status { get; } decode result status. success when decoding succeeded.  property public int errorscorrected { get; } number of codeword errors corrected by reed-solomon decoding.  property public int maskpattern { get; } mask pattern (0-3) read from the format information, or -1 when unknown. ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.MicroQRCodeDecodeInfo" aria-label="Link to SkiaSharp.QrCode.MicroQRCodeDecodeInfo">#</a><span class="kind">struct</span> <span class="name">MicroQRCodeDecodeInfo</span></h3>
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.MicroQRCodeDecodeInfo" aria-label="Link to SkiaSharp.QrCode.MicroQRCodeDecodeInfo">#</a><span class="kind">struct</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeDecodeInfo.cs" title="View source file on GitHub" target="_blank" rel="noopener noreferrer">MicroQRCodeDecodeInfo</a></h3>
           <pre class="sig"><code>public readonly struct MicroQRCodeDecodeInfo</code></pre>
           <p class="doc">Diagnostic information produced by a Micro QR code decode attempt.</p>
           <details class="notes" data-text="statuses are shared with the standard qr decoder ( qrcodedecodestatus ); version, ecc level and mask pattern use the micro qr domains.">
@@ -535,34 +538,34 @@
           </details>
           <div class="members">
             <div class="member" data-text="property public microqrecclevel ecclevel { get; } error correction level read from the format information. ">
-              <h4><span class="kind">property</span> <span class="name">EccLevel</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeDecodeInfo.cs#L28" title="View source on GitHub" target="_blank" rel="noopener noreferrer">EccLevel</a></h4>
               <pre class="sig"><code>public MicroQREccLevel EccLevel { get; }</code></pre>
               <p class="doc">Error correction level read from the format information.</p>
             </div>
             <div class="member" data-text="property public microqrversion version { get; } micro qr version (m1-m4), or default (0) when the matrix was invalid. ">
-              <h4><span class="kind">property</span> <span class="name">Version</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeDecodeInfo.cs#L25" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Version</a></h4>
               <pre class="sig"><code>public MicroQRVersion Version { get; }</code></pre>
               <p class="doc">Micro QR version (M1-M4), or default (0) when the matrix was invalid.</p>
             </div>
             <div class="member" data-text="property public qrcodedecodestatus status { get; } decode result status. success when decoding succeeded. ">
-              <h4><span class="kind">property</span> <span class="name">Status</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeDecodeInfo.cs#L22" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Status</a></h4>
               <pre class="sig"><code>public QRCodeDecodeStatus Status { get; }</code></pre>
               <p class="doc">Decode result status. Success when decoding succeeded.</p>
             </div>
             <div class="member" data-text="property public int errorscorrected { get; } number of codeword errors corrected by reed-solomon decoding. ">
-              <h4><span class="kind">property</span> <span class="name">ErrorsCorrected</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeDecodeInfo.cs#L34" title="View source on GitHub" target="_blank" rel="noopener noreferrer">ErrorsCorrected</a></h4>
               <pre class="sig"><code>public int ErrorsCorrected { get; }</code></pre>
               <p class="doc">Number of codeword errors corrected by Reed-Solomon decoding.</p>
             </div>
             <div class="member" data-text="property public int maskpattern { get; } mask pattern (0-3) read from the format information, or -1 when unknown. ">
-              <h4><span class="kind">property</span> <span class="name">MaskPattern</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeDecodeInfo.cs#L31" title="View source on GitHub" target="_blank" rel="noopener noreferrer">MaskPattern</a></h4>
               <pre class="sig"><code>public int MaskPattern { get; }</code></pre>
               <p class="doc">Mask pattern (0-3) read from the format information, or -1 when unknown.</p>
             </div>
           </div>
         </article>
         <article class="type" id="SkiaSharp.QrCode.MicroQRCodeDecoder" data-name="skiasharp.qrcode.microqrcodedecoder" data-text="skiasharp.qrcode.microqrcodedecoder public static class microqrcodedecoder micro qr code decoder based on iso/iec 18004. decodes micro qr module matrices back into text, including reed-solomon error correction. supported content: numeric, alphanumeric and byte mode segments (iso-8859-1 and utf-8), all versions m1-m4 and all legal ecc levels, plus kanji mode segments in m3 and m4 (decoded as jis x 0208; this library never emits them). a kanji cell outside the jis x 0208 repertoire fails the whole symbol with unmappedcharacter rather than substituting a replacement character. micro qr has no eci mode; byte segments use utf-8 when the payload validates as utf-8 and iso-8859-1 otherwise (matching this library's encoder). inputs are module matrices ( microqrcodedata or byte-per-module buffers as produced by microqrcodegenerator ; a uniform light quiet zone border is detected and skipped automatically) or images via the trydecode / trydecodeimage overloads. image detection targets clean, screen-rendered or scanned images: arbitrary rotation, mirroring, reflectance reversal, uniform or non-uniform scaling, translation and mild perspective distortion are supported. micro qr image scanning is a separate, explicitly-typed entry point — qrcodedecoder continues to scan standard qr only. method public static bool trydecode(microqrcodedata data, out string text); decodes the text content from micro qr code data.  method public static bool trydecode(microqrcodedata data, out string text, out microqrcodedecodeinfo info); decodes the text content from micro qr code data, with diagnostic information.  method public static bool trydecode(readonlyspan&lt;byte&gt; modules, int size, span&lt;char&gt; destination, out int charswritten, out microqrcodedecodeinfo info); decodes the text content from a module matrix into a caller-provided buffer without per-call heap allocation.  method public static bool trydecode(readonlyspan&lt;byte&gt; modules, int size, out string text, out microqrcodedecodeinfo info); decodes the text content from a module matrix.  method public static bool trydecode(skbitmap bitmap, out string text); detects and decodes a micro qr code from a bitmap image. targets clean, well-lit images such as screenshots, rendered symbols and scans: arbitrary rotation, mirroring, reflectance reversal (light-on-dark), uniform or non-uniform scaling, translation and mild perspective distortion are handled. strong perspective, uneven lighting and blur are out of scope. method public static bool trydecode(skbitmap bitmap, out string text, out microqrcodedecodeinfo info); detects and decodes a micro qr code from a bitmap image, with diagnostic information. see trydecode for the supported image envelope. method public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, span&lt;char&gt; destination, out int charswritten, out microqrcodedecodeinfo info); detects and decodes a micro qr code from grayscale image pixels into a caller-provided buffer without per-call heap allocation.  method public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, out string text, out microqrcodedecodeinfo info); detects and decodes a micro qr code from grayscale image pixels.  method public static int getmaxdecodedlength(microqrversion version); calculates the maximum possible decoded character count for a micro qr version, across all ecc levels and encoding modes. use to size the destination buffer for the allocation-free trydecode overload. ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.MicroQRCodeDecoder" aria-label="Link to SkiaSharp.QrCode.MicroQRCodeDecoder">#</a><span class="kind">class</span> <span class="name">MicroQRCodeDecoder</span></h3>
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.MicroQRCodeDecoder" aria-label="Link to SkiaSharp.QrCode.MicroQRCodeDecoder">#</a><span class="kind">class</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeDecoder.cs" title="View source file on GitHub" target="_blank" rel="noopener noreferrer">MicroQRCodeDecoder</a></h3>
           <pre class="sig"><code>public static class MicroQRCodeDecoder</code></pre>
           <p class="doc">Micro QR code decoder based on ISO/IEC 18004. Decodes Micro QR module matrices back into text, including Reed-Solomon error correction.</p>
           <details class="notes" data-text="supported content: numeric, alphanumeric and byte mode segments (iso-8859-1 and utf-8), all versions m1-m4 and all legal ecc levels, plus kanji mode segments in m3 and m4 (decoded as jis x 0208; this library never emits them). a kanji cell outside the jis x 0208 repertoire fails the whole symbol with unmappedcharacter rather than substituting a replacement character. micro qr has no eci mode; byte segments use utf-8 when the payload validates as utf-8 and iso-8859-1 otherwise (matching this library's encoder). inputs are module matrices ( microqrcodedata or byte-per-module buffers as produced by microqrcodegenerator ; a uniform light quiet zone border is detected and skipped automatically) or images via the trydecode / trydecodeimage overloads. image detection targets clean, screen-rendered or scanned images: arbitrary rotation, mirroring, reflectance reversal, uniform or non-uniform scaling, translation and mild perspective distortion are supported. micro qr image scanning is a separate, explicitly-typed entry point — qrcodedecoder continues to scan standard qr only.">
@@ -571,27 +574,27 @@
           </details>
           <div class="members">
             <div class="member" data-text="method public static bool trydecode(microqrcodedata data, out string text); decodes the text content from micro qr code data. ">
-              <h4><span class="kind">method</span> <span class="name">TryDecode</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeDecoder.cs#L44" title="View source on GitHub" target="_blank" rel="noopener noreferrer">TryDecode</a></h4>
               <pre class="sig"><code>public static bool TryDecode(MicroQRCodeData data, out string text);</code></pre>
               <p class="doc">Decodes the text content from Micro QR code data.</p>
             </div>
             <div class="member" data-text="method public static bool trydecode(microqrcodedata data, out string text, out microqrcodedecodeinfo info); decodes the text content from micro qr code data, with diagnostic information. ">
-              <h4><span class="kind">method</span> <span class="name">TryDecode</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeDecoder.cs#L55" title="View source on GitHub" target="_blank" rel="noopener noreferrer">TryDecode</a></h4>
               <pre class="sig"><code>public static bool TryDecode(MicroQRCodeData data, out string text, out MicroQRCodeDecodeInfo info);</code></pre>
               <p class="doc">Decodes the text content from Micro QR code data, with diagnostic information.</p>
             </div>
             <div class="member" data-text="method public static bool trydecode(readonlyspan&lt;byte&gt; modules, int size, span&lt;char&gt; destination, out int charswritten, out microqrcodedecodeinfo info); decodes the text content from a module matrix into a caller-provided buffer without per-call heap allocation. ">
-              <h4><span class="kind">method</span> <span class="name">TryDecode</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeDecoder.cs#L130" title="View source on GitHub" target="_blank" rel="noopener noreferrer">TryDecode</a></h4>
               <pre class="sig"><code>public static bool TryDecode(ReadOnlySpan&lt;byte&gt; modules, int size, Span&lt;char&gt; destination, out int charsWritten, out MicroQRCodeDecodeInfo info);</code></pre>
               <p class="doc">Decodes the text content from a module matrix into a caller-provided buffer without per-call heap allocation.</p>
             </div>
             <div class="member" data-text="method public static bool trydecode(readonlyspan&lt;byte&gt; modules, int size, out string text, out microqrcodedecodeinfo info); decodes the text content from a module matrix. ">
-              <h4><span class="kind">method</span> <span class="name">TryDecode</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeDecoder.cs#L87" title="View source on GitHub" target="_blank" rel="noopener noreferrer">TryDecode</a></h4>
               <pre class="sig"><code>public static bool TryDecode(ReadOnlySpan&lt;byte&gt; modules, int size, out string text, out MicroQRCodeDecodeInfo info);</code></pre>
               <p class="doc">Decodes the text content from a module matrix.</p>
             </div>
             <div class="member" data-text="method public static bool trydecode(skbitmap bitmap, out string text); detects and decodes a micro qr code from a bitmap image. targets clean, well-lit images such as screenshots, rendered symbols and scans: arbitrary rotation, mirroring, reflectance reversal (light-on-dark), uniform or non-uniform scaling, translation and mild perspective distortion are handled. strong perspective, uneven lighting and blur are out of scope.">
-              <h4><span class="kind">method</span> <span class="name">TryDecode</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeDecoder.cs#L165" title="View source on GitHub" target="_blank" rel="noopener noreferrer">TryDecode</a></h4>
               <pre class="sig"><code>public static bool TryDecode(SKBitmap bitmap, out string text);</code></pre>
               <p class="doc">Detects and decodes a Micro QR code from a bitmap image.</p>
               <details class="notes" data-text="targets clean, well-lit images such as screenshots, rendered symbols and scans: arbitrary rotation, mirroring, reflectance reversal (light-on-dark), uniform or non-uniform scaling, translation and mild perspective distortion are handled. strong perspective, uneven lighting and blur are out of scope.">
@@ -600,7 +603,7 @@
               </details>
             </div>
             <div class="member" data-text="method public static bool trydecode(skbitmap bitmap, out string text, out microqrcodedecodeinfo info); detects and decodes a micro qr code from a bitmap image, with diagnostic information. see trydecode for the supported image envelope.">
-              <h4><span class="kind">method</span> <span class="name">TryDecode</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeDecoder.cs#L179" title="View source on GitHub" target="_blank" rel="noopener noreferrer">TryDecode</a></h4>
               <pre class="sig"><code>public static bool TryDecode(SKBitmap bitmap, out string text, out MicroQRCodeDecodeInfo info);</code></pre>
               <p class="doc">Detects and decodes a Micro QR code from a bitmap image, with diagnostic information.</p>
               <details class="notes" data-text="see trydecode for the supported image envelope.">
@@ -609,24 +612,24 @@
               </details>
             </div>
             <div class="member" data-text="method public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, span&lt;char&gt; destination, out int charswritten, out microqrcodedecodeinfo info); detects and decodes a micro qr code from grayscale image pixels into a caller-provided buffer without per-call heap allocation. ">
-              <h4><span class="kind">method</span> <span class="name">TryDecodeImage</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeDecoder.cs#L249" title="View source on GitHub" target="_blank" rel="noopener noreferrer">TryDecodeImage</a></h4>
               <pre class="sig"><code>public static bool TryDecodeImage(ReadOnlySpan&lt;byte&gt; luminance, int width, int height, Span&lt;char&gt; destination, out int charsWritten, out MicroQRCodeDecodeInfo info);</code></pre>
               <p class="doc">Detects and decodes a Micro QR code from grayscale image pixels into a caller-provided buffer without per-call heap allocation.</p>
             </div>
             <div class="member" data-text="method public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, out string text, out microqrcodedecodeinfo info); detects and decodes a micro qr code from grayscale image pixels. ">
-              <h4><span class="kind">method</span> <span class="name">TryDecodeImage</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeDecoder.cs#L217" title="View source on GitHub" target="_blank" rel="noopener noreferrer">TryDecodeImage</a></h4>
               <pre class="sig"><code>public static bool TryDecodeImage(ReadOnlySpan&lt;byte&gt; luminance, int width, int height, out string text, out MicroQRCodeDecodeInfo info);</code></pre>
               <p class="doc">Detects and decodes a Micro QR code from grayscale image pixels.</p>
             </div>
             <div class="member" data-text="method public static int getmaxdecodedlength(microqrversion version); calculates the maximum possible decoded character count for a micro qr version, across all ecc levels and encoding modes. use to size the destination buffer for the allocation-free trydecode overload. ">
-              <h4><span class="kind">method</span> <span class="name">GetMaxDecodedLength</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeDecoder.cs#L265" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetMaxDecodedLength</a></h4>
               <pre class="sig"><code>public static int GetMaxDecodedLength(MicroQRVersion version);</code></pre>
               <p class="doc">Calculates the maximum possible decoded character count for a Micro QR version, across all ECC levels and encoding modes. Use to size the destination buffer for the allocation-free TryDecode overload.</p>
             </div>
           </div>
         </article>
         <article class="type" id="SkiaSharp.QrCode.MicroQRCodeGenerator" data-name="skiasharp.qrcode.microqrcodegenerator" data-text="skiasharp.qrcode.microqrcodegenerator public static class microqrcodegenerator micro qr code generator based on iso/iec 18004 (versions m1-m4). micro qr constraints enforced by this generator (they differ per version, so invalid combinations throw instead of silently degrading): m1: numeric mode only, errordetectiononly only.m2: numeric/alphanumeric, ecc l or m.m3: numeric/alphanumeric/byte, ecc l or m.m4: numeric/alphanumeric/byte, ecc l, m or q. micro qr has no eci mode; text that is not iso-8859-1-representable is encoded as raw utf-8 bytes in byte mode. kanji mode is not written; microqrcodedecoder does read the kanji segments (m3 and m4) that other encoders produce, so the two directions are deliberately asymmetric. method [obsolete] public static microqrcodecalculatedsize getrequiredbuffersize(readonlyspan&lt;char&gt; text, microqrecclevel ecclevel, microqrversion? requestedversion = null, int quietzonesize = 2); calculates the required buffer size for encoding the specified text as a micro qr code.  method public static microqrcodedata createmicroqrcode(readonlyspan&lt;char&gt; textspan, microqrecclevel ecclevel, microqrversion? requestedversion = null, int quietzonesize = 2);  method public static microqrcodedata createmicroqrcode(readonlyspan&lt;char&gt; textspan, microqrecclevel ecclevel, in microqrcodegeneratoroptions options);  method public static microqrcodedata createmicroqrcode(string plaintext, microqrecclevel ecclevel, microqrversion? requestedversion = null, int quietzonesize = 2); creates a micro qr code from the provided plain text.  method public static microqrcodedata createmicroqrcode(string plaintext, microqrecclevel ecclevel, in microqrcodegeneratoroptions options);  method public static bool trygetrequiredbuffersize(readonlyspan&lt;char&gt; text, microqrecclevel ecclevel, out microqrcodecalculatedsize size, in microqrcodegeneratoroptions options = null); calculates the required buffer size, matrix size and version for encoding the specified text as a micro qr code, reporting content that does not fit as false rather than as an exception. false means the content does not fit, which here includes an encoding mode the version or ecc level does not offer, since the text is what picks the mode. argument errors throw (rationale: specs/rmqr-encoder.md), and so does a version range that offers ecclevel on no version at all, which no content could satisfy. micro qr m1 holds 5 digits, so an overflow is an ordinary answer here. pass the same options you will encode with: segmentation can select a different version, so a buffer sized for one can be too small for the other. method public static int createmicroqrcode(readonlyspan&lt;char&gt; textspan, microqrecclevel ecclevel, span&lt;byte&gt; destination, microqrversion? requestedversion = null, int quietzonesize = 2); creates a micro qr code and writes the module matrix into the caller-provided buffer without per-call heap allocation. output format matches createqrcode : one byte per module (0 = light, 1 = dark), flat row-major, quiet zone included. use trygetrequiredbuffersize to size the destination. method public static int createmicroqrcode(readonlyspan&lt;char&gt; textspan, microqrecclevel ecclevel, span&lt;byte&gt; destination, in microqrcodegeneratoroptions options); ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.MicroQRCodeGenerator" aria-label="Link to SkiaSharp.QrCode.MicroQRCodeGenerator">#</a><span class="kind">class</span> <span class="name">MicroQRCodeGenerator</span></h3>
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.MicroQRCodeGenerator" aria-label="Link to SkiaSharp.QrCode.MicroQRCodeGenerator">#</a><span class="kind">class</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeGenerator.cs" title="View source file on GitHub" target="_blank" rel="noopener noreferrer">MicroQRCodeGenerator</a></h3>
           <pre class="sig"><code>public static class MicroQRCodeGenerator</code></pre>
           <p class="doc">Micro QR code generator based on ISO/IEC 18004 (versions M1-M4).</p>
           <details class="notes" data-text="micro qr constraints enforced by this generator (they differ per version, so invalid combinations throw instead of silently degrading): m1: numeric mode only, errordetectiononly only.m2: numeric/alphanumeric, ecc l or m.m3: numeric/alphanumeric/byte, ecc l or m.m4: numeric/alphanumeric/byte, ecc l, m or q. micro qr has no eci mode; text that is not iso-8859-1-representable is encoded as raw utf-8 bytes in byte mode. kanji mode is not written; microqrcodedecoder does read the kanji segments (m3 and m4) that other encoders produce, so the two directions are deliberately asymmetric.">
@@ -635,29 +638,29 @@
           </details>
           <div class="members">
             <div class="member" data-text="method public static microqrcodecalculatedsize getrequiredbuffersize(readonlyspan&lt;char&gt; text, microqrecclevel ecclevel, microqrversion? requestedversion = null, int quietzonesize = 2); calculates the required buffer size for encoding the specified text as a micro qr code. ">
-              <h4><span class="kind">method</span> <span class="name">GetRequiredBufferSize</span> <span class="tag">obsolete</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeGenerator.cs#L137" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetRequiredBufferSize</a> <span class="tag">obsolete</span></h4>
               <pre class="sig"><code>public static MicroQRCodeCalculatedSize GetRequiredBufferSize(ReadOnlySpan&lt;char&gt; text, MicroQREccLevel eccLevel, MicroQRVersion? requestedVersion = null, int quietZoneSize = 2);</code></pre>
               <p class="doc">Calculates the required buffer size for encoding the specified text as a Micro QR code.</p>
             </div>
             <div class="member" data-text="method public static microqrcodedata createmicroqrcode(readonlyspan&lt;char&gt; textspan, microqrecclevel ecclevel, microqrversion? requestedversion = null, int quietzonesize = 2); ">
-              <h4><span class="kind">method</span> <span class="name">CreateMicroQRCode</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeGenerator.cs#L55" title="View source on GitHub" target="_blank" rel="noopener noreferrer">CreateMicroQRCode</a></h4>
               <pre class="sig"><code>public static MicroQRCodeData CreateMicroQRCode(ReadOnlySpan&lt;char&gt; textSpan, MicroQREccLevel eccLevel, MicroQRVersion? requestedVersion = null, int quietZoneSize = 2);</code></pre>
             </div>
             <div class="member" data-text="method public static microqrcodedata createmicroqrcode(readonlyspan&lt;char&gt; textspan, microqrecclevel ecclevel, in microqrcodegeneratoroptions options); ">
-              <h4><span class="kind">method</span> <span class="name">CreateMicroQRCode</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeGenerator.cs#L188" title="View source on GitHub" target="_blank" rel="noopener noreferrer">CreateMicroQRCode</a></h4>
               <pre class="sig"><code>public static MicroQRCodeData CreateMicroQRCode(ReadOnlySpan&lt;char&gt; textSpan, MicroQREccLevel eccLevel, in MicroQRCodeGeneratorOptions options);</code></pre>
             </div>
             <div class="member" data-text="method public static microqrcodedata createmicroqrcode(string plaintext, microqrecclevel ecclevel, microqrversion? requestedversion = null, int quietzonesize = 2); creates a micro qr code from the provided plain text. ">
-              <h4><span class="kind">method</span> <span class="name">CreateMicroQRCode</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeGenerator.cs#L47" title="View source on GitHub" target="_blank" rel="noopener noreferrer">CreateMicroQRCode</a></h4>
               <pre class="sig"><code>public static MicroQRCodeData CreateMicroQRCode(string plainText, MicroQREccLevel eccLevel, MicroQRVersion? requestedVersion = null, int quietZoneSize = 2);</code></pre>
               <p class="doc">Creates a Micro QR code from the provided plain text.</p>
             </div>
             <div class="member" data-text="method public static microqrcodedata createmicroqrcode(string plaintext, microqrecclevel ecclevel, in microqrcodegeneratoroptions options); ">
-              <h4><span class="kind">method</span> <span class="name">CreateMicroQRCode</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeGenerator.cs#L181" title="View source on GitHub" target="_blank" rel="noopener noreferrer">CreateMicroQRCode</a></h4>
               <pre class="sig"><code>public static MicroQRCodeData CreateMicroQRCode(string plainText, MicroQREccLevel eccLevel, in MicroQRCodeGeneratorOptions options);</code></pre>
             </div>
             <div class="member" data-text="method public static bool trygetrequiredbuffersize(readonlyspan&lt;char&gt; text, microqrecclevel ecclevel, out microqrcodecalculatedsize size, in microqrcodegeneratoroptions options = null); calculates the required buffer size, matrix size and version for encoding the specified text as a micro qr code, reporting content that does not fit as false rather than as an exception. false means the content does not fit, which here includes an encoding mode the version or ecc level does not offer, since the text is what picks the mode. argument errors throw (rationale: specs/rmqr-encoder.md), and so does a version range that offers ecclevel on no version at all, which no content could satisfy. micro qr m1 holds 5 digits, so an overflow is an ordinary answer here. pass the same options you will encode with: segmentation can select a different version, so a buffer sized for one can be too small for the other.">
-              <h4><span class="kind">method</span> <span class="name">TryGetRequiredBufferSize</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeGenerator.cs#L239" title="View source on GitHub" target="_blank" rel="noopener noreferrer">TryGetRequiredBufferSize</a></h4>
               <pre class="sig"><code>public static bool TryGetRequiredBufferSize(ReadOnlySpan&lt;char&gt; text, MicroQREccLevel eccLevel, out MicroQRCodeCalculatedSize size, in MicroQRCodeGeneratorOptions options = null);</code></pre>
               <p class="doc">Calculates the required buffer size, matrix size and version for encoding the specified text as a Micro QR code, reporting content that does not fit as false rather than as an exception.</p>
               <details class="notes" data-text="false means the content does not fit, which here includes an encoding mode the version or ecc level does not offer, since the text is what picks the mode. argument errors throw (rationale: specs/rmqr-encoder.md), and so does a version range that offers ecclevel on no version at all, which no content could satisfy. micro qr m1 holds 5 digits, so an overflow is an ordinary answer here. pass the same options you will encode with: segmentation can select a different version, so a buffer sized for one can be too small for the other.">
@@ -666,7 +669,7 @@
               </details>
             </div>
             <div class="member" data-text="method public static int createmicroqrcode(readonlyspan&lt;char&gt; textspan, microqrecclevel ecclevel, span&lt;byte&gt; destination, microqrversion? requestedversion = null, int quietzonesize = 2); creates a micro qr code and writes the module matrix into the caller-provided buffer without per-call heap allocation. output format matches createqrcode : one byte per module (0 = light, 1 = dark), flat row-major, quiet zone included. use trygetrequiredbuffersize to size the destination.">
-              <h4><span class="kind">method</span> <span class="name">CreateMicroQRCode</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeGenerator.cs#L90" title="View source on GitHub" target="_blank" rel="noopener noreferrer">CreateMicroQRCode</a></h4>
               <pre class="sig"><code>public static int CreateMicroQRCode(ReadOnlySpan&lt;char&gt; textSpan, MicroQREccLevel eccLevel, Span&lt;byte&gt; destination, MicroQRVersion? requestedVersion = null, int quietZoneSize = 2);</code></pre>
               <p class="doc">Creates a Micro QR code and writes the module matrix into the caller-provided buffer without per-call heap allocation.</p>
               <details class="notes" data-text="output format matches createqrcode : one byte per module (0 = light, 1 = dark), flat row-major, quiet zone included. use trygetrequiredbuffersize to size the destination.">
@@ -675,13 +678,13 @@
               </details>
             </div>
             <div class="member" data-text="method public static int createmicroqrcode(readonlyspan&lt;char&gt; textspan, microqrecclevel ecclevel, span&lt;byte&gt; destination, in microqrcodegeneratoroptions options); ">
-              <h4><span class="kind">method</span> <span class="name">CreateMicroQRCode</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeGenerator.cs#L204" title="View source on GitHub" target="_blank" rel="noopener noreferrer">CreateMicroQRCode</a></h4>
               <pre class="sig"><code>public static int CreateMicroQRCode(ReadOnlySpan&lt;char&gt; textSpan, MicroQREccLevel eccLevel, Span&lt;byte&gt; destination, in MicroQRCodeGeneratorOptions options);</code></pre>
             </div>
           </div>
         </article>
         <article class="type" id="SkiaSharp.QrCode.MicroQRCodeGeneratorOptions" data-name="skiasharp.qrcode.microqrcodegeneratoroptions" data-text="skiasharp.qrcode.microqrcodegeneratoroptions public readonly struct microqrcodegeneratoroptions : iequatable&lt;microqrcodegeneratoroptions&gt; optional settings for microqrcodegenerator . default is the complete default configuration (automatic version, 2-module quiet zone), so set only what you need: new microqrcodegeneratoroptions { version = microqrversion.m3, quietzonesize = 0 }. the smallest option set of the three symbologies: micro qr has no eci, and no fit strategy because m1-m4 are totally ordered by capacity. property public microqrsegmentation segmentation { get; init; } how the content is split into encoding-mode segments (see microqrsegmentation ). defaults to single . optimal never selects a larger version, and emits the identical bit stream when a split would not shrink the symbol. size a destination buffer with the same value you encode with.  property public microqrversionrange version { get; init; } the versions the generator may choose from. defaults to any ; a microqrversion or its nullable converts implicitly, so a null means automatic.  property public int quietzonesize { get; init; } quiet zone width in modules. defaults to 2, the iso/iec 18004 value for micro qr; 0 is valid.  property public int? maskpattern { get; init; } pin one of the four micro qr data mask patterns (0-3, iso/iec 18004 table 10) instead of the automatic edge-score selection. null (the default) selects the highest-scoring pattern. any pattern yields a valid, decodable symbol; the automatic choice merely optimizes scan reliability. for reproducing a symbol produced elsewhere byte-for-byte (the pattern another encoder chose is reported by maskpattern ), and for exercising a decoder against all four patterns. micro qr numbers its patterns 0-3; they are not the standard qr patterns of the same index. like version , an invalid value is an argument error and is rejected here rather than when a generator reads it. property public static microqrcodegeneratoroptions default { get; } the default configuration, identical to default. ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.MicroQRCodeGeneratorOptions" aria-label="Link to SkiaSharp.QrCode.MicroQRCodeGeneratorOptions">#</a><span class="kind">struct</span> <span class="name">MicroQRCodeGeneratorOptions</span></h3>
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.MicroQRCodeGeneratorOptions" aria-label="Link to SkiaSharp.QrCode.MicroQRCodeGeneratorOptions">#</a><span class="kind">struct</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeGeneratorOptions.cs" title="View source file on GitHub" target="_blank" rel="noopener noreferrer">MicroQRCodeGeneratorOptions</a></h3>
           <pre class="sig"><code>public readonly struct MicroQRCodeGeneratorOptions : IEquatable&lt;MicroQRCodeGeneratorOptions&gt;</code></pre>
           <p class="doc">Optional settings for MicroQRCodeGenerator . default is the complete default configuration (automatic version, 2-module quiet zone), so set only what you need: new MicroQRCodeGeneratorOptions { Version = MicroQRVersion.M3, QuietZoneSize = 0 }.</p>
           <details class="notes" data-text="the smallest option set of the three symbologies: micro qr has no eci, and no fit strategy because m1-m4 are totally ordered by capacity.">
@@ -690,22 +693,22 @@
           </details>
           <div class="members">
             <div class="member" data-text="property public microqrsegmentation segmentation { get; init; } how the content is split into encoding-mode segments (see microqrsegmentation ). defaults to single . optimal never selects a larger version, and emits the identical bit stream when a split would not shrink the symbol. size a destination buffer with the same value you encode with. ">
-              <h4><span class="kind">property</span> <span class="name">Segmentation</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeGeneratorOptions.cs#L73" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Segmentation</a></h4>
               <pre class="sig"><code>public MicroQRSegmentation Segmentation { get; init; }</code></pre>
               <p class="doc">How the content is split into encoding-mode segments (see MicroQRSegmentation ). Defaults to Single . Optimal never selects a larger version, and emits the identical bit stream when a split would not shrink the symbol. Size a destination buffer with the same value you encode with.</p>
             </div>
             <div class="member" data-text="property public microqrversionrange version { get; init; } the versions the generator may choose from. defaults to any ; a microqrversion or its nullable converts implicitly, so a null means automatic. ">
-              <h4><span class="kind">property</span> <span class="name">Version</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeGeneratorOptions.cs#L27" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Version</a></h4>
               <pre class="sig"><code>public MicroQRVersionRange Version { get; init; }</code></pre>
               <p class="doc">The versions the generator may choose from. Defaults to Any ; a MicroQRVersion or its nullable converts implicitly, so a null means automatic.</p>
             </div>
             <div class="member" data-text="property public int quietzonesize { get; init; } quiet zone width in modules. defaults to 2, the iso/iec 18004 value for micro qr; 0 is valid. ">
-              <h4><span class="kind">property</span> <span class="name">QuietZoneSize</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeGeneratorOptions.cs#L61" title="View source on GitHub" target="_blank" rel="noopener noreferrer">QuietZoneSize</a></h4>
               <pre class="sig"><code>public int QuietZoneSize { get; init; }</code></pre>
               <p class="doc">Quiet zone width in modules. Defaults to 2, the ISO/IEC 18004 value for Micro QR; 0 is valid.</p>
             </div>
             <div class="member" data-text="property public int? maskpattern { get; init; } pin one of the four micro qr data mask patterns (0-3, iso/iec 18004 table 10) instead of the automatic edge-score selection. null (the default) selects the highest-scoring pattern. any pattern yields a valid, decodable symbol; the automatic choice merely optimizes scan reliability. for reproducing a symbol produced elsewhere byte-for-byte (the pattern another encoder chose is reported by maskpattern ), and for exercising a decoder against all four patterns. micro qr numbers its patterns 0-3; they are not the standard qr patterns of the same index. like version , an invalid value is an argument error and is rejected here rather than when a generator reads it.">
-              <h4><span class="kind">property</span> <span class="name">MaskPattern</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeGeneratorOptions.cs#L46" title="View source on GitHub" target="_blank" rel="noopener noreferrer">MaskPattern</a></h4>
               <pre class="sig"><code>public int? MaskPattern { get; init; }</code></pre>
               <p class="doc">Pin one of the four Micro QR data mask patterns (0-3, ISO/IEC 18004 Table 10) instead of the automatic edge-score selection. null (the default) selects the highest-scoring pattern. Any pattern yields a valid, decodable symbol; the automatic choice merely optimizes scan reliability.</p>
               <details class="notes" data-text="for reproducing a symbol produced elsewhere byte-for-byte (the pattern another encoder chose is reported by maskpattern ), and for exercising a decoder against all four patterns. micro qr numbers its patterns 0-3; they are not the standard qr patterns of the same index. like version , an invalid value is an argument error and is rejected here rather than when a generator reads it.">
@@ -714,7 +717,7 @@
               </details>
             </div>
             <div class="member" data-text="property public static microqrcodegeneratoroptions default { get; } the default configuration, identical to default. ">
-              <h4><span class="kind">property</span> <span class="name">Default</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRCodeGeneratorOptions.cs#L20" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Default</a></h4>
               <pre class="sig"><code>public static MicroQRCodeGeneratorOptions Default { get; }</code></pre>
               <p class="doc">The default configuration, identical to default.</p>
             </div>
@@ -786,7 +789,7 @@
           </div>
         </article>
         <article class="type" id="SkiaSharp.QrCode.MicroQRVersionRange" data-name="skiasharp.qrcode.microqrversionrange" data-text="skiasharp.qrcode.microqrversionrange public readonly struct microqrversionrange : iequatable&lt;microqrversionrange&gt; the micro qr versions a generator may choose from: the smallest one in the range that holds the content is used. the micro qr counterpart of qrcodeversionrange . m1-m4 differ in the modes and ecc levels they offer, not only in capacity, so a range can leave nothing usable for two reasons. no version offering the requested ecc level is a contradiction and throws; none carrying the mode the text needs is a poor fit and returns false, since the text is what picks the mode. constant public const microqrversion maxversion; the highest micro qr version, m4.  constant public const microqrversion minversion; the lowest micro qr version, m1.  constructor public microqrversionrange(microqrversion min, microqrversion max); an inclusive range from min to max .  property public microqrversion max { get; } the highest permitted version (m4 when unbounded above).  property public microqrversion min { get; } the lowest permitted version (m1 when unbounded below).  property public bool isany { get; } whether this range constrains nothing (the default).  property public bool isexact { get; } whether this range pins a single version.  property public static microqrversionrange any { get; } every version, m1 to m4. identical to default.  method public bool contains(microqrversion version); whether version falls inside this range.  method public override string tostring();  method public static microqrversionrange atleast(microqrversion version); version or larger.  method public static microqrversionrange atmost(microqrversion version); version or smaller.  method public static microqrversionrange between(microqrversion min, microqrversion max); an inclusive range from min to max .  method public static microqrversionrange exactly(microqrversion version); exactly version , with no automatic selection.  operator public static microqrversionrange op_implicit(microqrversion version); a single version, as exactly .  operator public static microqrversionrange op_implicit(microqrversion? version); a single version, or any when there is none, so an optional version needs no branch. ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.MicroQRVersionRange" aria-label="Link to SkiaSharp.QrCode.MicroQRVersionRange">#</a><span class="kind">struct</span> <span class="name">MicroQRVersionRange</span></h3>
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.MicroQRVersionRange" aria-label="Link to SkiaSharp.QrCode.MicroQRVersionRange">#</a><span class="kind">struct</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRVersionRange.cs" title="View source file on GitHub" target="_blank" rel="noopener noreferrer">MicroQRVersionRange</a></h3>
           <pre class="sig"><code>public readonly struct MicroQRVersionRange : IEquatable&lt;MicroQRVersionRange&gt;</code></pre>
           <p class="doc">The Micro QR versions a generator may choose from: the smallest one in the range that holds the content is used. The Micro QR counterpart of QRCodeVersionRange .</p>
           <details class="notes" data-text="m1-m4 differ in the modes and ecc levels they offer, not only in capacity, so a range can leave nothing usable for two reasons. no version offering the requested ecc level is a contradiction and throws; none carrying the mode the text needs is a poor fit and returns false, since the text is what picks the mode.">
@@ -805,78 +808,78 @@
               <p class="doc">The lowest Micro QR version, M1.</p>
             </div>
             <div class="member" data-text="constructor public microqrversionrange(microqrversion min, microqrversion max); an inclusive range from min to max . ">
-              <h4><span class="kind">constructor</span> <span class="name">MicroQRVersionRange</span></h4>
+              <h4><span class="kind">constructor</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRVersionRange.cs#L29" title="View source on GitHub" target="_blank" rel="noopener noreferrer">MicroQRVersionRange</a></h4>
               <pre class="sig"><code>public MicroQRVersionRange(MicroQRVersion min, MicroQRVersion max);</code></pre>
               <p class="doc">An inclusive range from min to max .</p>
             </div>
             <div class="member" data-text="property public microqrversion max { get; } the highest permitted version (m4 when unbounded above). ">
-              <h4><span class="kind">property</span> <span class="name">Max</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRVersionRange.cs#L43" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Max</a></h4>
               <pre class="sig"><code>public MicroQRVersion Max { get; }</code></pre>
               <p class="doc">The highest permitted version (M4 when unbounded above).</p>
             </div>
             <div class="member" data-text="property public microqrversion min { get; } the lowest permitted version (m1 when unbounded below). ">
-              <h4><span class="kind">property</span> <span class="name">Min</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRVersionRange.cs#L40" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Min</a></h4>
               <pre class="sig"><code>public MicroQRVersion Min { get; }</code></pre>
               <p class="doc">The lowest permitted version (M1 when unbounded below).</p>
             </div>
             <div class="member" data-text="property public bool isany { get; } whether this range constrains nothing (the default). ">
-              <h4><span class="kind">property</span> <span class="name">IsAny</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRVersionRange.cs#L46" title="View source on GitHub" target="_blank" rel="noopener noreferrer">IsAny</a></h4>
               <pre class="sig"><code>public bool IsAny { get; }</code></pre>
               <p class="doc">Whether this range constrains nothing (the default).</p>
             </div>
             <div class="member" data-text="property public bool isexact { get; } whether this range pins a single version. ">
-              <h4><span class="kind">property</span> <span class="name">IsExact</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRVersionRange.cs#L49" title="View source on GitHub" target="_blank" rel="noopener noreferrer">IsExact</a></h4>
               <pre class="sig"><code>public bool IsExact { get; }</code></pre>
               <p class="doc">Whether this range pins a single version.</p>
             </div>
             <div class="member" data-text="property public static microqrversionrange any { get; } every version, m1 to m4. identical to default. ">
-              <h4><span class="kind">property</span> <span class="name">Any</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRVersionRange.cs#L52" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Any</a></h4>
               <pre class="sig"><code>public static MicroQRVersionRange Any { get; }</code></pre>
               <p class="doc">Every version, M1 to M4. Identical to default.</p>
             </div>
             <div class="member" data-text="method public bool contains(microqrversion version); whether version falls inside this range. ">
-              <h4><span class="kind">method</span> <span class="name">Contains</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRVersionRange.cs#L79" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Contains</a></h4>
               <pre class="sig"><code>public bool Contains(MicroQRVersion version);</code></pre>
               <p class="doc">Whether version falls inside this range.</p>
             </div>
             <div class="member" data-text="method public override string tostring(); ">
-              <h4><span class="kind">method</span> <span class="name">ToString</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRVersionRange.cs#L82" title="View source on GitHub" target="_blank" rel="noopener noreferrer">ToString</a></h4>
               <pre class="sig"><code>public override string ToString();</code></pre>
             </div>
             <div class="member" data-text="method public static microqrversionrange atleast(microqrversion version); version or larger. ">
-              <h4><span class="kind">method</span> <span class="name">AtLeast</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRVersionRange.cs#L60" title="View source on GitHub" target="_blank" rel="noopener noreferrer">AtLeast</a></h4>
               <pre class="sig"><code>public static MicroQRVersionRange AtLeast(MicroQRVersion version);</code></pre>
               <p class="doc">version or larger.</p>
             </div>
             <div class="member" data-text="method public static microqrversionrange atmost(microqrversion version); version or smaller. ">
-              <h4><span class="kind">method</span> <span class="name">AtMost</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRVersionRange.cs#L64" title="View source on GitHub" target="_blank" rel="noopener noreferrer">AtMost</a></h4>
               <pre class="sig"><code>public static MicroQRVersionRange AtMost(MicroQRVersion version);</code></pre>
               <p class="doc">version or smaller.</p>
             </div>
             <div class="member" data-text="method public static microqrversionrange between(microqrversion min, microqrversion max); an inclusive range from min to max . ">
-              <h4><span class="kind">method</span> <span class="name">Between</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRVersionRange.cs#L68" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Between</a></h4>
               <pre class="sig"><code>public static MicroQRVersionRange Between(MicroQRVersion min, MicroQRVersion max);</code></pre>
               <p class="doc">An inclusive range from min to max .</p>
             </div>
             <div class="member" data-text="method public static microqrversionrange exactly(microqrversion version); exactly version , with no automatic selection. ">
-              <h4><span class="kind">method</span> <span class="name">Exactly</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRVersionRange.cs#L56" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Exactly</a></h4>
               <pre class="sig"><code>public static MicroQRVersionRange Exactly(MicroQRVersion version);</code></pre>
               <p class="doc">Exactly version , with no automatic selection.</p>
             </div>
             <div class="member" data-text="operator public static microqrversionrange op_implicit(microqrversion version); a single version, as exactly . ">
-              <h4><span class="kind">operator</span> <span class="name">op_Implicit</span></h4>
+              <h4><span class="kind">operator</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRVersionRange.cs#L72" title="View source on GitHub" target="_blank" rel="noopener noreferrer">op_Implicit</a></h4>
               <pre class="sig"><code>public static MicroQRVersionRange op_Implicit(MicroQRVersion version);</code></pre>
               <p class="doc">A single version, as Exactly .</p>
             </div>
             <div class="member" data-text="operator public static microqrversionrange op_implicit(microqrversion? version); a single version, or any when there is none, so an optional version needs no branch. ">
-              <h4><span class="kind">operator</span> <span class="name">op_Implicit</span></h4>
+              <h4><span class="kind">operator</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/MicroQRVersionRange.cs#L76" title="View source on GitHub" target="_blank" rel="noopener noreferrer">op_Implicit</a></h4>
               <pre class="sig"><code>public static MicroQRVersionRange op_Implicit(MicroQRVersion? version);</code></pre>
               <p class="doc">A single version, or Any when there is none, so an optional version needs no branch.</p>
             </div>
           </div>
         </article>
         <article class="type" id="SkiaSharp.QrCode.ModuleRect" data-name="skiasharp.qrcode.modulerect" data-text="skiasharp.qrcode.modulerect public readonly struct modulerect : iequatable&lt;modulerect&gt; an axis-aligned rectangle of dark modules, in module coordinates. produced by the getmodulerectangles family on qrcodedata , microqrcodedata , and rmqrcodedata . coordinates use the same space as the matrix indexer: one unit is one module, origin at the top-left corner of the symbol including its quiet zone, x growing right and y growing down. the module at column c, row r read via data[r, c] corresponds to the unit rectangle at x = c, y = r. renderers map to pixels by multiplying all four values by the pixel size of one module. no scale or pixel size is baked in, so the same value works for svg path data (viewbox in module units), draw calls, and any other coordinate transform the consumer applies. constructor public modulerect(int x, int y, int width, int height); an axis-aligned rectangle of dark modules, in module coordinates. produced by the getmodulerectangles family on qrcodedata , microqrcodedata , and rmqrcodedata . coordinates use the same space as the matrix indexer: one unit is one module, origin at the top-left corner of the symbol including its quiet zone, x growing right and y growing down. the module at column c, row r read via data[r, c] corresponds to the unit rectangle at x = c, y = r. renderers map to pixels by multiplying all four values by the pixel size of one module. no scale or pixel size is baked in, so the same value works for svg path data (viewbox in module units), draw calls, and any other coordinate transform the consumer applies. property public int height { get; init; } height in modules (always positive).  property public int width { get; init; } width in modules (always positive).  property public int x { get; init; } column of the left edge (0-based, including the quiet zone if present).  property public int y { get; init; } row of the top edge (0-based, including the quiet zone if present). ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.ModuleRect" aria-label="Link to SkiaSharp.QrCode.ModuleRect">#</a><span class="kind">struct</span> <span class="name">ModuleRect</span></h3>
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.ModuleRect" aria-label="Link to SkiaSharp.QrCode.ModuleRect">#</a><span class="kind">struct</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/ModuleRect.cs" title="View source file on GitHub" target="_blank" rel="noopener noreferrer">ModuleRect</a></h3>
           <pre class="sig"><code>public readonly struct ModuleRect : IEquatable&lt;ModuleRect&gt;</code></pre>
           <p class="doc">An axis-aligned rectangle of dark modules, in module coordinates. Produced by the GetModuleRectangles family on QRCodeData , MicroQRCodeData , and RmQRCodeData .</p>
           <details class="notes" data-text="coordinates use the same space as the matrix indexer: one unit is one module, origin at the top-left corner of the symbol including its quiet zone, x growing right and y growing down. the module at column c, row r read via data[r, c] corresponds to the unit rectangle at x = c, y = r. renderers map to pixels by multiplying all four values by the pixel size of one module. no scale or pixel size is baked in, so the same value works for svg path data (viewbox in module units), draw calls, and any other coordinate transform the consumer applies.">
@@ -894,29 +897,29 @@
               </details>
             </div>
             <div class="member" data-text="property public int height { get; init; } height in modules (always positive). ">
-              <h4><span class="kind">property</span> <span class="name">Height</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/ModuleRect.cs#L26" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Height</a></h4>
               <pre class="sig"><code>public int Height { get; init; }</code></pre>
               <p class="doc">Height in modules (always positive).</p>
             </div>
             <div class="member" data-text="property public int width { get; init; } width in modules (always positive). ">
-              <h4><span class="kind">property</span> <span class="name">Width</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/ModuleRect.cs#L26" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Width</a></h4>
               <pre class="sig"><code>public int Width { get; init; }</code></pre>
               <p class="doc">Width in modules (always positive).</p>
             </div>
             <div class="member" data-text="property public int x { get; init; } column of the left edge (0-based, including the quiet zone if present). ">
-              <h4><span class="kind">property</span> <span class="name">X</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/ModuleRect.cs#L26" title="View source on GitHub" target="_blank" rel="noopener noreferrer">X</a></h4>
               <pre class="sig"><code>public int X { get; init; }</code></pre>
               <p class="doc">Column of the left edge (0-based, including the quiet zone if present).</p>
             </div>
             <div class="member" data-text="property public int y { get; init; } row of the top edge (0-based, including the quiet zone if present). ">
-              <h4><span class="kind">property</span> <span class="name">Y</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/ModuleRect.cs#L26" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Y</a></h4>
               <pre class="sig"><code>public int Y { get; init; }</code></pre>
               <p class="doc">Row of the top edge (0-based, including the quiet zone if present).</p>
             </div>
           </div>
         </article>
         <article class="type" id="SkiaSharp.QrCode.QRCodeCalculatedSize" data-name="skiasharp.qrcode.qrcodecalculatedsize" data-text="skiasharp.qrcode.qrcodecalculatedsize public readonly struct qrcodecalculatedsize : iequatable&lt;qrcodecalculatedsize&gt; calculated qr code size information.  constructor public qrcodecalculatedsize(int buffersize, int qrsize, int version); calculated qr code size information.  property public bool isvalid { get; } validates that the calculated size values are within acceptable ranges.  property public int buffersize { get; init; } required buffer size for the qr code matrix data (in bytes). calculated as qrsize × qrsize.  property public int qrsize { get; init; } qr code size in modules per side (including quiet zone if specified)  property public int version { get; init; } qr code version (1-40) determined by data capacity requirements ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeCalculatedSize" aria-label="Link to SkiaSharp.QrCode.QRCodeCalculatedSize">#</a><span class="kind">struct</span> <span class="name">QRCodeCalculatedSize</span></h3>
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeCalculatedSize" aria-label="Link to SkiaSharp.QrCode.QRCodeCalculatedSize">#</a><span class="kind">struct</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeCalculatedSize.cs" title="View source file on GitHub" target="_blank" rel="noopener noreferrer">QRCodeCalculatedSize</a></h3>
           <pre class="sig"><code>public readonly struct QRCodeCalculatedSize : IEquatable&lt;QRCodeCalculatedSize&gt;</code></pre>
           <p class="doc">Calculated QR code size information.</p>
           <div class="members">
@@ -926,29 +929,29 @@
               <p class="doc">Calculated QR code size information.</p>
             </div>
             <div class="member" data-text="property public bool isvalid { get; } validates that the calculated size values are within acceptable ranges. ">
-              <h4><span class="kind">property</span> <span class="name">IsValid</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeCalculatedSize.cs#L14" title="View source on GitHub" target="_blank" rel="noopener noreferrer">IsValid</a></h4>
               <pre class="sig"><code>public bool IsValid { get; }</code></pre>
               <p class="doc">Validates that the calculated size values are within acceptable ranges.</p>
             </div>
             <div class="member" data-text="property public int buffersize { get; init; } required buffer size for the qr code matrix data (in bytes). calculated as qrsize × qrsize. ">
-              <h4><span class="kind">property</span> <span class="name">BufferSize</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeCalculatedSize.cs#L9" title="View source on GitHub" target="_blank" rel="noopener noreferrer">BufferSize</a></h4>
               <pre class="sig"><code>public int BufferSize { get; init; }</code></pre>
               <p class="doc">Required buffer size for the QR code matrix data (in bytes). Calculated as QrSize × QrSize.</p>
             </div>
             <div class="member" data-text="property public int qrsize { get; init; } qr code size in modules per side (including quiet zone if specified) ">
-              <h4><span class="kind">property</span> <span class="name">QrSize</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeCalculatedSize.cs#L9" title="View source on GitHub" target="_blank" rel="noopener noreferrer">QrSize</a></h4>
               <pre class="sig"><code>public int QrSize { get; init; }</code></pre>
               <p class="doc">QR code size in modules per side (including quiet zone if specified)</p>
             </div>
             <div class="member" data-text="property public int version { get; init; } qr code version (1-40) determined by data capacity requirements ">
-              <h4><span class="kind">property</span> <span class="name">Version</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeCalculatedSize.cs#L9" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Version</a></h4>
               <pre class="sig"><code>public int Version { get; init; }</code></pre>
               <p class="doc">QR code version (1-40) determined by data capacity requirements</p>
             </div>
           </div>
         </article>
         <article class="type" id="SkiaSharp.QrCode.QRCodeData" data-name="skiasharp.qrcode.qrcodedata" data-text="skiasharp.qrcode.qrcodedata public class qrcodedata represents qr code data as a 2d boolean matrix. qr code structure: - version: 1-40 (determines size: 21×21 to 177×177) - module matrix: 2d array of boolean values (dark/light) - serialization format: &quot;qrr&quot; header + size + bit-packed data constructor public qrcodedata(readonlyspan&lt;byte&gt; rawdataspan, int quietzonesize); initializes a new instance of the qrcodedata class from serialized raw data. this constructor deserializes qr code data that was previously serialized using getrawdata . the raw data contains only the core qr code modules (excluding quiet zone). data format: &quot;qrr&quot; header (3 bytes) + base size (1 byte) + bit-packed module data the quiet zone (white border) can be added during deserialization by specifying the quietzonesize parameter. this overload is useful for high-performance scenarios where you want to deserialize from existing memory buffers (e.g., memory , arraysegment , or stack-allocated arrays) without allocating a new byte array. constructor public qrcodedata(byte[] rawdata, int quietzonesize); initializes a new instance of the qrcodedata class from serialized raw data. this constructor deserializes qr code data that was previously serialized using getrawdata . the raw data contains only the core qr code modules (excluding quiet zone). data format: &quot;qrr&quot; header (3 bytes) + base size (1 byte) + bit-packed module data the quiet zone (white border) can be added during deserialization by specifying the quietzonesize parameter. constructor public qrcodedata(int version, int quietzonesize); initializes with the specified version.  indexer public bool this[int row, int col] { get; } gets or sets the module state at the specified position. quiet zone positions always read false (the quiet zone is light by definition and is not stored). the internal setter only accepts core positions, quiet zone modules cannot be modified. property public int size { get; } gets the size of the qr code matrix (modules per side).  property public int version { get; } get the qr code version (1-40)  method public modulerect[] getmodulerectangles(); gets the dark modules as merged rectangles in module coordinates, for rendering with any graphics api without skiasharp (svg path data, draw calls, vector output). coordinates use the same space as the indexer (this[row, col]): one unit is one module, origin at the top-left including the quiet zone, x is the column and y is the row. consumers scale by the pixel size of one module; size gives the total extent in modules. three properties are contractual: rectangles never overlap, cover only dark modules, and cover every dark module. the decomposition shape and ordering are unspecified and may change between versions (currently maximal horizontal runs in row-major order, the same merge the built-in renderer draws). method public bool isfinderpattern(int row, int col); checks if the specified module position (excluding quiet zone) is part of a finder pattern.  method public bool trygetmodulerectangles(span&lt;modulerect&gt; destination, out int written); writes the dark modules as merged rectangles into a caller-provided buffer. same contract as getmodulerectangles without allocations.  method public byte[] getrawdata(); serializes the qr code data to a byte array. the serialized data contains only the core qr code modules (excluding quiet zone). the quiet zone can be added when deserializing via the #ctor constructor. format: &quot;qrr&quot; header (3 bytes) + base size (1 byte) + bit-packed module data method public int getfinderpatternindex(int row, int col); gets the finder pattern index for the specified module position (excluding quiet zone).  method public int getmodulerectanglesmaxcount(); gets an upper bound on the number of rectangles getmodulerectangles can return, suitable for sizing a pooled buffer for trygetmodulerectangles . o(1), no matrix scan.  method public int getrawdata(ibufferwriter&lt;byte&gt; writer); writes the serialized qr code data to the specified buffer writer. this method writes only the core qr mode modules (excluding quiet zone). the quiet zone can be added when deserializing via the #ctor constructor. format: &quot;qrr&quot; header (3 bytes) + base size (1 byte) + bit-packed module data this overload is useful for high-performance scenarios where memory allocations need to be minimized, such as response writing or streaming. method public int getrawdatasize(); calculates the required buffer size for serialization. ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeData" aria-label="Link to SkiaSharp.QrCode.QRCodeData">#</a><span class="kind">class</span> <span class="name">QRCodeData</span></h3>
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeData" aria-label="Link to SkiaSharp.QrCode.QRCodeData">#</a><span class="kind">class</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeData.cs" title="View source file on GitHub" target="_blank" rel="noopener noreferrer">QRCodeData</a></h3>
           <pre class="sig"><code>public class QRCodeData</code></pre>
           <p class="doc">Represents QR code data as a 2D boolean matrix.</p>
           <details class="notes" data-text="qr code structure: - version: 1-40 (determines size: 21×21 to 177×177) - module matrix: 2d array of boolean values (dark/light) - serialization format: &quot;qrr&quot; header + size + bit-packed data">
@@ -957,7 +960,7 @@
           </details>
           <div class="members">
             <div class="member" data-text="constructor public qrcodedata(readonlyspan&lt;byte&gt; rawdataspan, int quietzonesize); initializes a new instance of the qrcodedata class from serialized raw data. this constructor deserializes qr code data that was previously serialized using getrawdata . the raw data contains only the core qr code modules (excluding quiet zone). data format: &quot;qrr&quot; header (3 bytes) + base size (1 byte) + bit-packed module data the quiet zone (white border) can be added during deserialization by specifying the quietzonesize parameter. this overload is useful for high-performance scenarios where you want to deserialize from existing memory buffers (e.g., memory , arraysegment , or stack-allocated arrays) without allocating a new byte array.">
-              <h4><span class="kind">constructor</span> <span class="name">QRCodeData</span></h4>
+              <h4><span class="kind">constructor</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeData.cs#L292" title="View source on GitHub" target="_blank" rel="noopener noreferrer">QRCodeData</a></h4>
               <pre class="sig"><code>public QRCodeData(ReadOnlySpan&lt;byte&gt; rawDataSpan, int quietZoneSize);</code></pre>
               <p class="doc">Initializes a new instance of the QRCodeData class from serialized raw data.</p>
               <details class="notes" data-text="this constructor deserializes qr code data that was previously serialized using getrawdata . the raw data contains only the core qr code modules (excluding quiet zone). data format: &quot;qrr&quot; header (3 bytes) + base size (1 byte) + bit-packed module data the quiet zone (white border) can be added during deserialization by specifying the quietzonesize parameter. this overload is useful for high-performance scenarios where you want to deserialize from existing memory buffers (e.g., memory , arraysegment , or stack-allocated arrays) without allocating a new byte array.">
@@ -966,7 +969,7 @@
               </details>
             </div>
             <div class="member" data-text="constructor public qrcodedata(byte[] rawdata, int quietzonesize); initializes a new instance of the qrcodedata class from serialized raw data. this constructor deserializes qr code data that was previously serialized using getrawdata . the raw data contains only the core qr code modules (excluding quiet zone). data format: &quot;qrr&quot; header (3 bytes) + base size (1 byte) + bit-packed module data the quiet zone (white border) can be added during deserialization by specifying the quietzonesize parameter.">
-              <h4><span class="kind">constructor</span> <span class="name">QRCodeData</span></h4>
+              <h4><span class="kind">constructor</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeData.cs#L260" title="View source on GitHub" target="_blank" rel="noopener noreferrer">QRCodeData</a></h4>
               <pre class="sig"><code>public QRCodeData(byte[] rawData, int quietZoneSize);</code></pre>
               <p class="doc">Initializes a new instance of the QRCodeData class from serialized raw data.</p>
               <details class="notes" data-text="this constructor deserializes qr code data that was previously serialized using getrawdata . the raw data contains only the core qr code modules (excluding quiet zone). data format: &quot;qrr&quot; header (3 bytes) + base size (1 byte) + bit-packed module data the quiet zone (white border) can be added during deserialization by specifying the quietzonesize parameter.">
@@ -975,12 +978,12 @@
               </details>
             </div>
             <div class="member" data-text="constructor public qrcodedata(int version, int quietzonesize); initializes with the specified version. ">
-              <h4><span class="kind">constructor</span> <span class="name">QRCodeData</span></h4>
+              <h4><span class="kind">constructor</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeData.cs#L228" title="View source on GitHub" target="_blank" rel="noopener noreferrer">QRCodeData</a></h4>
               <pre class="sig"><code>public QRCodeData(int version, int quietZoneSize);</code></pre>
               <p class="doc">Initializes with the specified version.</p>
             </div>
             <div class="member" data-text="indexer public bool this[int row, int col] { get; } gets or sets the module state at the specified position. quiet zone positions always read false (the quiet zone is light by definition and is not stored). the internal setter only accepts core positions, quiet zone modules cannot be modified.">
-              <h4><span class="kind">indexer</span> <span class="name">this[int row, int col]</span></h4>
+              <h4><span class="kind">indexer</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeData.cs#L185" title="View source on GitHub" target="_blank" rel="noopener noreferrer">this[int row, int col]</a></h4>
               <pre class="sig"><code>public bool this[int row, int col] { get; }</code></pre>
               <p class="doc">Gets or sets the module state at the specified position.</p>
               <details class="notes" data-text="quiet zone positions always read false (the quiet zone is light by definition and is not stored). the internal setter only accepts core positions, quiet zone modules cannot be modified.">
@@ -989,17 +992,17 @@
               </details>
             </div>
             <div class="member" data-text="property public int size { get; } gets the size of the qr code matrix (modules per side). ">
-              <h4><span class="kind">property</span> <span class="name">Size</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeData.cs#L163" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Size</a></h4>
               <pre class="sig"><code>public int Size { get; }</code></pre>
               <p class="doc">Gets the size of the QR code matrix (modules per side).</p>
             </div>
             <div class="member" data-text="property public int version { get; } get the qr code version (1-40) ">
-              <h4><span class="kind">property</span> <span class="name">Version</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeData.cs#L168" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Version</a></h4>
               <pre class="sig"><code>public int Version { get; }</code></pre>
               <p class="doc">Get the QR code version (1-40)</p>
             </div>
             <div class="member" data-text="method public modulerect[] getmodulerectangles(); gets the dark modules as merged rectangles in module coordinates, for rendering with any graphics api without skiasharp (svg path data, draw calls, vector output). coordinates use the same space as the indexer (this[row, col]): one unit is one module, origin at the top-left including the quiet zone, x is the column and y is the row. consumers scale by the pixel size of one module; size gives the total extent in modules. three properties are contractual: rectangles never overlap, cover only dark modules, and cover every dark module. the decomposition shape and ordering are unspecified and may change between versions (currently maximal horizontal runs in row-major order, the same merge the built-in renderer draws).">
-              <h4><span class="kind">method</span> <span class="name">GetModuleRectangles</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeData.cs#L485" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetModuleRectangles</a></h4>
               <pre class="sig"><code>public ModuleRect[] GetModuleRectangles();</code></pre>
               <p class="doc">Gets the dark modules as merged rectangles in module coordinates, for rendering with any graphics API without SkiaSharp (SVG path data, draw calls, vector output).</p>
               <details class="notes" data-text="coordinates use the same space as the indexer (this[row, col]): one unit is one module, origin at the top-left including the quiet zone, x is the column and y is the row. consumers scale by the pixel size of one module; size gives the total extent in modules. three properties are contractual: rectangles never overlap, cover only dark modules, and cover every dark module. the decomposition shape and ordering are unspecified and may change between versions (currently maximal horizontal runs in row-major order, the same merge the built-in renderer draws).">
@@ -1008,17 +1011,17 @@
               </details>
             </div>
             <div class="member" data-text="method public bool isfinderpattern(int row, int col); checks if the specified module position (excluding quiet zone) is part of a finder pattern. ">
-              <h4><span class="kind">method</span> <span class="name">IsFinderPattern</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeData.cs#L416" title="View source on GitHub" target="_blank" rel="noopener noreferrer">IsFinderPattern</a></h4>
               <pre class="sig"><code>public bool IsFinderPattern(int row, int col);</code></pre>
               <p class="doc">Checks if the specified module position (excluding quiet zone) is part of a finder pattern.</p>
             </div>
             <div class="member" data-text="method public bool trygetmodulerectangles(span&lt;modulerect&gt; destination, out int written); writes the dark modules as merged rectangles into a caller-provided buffer. same contract as getmodulerectangles without allocations. ">
-              <h4><span class="kind">method</span> <span class="name">TryGetModuleRectangles</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeData.cs#L498" title="View source on GitHub" target="_blank" rel="noopener noreferrer">TryGetModuleRectangles</a></h4>
               <pre class="sig"><code>public bool TryGetModuleRectangles(Span&lt;ModuleRect&gt; destination, out int written);</code></pre>
               <p class="doc">Writes the dark modules as merged rectangles into a caller-provided buffer. Same contract as GetModuleRectangles without allocations.</p>
             </div>
             <div class="member" data-text="method public byte[] getrawdata(); serializes the qr code data to a byte array. the serialized data contains only the core qr code modules (excluding quiet zone). the quiet zone can be added when deserializing via the #ctor constructor. format: &quot;qrr&quot; header (3 bytes) + base size (1 byte) + bit-packed module data">
-              <h4><span class="kind">method</span> <span class="name">GetRawData</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeData.cs#L363" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetRawData</a></h4>
               <pre class="sig"><code>public byte[] GetRawData();</code></pre>
               <p class="doc">Serializes the QR code data to a byte array.</p>
               <details class="notes" data-text="the serialized data contains only the core qr code modules (excluding quiet zone). the quiet zone can be added when deserializing via the #ctor constructor. format: &quot;qrr&quot; header (3 bytes) + base size (1 byte) + bit-packed module data">
@@ -1027,17 +1030,17 @@
               </details>
             </div>
             <div class="member" data-text="method public int getfinderpatternindex(int row, int col); gets the finder pattern index for the specified module position (excluding quiet zone). ">
-              <h4><span class="kind">method</span> <span class="name">GetFinderPatternIndex</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeData.cs#L443" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetFinderPatternIndex</a></h4>
               <pre class="sig"><code>public int GetFinderPatternIndex(int row, int col);</code></pre>
               <p class="doc">Gets the finder pattern index for the specified module position (excluding quiet zone).</p>
             </div>
             <div class="member" data-text="method public int getmodulerectanglesmaxcount(); gets an upper bound on the number of rectangles getmodulerectangles can return, suitable for sizing a pooled buffer for trygetmodulerectangles . o(1), no matrix scan. ">
-              <h4><span class="kind">method</span> <span class="name">GetModuleRectanglesMaxCount</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeData.cs#L463" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetModuleRectanglesMaxCount</a></h4>
               <pre class="sig"><code>public int GetModuleRectanglesMaxCount();</code></pre>
               <p class="doc">Gets an upper bound on the number of rectangles GetModuleRectangles can return, suitable for sizing a pooled buffer for TryGetModuleRectangles . O(1), no matrix scan.</p>
             </div>
             <div class="member" data-text="method public int getrawdata(ibufferwriter&lt;byte&gt; writer); writes the serialized qr code data to the specified buffer writer. this method writes only the core qr mode modules (excluding quiet zone). the quiet zone can be added when deserializing via the #ctor constructor. format: &quot;qrr&quot; header (3 bytes) + base size (1 byte) + bit-packed module data this overload is useful for high-performance scenarios where memory allocations need to be minimized, such as response writing or streaming.">
-              <h4><span class="kind">method</span> <span class="name">GetRawData</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeData.cs#L387" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetRawData</a></h4>
               <pre class="sig"><code>public int GetRawData(IBufferWriter&lt;byte&gt; writer);</code></pre>
               <p class="doc">Writes the serialized QR code data to the specified buffer writer.</p>
               <details class="notes" data-text="this method writes only the core qr mode modules (excluding quiet zone). the quiet zone can be added when deserializing via the #ctor constructor. format: &quot;qrr&quot; header (3 bytes) + base size (1 byte) + bit-packed module data this overload is useful for high-performance scenarios where memory allocations need to be minimized, such as response writing or streaming.">
@@ -1046,39 +1049,39 @@
               </details>
             </div>
             <div class="member" data-text="method public int getrawdatasize(); calculates the required buffer size for serialization. ">
-              <h4><span class="kind">method</span> <span class="name">GetRawDataSize</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeData.cs#L337" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetRawDataSize</a></h4>
               <pre class="sig"><code>public int GetRawDataSize();</code></pre>
               <p class="doc">Calculates the required buffer size for serialization.</p>
             </div>
           </div>
         </article>
         <article class="type" id="SkiaSharp.QrCode.QRCodeDecodeInfo" data-name="skiasharp.qrcode.qrcodedecodeinfo" data-text="skiasharp.qrcode.qrcodedecodeinfo public readonly struct qrcodedecodeinfo diagnostic information produced by a qr code decode attempt.  property public ecclevel ecclevel { get; } error correction level read from the format information.  property public qrcodedecodestatus status { get; } decode result status. success when decoding succeeded.  property public int errorscorrected { get; } total number of codeword errors corrected by reed-solomon decoding.  property public int maskpattern { get; } mask pattern (0-7) read from the format information, or -1 when unknown.  property public int version { get; } qr code version (1-40), or 0 when the matrix was invalid. ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeDecodeInfo" aria-label="Link to SkiaSharp.QrCode.QRCodeDecodeInfo">#</a><span class="kind">struct</span> <span class="name">QRCodeDecodeInfo</span></h3>
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeDecodeInfo" aria-label="Link to SkiaSharp.QrCode.QRCodeDecodeInfo">#</a><span class="kind">struct</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeDecodeInfo.cs" title="View source file on GitHub" target="_blank" rel="noopener noreferrer">QRCodeDecodeInfo</a></h3>
           <pre class="sig"><code>public readonly struct QRCodeDecodeInfo</code></pre>
           <p class="doc">Diagnostic information produced by a QR code decode attempt.</p>
           <div class="members">
             <div class="member" data-text="property public ecclevel ecclevel { get; } error correction level read from the format information. ">
-              <h4><span class="kind">property</span> <span class="name">EccLevel</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeDecodeInfo.cs#L74" title="View source on GitHub" target="_blank" rel="noopener noreferrer">EccLevel</a></h4>
               <pre class="sig"><code>public ECCLevel EccLevel { get; }</code></pre>
               <p class="doc">Error correction level read from the format information.</p>
             </div>
             <div class="member" data-text="property public qrcodedecodestatus status { get; } decode result status. success when decoding succeeded. ">
-              <h4><span class="kind">property</span> <span class="name">Status</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeDecodeInfo.cs#L68" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Status</a></h4>
               <pre class="sig"><code>public QRCodeDecodeStatus Status { get; }</code></pre>
               <p class="doc">Decode result status. Success when decoding succeeded.</p>
             </div>
             <div class="member" data-text="property public int errorscorrected { get; } total number of codeword errors corrected by reed-solomon decoding. ">
-              <h4><span class="kind">property</span> <span class="name">ErrorsCorrected</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeDecodeInfo.cs#L80" title="View source on GitHub" target="_blank" rel="noopener noreferrer">ErrorsCorrected</a></h4>
               <pre class="sig"><code>public int ErrorsCorrected { get; }</code></pre>
               <p class="doc">Total number of codeword errors corrected by Reed-Solomon decoding.</p>
             </div>
             <div class="member" data-text="property public int maskpattern { get; } mask pattern (0-7) read from the format information, or -1 when unknown. ">
-              <h4><span class="kind">property</span> <span class="name">MaskPattern</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeDecodeInfo.cs#L77" title="View source on GitHub" target="_blank" rel="noopener noreferrer">MaskPattern</a></h4>
               <pre class="sig"><code>public int MaskPattern { get; }</code></pre>
               <p class="doc">Mask pattern (0-7) read from the format information, or -1 when unknown.</p>
             </div>
             <div class="member" data-text="property public int version { get; } qr code version (1-40), or 0 when the matrix was invalid. ">
-              <h4><span class="kind">property</span> <span class="name">Version</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeDecodeInfo.cs#L71" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Version</a></h4>
               <pre class="sig"><code>public int Version { get; }</code></pre>
               <p class="doc">QR code version (1-40), or 0 when the matrix was invalid.</p>
             </div>
@@ -1132,7 +1135,7 @@
           </div>
         </article>
         <article class="type" id="SkiaSharp.QrCode.QRCodeDecoder" data-name="skiasharp.qrcode.qrcodedecoder" data-text="skiasharp.qrcode.qrcodedecoder public static class qrcodedecoder qr code decoder based on iso/iec 18004 standard. decodes qr module matrices back into text, including reed-solomon error correction. supported content: numeric, alphanumeric and byte mode segments (iso-8859-1 and utf-8, with or without eci headers), the full version range 1-40 and all ecc levels. kanji mode is decoded as jis x 0208; the generator never emits it, so kanji is a read-only mode here. a kanji cell outside the jis x 0208 repertoire (most visibly the nec row 13 characters cp932 adds, such as circled digits) fails the whole symbol with unmappedcharacter rather than substituting a replacement character; that status is distinct from unsupportedcontent so a caller can tell &quot;a cp932 reader would read this&quot; from &quot;this uses a feature we do not implement&quot;. fnc1 and structured append are the latter. byte segments without an eci header have no declared charset. the decoder uses utf-8 when the payload is valid utf-8 (or carries a bom) and iso-8859-1 otherwise. method public static bool trydecode(qrcodedata data, out string text); decodes the text content from qr code data.  method public static bool trydecode(qrcodedata data, out string text, out qrcodedecodeinfo info); decodes the text content from qr code data, with diagnostic information.  method public static bool trydecode(readonlyspan&lt;byte&gt; modules, int size, span&lt;char&gt; destination, out int charswritten, out qrcodedecodeinfo info); decodes the text content from a module matrix into a caller-provided buffer without per-call heap allocation.  method public static bool trydecode(readonlyspan&lt;byte&gt; modules, int size, out string text, out qrcodedecodeinfo info); decodes the text content from a module matrix.  method public static bool trydecode(skbitmap bitmap, out string text); detects and decodes a qr code from a bitmap image. tier-1/2 image support: clean, well-lit images such as screenshots, rendered qr codes and scans, including arbitrary rotation, mirroring, reflectance reversal (light-on-dark) and mild perspective distortion. photos with strong perspective distortion, uneven lighting or blur are out of scope — use a computer-vision grade reader (e.g. zxing.net) for those. method public static bool trydecode(skbitmap bitmap, out string text, out qrcodedecodeinfo info); detects and decodes a qr code from a bitmap image, with diagnostic information. tier-1/2 image support: clean, well-lit images such as screenshots, rendered qr codes and scans, including arbitrary rotation, mirroring, reflectance reversal (light-on-dark) and mild perspective distortion. photos with strong perspective distortion, uneven lighting or blur are out of scope — use a computer-vision grade reader (e.g. zxing.net) for those. method public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, span&lt;char&gt; destination, out int charswritten, out qrcodedecodeinfo info); detects and decodes a qr code from grayscale image pixels into a caller-provided buffer without per-call heap allocation.  method public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, out string text, out qrcodedecodeinfo info); detects and decodes a qr code from grayscale image pixels.  method public static int getmaxdecodedlength(int version); calculates the maximum possible decoded character count for a qr code version, across all ecc levels and encoding modes. use to size the destination buffer for the allocation-free trydecode overload. ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeDecoder" aria-label="Link to SkiaSharp.QrCode.QRCodeDecoder">#</a><span class="kind">class</span> <span class="name">QRCodeDecoder</span></h3>
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeDecoder" aria-label="Link to SkiaSharp.QrCode.QRCodeDecoder">#</a><span class="kind">class</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeDecoder.cs" title="View source file on GitHub" target="_blank" rel="noopener noreferrer">QRCodeDecoder</a></h3>
           <pre class="sig"><code>public static class QRCodeDecoder</code></pre>
           <p class="doc">QR code decoder based on ISO/IEC 18004 standard. Decodes QR module matrices back into text, including Reed-Solomon error correction.</p>
           <details class="notes" data-text="supported content: numeric, alphanumeric and byte mode segments (iso-8859-1 and utf-8, with or without eci headers), the full version range 1-40 and all ecc levels. kanji mode is decoded as jis x 0208; the generator never emits it, so kanji is a read-only mode here. a kanji cell outside the jis x 0208 repertoire (most visibly the nec row 13 characters cp932 adds, such as circled digits) fails the whole symbol with unmappedcharacter rather than substituting a replacement character; that status is distinct from unsupportedcontent so a caller can tell &quot;a cp932 reader would read this&quot; from &quot;this uses a feature we do not implement&quot;. fnc1 and structured append are the latter. byte segments without an eci header have no declared charset. the decoder uses utf-8 when the payload is valid utf-8 (or carries a bom) and iso-8859-1 otherwise.">
@@ -1141,27 +1144,27 @@
           </details>
           <div class="members">
             <div class="member" data-text="method public static bool trydecode(qrcodedata data, out string text); decodes the text content from qr code data. ">
-              <h4><span class="kind">method</span> <span class="name">TryDecode</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeDecoder.cs#L39" title="View source on GitHub" target="_blank" rel="noopener noreferrer">TryDecode</a></h4>
               <pre class="sig"><code>public static bool TryDecode(QRCodeData data, out string text);</code></pre>
               <p class="doc">Decodes the text content from QR code data.</p>
             </div>
             <div class="member" data-text="method public static bool trydecode(qrcodedata data, out string text, out qrcodedecodeinfo info); decodes the text content from qr code data, with diagnostic information. ">
-              <h4><span class="kind">method</span> <span class="name">TryDecode</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeDecoder.cs#L50" title="View source on GitHub" target="_blank" rel="noopener noreferrer">TryDecode</a></h4>
               <pre class="sig"><code>public static bool TryDecode(QRCodeData data, out string text, out QRCodeDecodeInfo info);</code></pre>
               <p class="doc">Decodes the text content from QR code data, with diagnostic information.</p>
             </div>
             <div class="member" data-text="method public static bool trydecode(readonlyspan&lt;byte&gt; modules, int size, span&lt;char&gt; destination, out int charswritten, out qrcodedecodeinfo info); decodes the text content from a module matrix into a caller-provided buffer without per-call heap allocation. ">
-              <h4><span class="kind">method</span> <span class="name">TryDecode</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeDecoder.cs#L125" title="View source on GitHub" target="_blank" rel="noopener noreferrer">TryDecode</a></h4>
               <pre class="sig"><code>public static bool TryDecode(ReadOnlySpan&lt;byte&gt; modules, int size, Span&lt;char&gt; destination, out int charsWritten, out QRCodeDecodeInfo info);</code></pre>
               <p class="doc">Decodes the text content from a module matrix into a caller-provided buffer without per-call heap allocation.</p>
             </div>
             <div class="member" data-text="method public static bool trydecode(readonlyspan&lt;byte&gt; modules, int size, out string text, out qrcodedecodeinfo info); decodes the text content from a module matrix. ">
-              <h4><span class="kind">method</span> <span class="name">TryDecode</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeDecoder.cs#L82" title="View source on GitHub" target="_blank" rel="noopener noreferrer">TryDecode</a></h4>
               <pre class="sig"><code>public static bool TryDecode(ReadOnlySpan&lt;byte&gt; modules, int size, out string text, out QRCodeDecodeInfo info);</code></pre>
               <p class="doc">Decodes the text content from a module matrix.</p>
             </div>
             <div class="member" data-text="method public static bool trydecode(skbitmap bitmap, out string text); detects and decodes a qr code from a bitmap image. tier-1/2 image support: clean, well-lit images such as screenshots, rendered qr codes and scans, including arbitrary rotation, mirroring, reflectance reversal (light-on-dark) and mild perspective distortion. photos with strong perspective distortion, uneven lighting or blur are out of scope — use a computer-vision grade reader (e.g. zxing.net) for those.">
-              <h4><span class="kind">method</span> <span class="name">TryDecode</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeDecoder.cs#L167" title="View source on GitHub" target="_blank" rel="noopener noreferrer">TryDecode</a></h4>
               <pre class="sig"><code>public static bool TryDecode(SKBitmap bitmap, out string text);</code></pre>
               <p class="doc">Detects and decodes a QR code from a bitmap image.</p>
               <details class="notes" data-text="tier-1/2 image support: clean, well-lit images such as screenshots, rendered qr codes and scans, including arbitrary rotation, mirroring, reflectance reversal (light-on-dark) and mild perspective distortion. photos with strong perspective distortion, uneven lighting or blur are out of scope — use a computer-vision grade reader (e.g. zxing.net) for those.">
@@ -1170,7 +1173,7 @@
               </details>
             </div>
             <div class="member" data-text="method public static bool trydecode(skbitmap bitmap, out string text, out qrcodedecodeinfo info); detects and decodes a qr code from a bitmap image, with diagnostic information. tier-1/2 image support: clean, well-lit images such as screenshots, rendered qr codes and scans, including arbitrary rotation, mirroring, reflectance reversal (light-on-dark) and mild perspective distortion. photos with strong perspective distortion, uneven lighting or blur are out of scope — use a computer-vision grade reader (e.g. zxing.net) for those.">
-              <h4><span class="kind">method</span> <span class="name">TryDecode</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeDecoder.cs#L184" title="View source on GitHub" target="_blank" rel="noopener noreferrer">TryDecode</a></h4>
               <pre class="sig"><code>public static bool TryDecode(SKBitmap bitmap, out string text, out QRCodeDecodeInfo info);</code></pre>
               <p class="doc">Detects and decodes a QR code from a bitmap image, with diagnostic information.</p>
               <details class="notes" data-text="tier-1/2 image support: clean, well-lit images such as screenshots, rendered qr codes and scans, including arbitrary rotation, mirroring, reflectance reversal (light-on-dark) and mild perspective distortion. photos with strong perspective distortion, uneven lighting or blur are out of scope — use a computer-vision grade reader (e.g. zxing.net) for those.">
@@ -1179,24 +1182,24 @@
               </details>
             </div>
             <div class="member" data-text="method public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, span&lt;char&gt; destination, out int charswritten, out qrcodedecodeinfo info); detects and decodes a qr code from grayscale image pixels into a caller-provided buffer without per-call heap allocation. ">
-              <h4><span class="kind">method</span> <span class="name">TryDecodeImage</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeDecoder.cs#L253" title="View source on GitHub" target="_blank" rel="noopener noreferrer">TryDecodeImage</a></h4>
               <pre class="sig"><code>public static bool TryDecodeImage(ReadOnlySpan&lt;byte&gt; luminance, int width, int height, Span&lt;char&gt; destination, out int charsWritten, out QRCodeDecodeInfo info);</code></pre>
               <p class="doc">Detects and decodes a QR code from grayscale image pixels into a caller-provided buffer without per-call heap allocation.</p>
             </div>
             <div class="member" data-text="method public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, out string text, out qrcodedecodeinfo info); detects and decodes a qr code from grayscale image pixels. ">
-              <h4><span class="kind">method</span> <span class="name">TryDecodeImage</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeDecoder.cs#L221" title="View source on GitHub" target="_blank" rel="noopener noreferrer">TryDecodeImage</a></h4>
               <pre class="sig"><code>public static bool TryDecodeImage(ReadOnlySpan&lt;byte&gt; luminance, int width, int height, out string text, out QRCodeDecodeInfo info);</code></pre>
               <p class="doc">Detects and decodes a QR code from grayscale image pixels.</p>
             </div>
             <div class="member" data-text="method public static int getmaxdecodedlength(int version); calculates the maximum possible decoded character count for a qr code version, across all ecc levels and encoding modes. use to size the destination buffer for the allocation-free trydecode overload. ">
-              <h4><span class="kind">method</span> <span class="name">GetMaxDecodedLength</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeDecoder.cs#L269" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetMaxDecodedLength</a></h4>
               <pre class="sig"><code>public static int GetMaxDecodedLength(int version);</code></pre>
               <p class="doc">Calculates the maximum possible decoded character count for a QR code version, across all ECC levels and encoding modes. Use to size the destination buffer for the allocation-free TryDecode overload.</p>
             </div>
           </div>
         </article>
         <article class="type" id="SkiaSharp.QrCode.QRCodeExtensions" data-name="skiasharp.qrcode.qrcodeextensions" data-text="skiasharp.qrcode.qrcodeextensions public static class qrcodeextensions extension methods that render a qr, micro qr or rmqr symbol onto an skcanvas you already have, instead of producing an image file. each method clears the whole canvas before drawing, so anything already on it is lost. to place a symbol inside a larger drawing, wrap the call in save and cliprect , or call qrcoderenderer directly, which draws only the symbol. method public static void render(skcanvas canvas, microqrcodedata data, skrect area, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); renders a micro qr code on the canvas with custom colors. micro qr does not offer the standard qr icon overlay or custom finder pattern shape options (single finder pattern, no error-correction headroom for overlays). method public static void render(skcanvas canvas, microqrcodedata data, int width, int height, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); renders a micro qr code on the canvas with default colors. micro qr does not offer the standard qr icon overlay or custom finder pattern shape options (single finder pattern, no error-correction headroom for overlays). method public static void render(skcanvas canvas, qrcodedata data, skrect area, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, icondata? icondata = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null, finderpatternshape? finderpatternshape = null); renders a qr code on the canvas with custom colors.  method public static void render(skcanvas canvas, qrcodedata data, int width, int height, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, icondata? icondata = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null, finderpatternshape? finderpatternshape = null); renders a qr code on the canvas with default colors.  method public static void render(skcanvas canvas, rmqrcodedata data, skrect area, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); renders an rmqr code on the canvas with custom colors. the rectangular symbol (quiet zone included) is drawn with a uniform module scale and centered in the area (letterbox); the whole area receives the background color. rmqr offers no icon overlay or finder styling options. method public static void render(skcanvas canvas, rmqrcodedata data, int width, int height, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); renders an rmqr code on the canvas with default colors. the rectangular symbol (quiet zone included) is drawn with a uniform module scale and centered in the area (letterbox); the whole area receives the background color. rmqr offers no icon overlay or finder styling options.">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeExtensions" aria-label="Link to SkiaSharp.QrCode.QRCodeExtensions">#</a><span class="kind">class</span> <span class="name">QRCodeExtensions</span></h3>
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeExtensions" aria-label="Link to SkiaSharp.QrCode.QRCodeExtensions">#</a><span class="kind">class</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeExtensions.cs" title="View source file on GitHub" target="_blank" rel="noopener noreferrer">QRCodeExtensions</a></h3>
           <pre class="sig"><code>public static class QRCodeExtensions</code></pre>
           <p class="doc">Extension methods that render a QR, Micro QR or rMQR symbol onto an SKCanvas you already have, instead of producing an image file.</p>
           <details class="notes" data-text="each method clears the whole canvas before drawing, so anything already on it is lost. to place a symbol inside a larger drawing, wrap the call in save and cliprect , or call qrcoderenderer directly, which draws only the symbol.">
@@ -1205,7 +1208,7 @@
           </details>
           <div class="members">
             <div class="member" data-text="method public static void render(skcanvas canvas, microqrcodedata data, skrect area, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); renders a micro qr code on the canvas with custom colors. micro qr does not offer the standard qr icon overlay or custom finder pattern shape options (single finder pattern, no error-correction headroom for overlays).">
-              <h4><span class="kind">method</span> <span class="name">Render</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeExtensions.cs#L140" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Render</a></h4>
               <pre class="sig"><code>public static void Render(SKCanvas canvas, MicroQRCodeData data, SKRect area, SKColor? clearColor = null, SKColor? codeColor = null, SKColor? backgroundColor = null, ModuleShape? moduleShape = null, float moduleSizePercent = 1, GradientOptions? gradientOptions = null);</code></pre>
               <p class="doc">Renders a Micro QR code on the canvas with custom colors.</p>
               <details class="notes" data-text="micro qr does not offer the standard qr icon overlay or custom finder pattern shape options (single finder pattern, no error-correction headroom for overlays).">
@@ -1214,7 +1217,7 @@
               </details>
             </div>
             <div class="member" data-text="method public static void render(skcanvas canvas, microqrcodedata data, int width, int height, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); renders a micro qr code on the canvas with default colors. micro qr does not offer the standard qr icon overlay or custom finder pattern shape options (single finder pattern, no error-correction headroom for overlays).">
-              <h4><span class="kind">method</span> <span class="name">Render</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeExtensions.cs#L109" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Render</a></h4>
               <pre class="sig"><code>public static void Render(SKCanvas canvas, MicroQRCodeData data, int width, int height, SKColor? clearColor = null, SKColor? codeColor = null, SKColor? backgroundColor = null, ModuleShape? moduleShape = null, float moduleSizePercent = 1, GradientOptions? gradientOptions = null);</code></pre>
               <p class="doc">Renders a Micro QR code on the canvas with default colors.</p>
               <details class="notes" data-text="micro qr does not offer the standard qr icon overlay or custom finder pattern shape options (single finder pattern, no error-correction headroom for overlays).">
@@ -1223,17 +1226,17 @@
               </details>
             </div>
             <div class="member" data-text="method public static void render(skcanvas canvas, qrcodedata data, skrect area, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, icondata? icondata = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null, finderpatternshape? finderpatternshape = null); renders a qr code on the canvas with custom colors. ">
-              <h4><span class="kind">method</span> <span class="name">Render</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeExtensions.cs#L76" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Render</a></h4>
               <pre class="sig"><code>public static void Render(SKCanvas canvas, QRCodeData data, SKRect area, SKColor? clearColor = null, SKColor? codeColor = null, SKColor? backgroundColor = null, IconData? iconData = null, ModuleShape? moduleShape = null, float moduleSizePercent = 1, GradientOptions? gradientOptions = null, FinderPatternShape? finderPatternShape = null);</code></pre>
               <p class="doc">Renders a QR code on the canvas with custom colors.</p>
             </div>
             <div class="member" data-text="method public static void render(skcanvas canvas, qrcodedata data, int width, int height, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, icondata? icondata = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null, finderpatternshape? finderpatternshape = null); renders a qr code on the canvas with default colors. ">
-              <h4><span class="kind">method</span> <span class="name">Render</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeExtensions.cs#L45" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Render</a></h4>
               <pre class="sig"><code>public static void Render(SKCanvas canvas, QRCodeData data, int width, int height, SKColor? clearColor = null, SKColor? codeColor = null, SKColor? backgroundColor = null, IconData? iconData = null, ModuleShape? moduleShape = null, float moduleSizePercent = 1, GradientOptions? gradientOptions = null, FinderPatternShape? finderPatternShape = null);</code></pre>
               <p class="doc">Renders a QR code on the canvas with default colors.</p>
             </div>
             <div class="member" data-text="method public static void render(skcanvas canvas, rmqrcodedata data, skrect area, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); renders an rmqr code on the canvas with custom colors. the rectangular symbol (quiet zone included) is drawn with a uniform module scale and centered in the area (letterbox); the whole area receives the background color. rmqr offers no icon overlay or finder styling options.">
-              <h4><span class="kind">method</span> <span class="name">Render</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeExtensions.cs#L206" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Render</a></h4>
               <pre class="sig"><code>public static void Render(SKCanvas canvas, RmQRCodeData data, SKRect area, SKColor? clearColor = null, SKColor? codeColor = null, SKColor? backgroundColor = null, ModuleShape? moduleShape = null, float moduleSizePercent = 1, GradientOptions? gradientOptions = null);</code></pre>
               <p class="doc">Renders an rMQR code on the canvas with custom colors.</p>
               <details class="notes" data-text="the rectangular symbol (quiet zone included) is drawn with a uniform module scale and centered in the area (letterbox); the whole area receives the background color. rmqr offers no icon overlay or finder styling options.">
@@ -1242,7 +1245,7 @@
               </details>
             </div>
             <div class="member" data-text="method public static void render(skcanvas canvas, rmqrcodedata data, int width, int height, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); renders an rmqr code on the canvas with default colors. the rectangular symbol (quiet zone included) is drawn with a uniform module scale and centered in the area (letterbox); the whole area receives the background color. rmqr offers no icon overlay or finder styling options.">
-              <h4><span class="kind">method</span> <span class="name">Render</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeExtensions.cs#L174" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Render</a></h4>
               <pre class="sig"><code>public static void Render(SKCanvas canvas, RmQRCodeData data, int width, int height, SKColor? clearColor = null, SKColor? codeColor = null, SKColor? backgroundColor = null, ModuleShape? moduleShape = null, float moduleSizePercent = 1, GradientOptions? gradientOptions = null);</code></pre>
               <p class="doc">Renders an rMQR code on the canvas with default colors.</p>
               <details class="notes" data-text="the rectangular symbol (quiet zone included) is drawn with a uniform module scale and centered in the area (letterbox); the whole area receives the background color. rmqr offers no icon overlay or finder styling options.">
@@ -1253,7 +1256,7 @@
           </div>
         </article>
         <article class="type" id="SkiaSharp.QrCode.QRCodeGenerator" data-name="skiasharp.qrcode.qrcodegenerator" data-text="skiasharp.qrcode.qrcodegenerator public static class qrcodegenerator qr code generator based on iso/iec 18004 standard. supports qr code versions 1-40 with multiple encoding modes and error correction levels. encoding modes written here are numeric, alphanumeric and byte (iso-8859-1 / utf-8, with eci). kanji mode is never written, japanese text goes out as utf-8 in byte mode; qrcodedecoder does read kanji segments other encoders produce, so the two directions are deliberately asymmetric. method [obsolete] public static qrcodecalculatedsize getrequiredbuffersize(readonlyspan&lt;char&gt; text, ecclevel ecclevel, bool utf8bom = false, ecimode ecimode = 0, int quietzonesize = 4); calculates the required buffer size for encoding the specified text as a qr code.  method public static qrcodedata createqrcode(readonlyspan&lt;char&gt; textspan, ecclevel ecclevel, bool utf8bom = false, ecimode ecimode = 0, int requestedversion = -1, int quietzonesize = 4); creates a qr code from the provided plain text.  method public static qrcodedata createqrcode(readonlyspan&lt;char&gt; textspan, ecclevel ecclevel, in qrcodegeneratoroptions options);  method public static qrcodedata createqrcode(string plaintext, ecclevel ecclevel, bool utf8bom = false, ecimode ecimode = 0, int requestedversion = -1, int quietzonesize = 4); creates a qr code from the provided plain text.  method public static qrcodedata createqrcode(string plaintext, ecclevel ecclevel, in qrcodegeneratoroptions options);  method public static bool trygetrequiredbuffersize(readonlyspan&lt;char&gt; text, ecclevel ecclevel, out qrcodecalculatedsize size, in qrcodegeneratoroptions options = null); calculates the required buffer size, matrix size and version for encoding the specified text as a qr code, reporting content that does not fit as false rather than as an exception. false means the content does not fit, and nothing else: argument errors throw (rationale: specs/rmqr-encoder.md). when version is narrower than any , that means no version in that range holds the content, not merely that it exceeds version 40. boostecclevel has no effect here: the boost never changes the version, and the buffer size depends only on the version. pass the same options you will encode with: segmentation and ecimode can select different versions, so a buffer sized for one can be too small for the other. method public static int createqrcode(readonlyspan&lt;char&gt; textspan, ecclevel ecclevel, span&lt;byte&gt; destination, bool utf8bom = false, ecimode ecimode = 0, int requestedversion = -1, int quietzonesize = 4); creates a qr code from the provided plain text and writes the module matrix into the caller-provided buffer without per-call heap allocation. output format: one byte per module (0 = light, 1 = dark), flat row-major order, quiet zone included. module at (row, col) is destination[row * qrsize + col] where qrsize is qrsize returned by trygetrequiredbuffersize . usage flow for allocation-free generation: if (!qrcodegenerator.trygetrequiredbuffersize(text, ecclevel.m, out var calculated, qrcodegeneratoroptions.default)) return; // content does not fit version 40 at this ecc level var buffer = arraypool&lt;byte&gt;.shared.rent(calculated.buffersize); var written = qrcodegenerator.createqrcode(text, ecclevel.m, buffer); var matrix = buffer.asspan(0, written); // ... consume matrix ... arraypool&lt;byte&gt;.shared.return(buffer); only the first buffersize bytes of destination are written (every byte of that region is written, so a dirty pooled buffer is fine); any remaining bytes are left untouched. method public static int createqrcode(readonlyspan&lt;char&gt; textspan, ecclevel ecclevel, span&lt;byte&gt; destination, in qrcodegeneratoroptions options);  method public static int createqrcode(string plaintext, ecclevel ecclevel, span&lt;byte&gt; destination, bool utf8bom = false, ecimode ecimode = 0, int requestedversion = -1, int quietzonesize = 4); creates a qr code from the provided plain text and writes the module matrix into the caller-provided buffer without per-call heap allocation.  method public static int createqrcode(string plaintext, ecclevel ecclevel, span&lt;byte&gt; destination, in qrcodegeneratoroptions options); ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeGenerator" aria-label="Link to SkiaSharp.QrCode.QRCodeGenerator">#</a><span class="kind">class</span> <span class="name">QRCodeGenerator</span></h3>
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeGenerator" aria-label="Link to SkiaSharp.QrCode.QRCodeGenerator">#</a><span class="kind">class</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeGenerator.cs" title="View source file on GitHub" target="_blank" rel="noopener noreferrer">QRCodeGenerator</a></h3>
           <pre class="sig"><code>public static class QRCodeGenerator</code></pre>
           <p class="doc">QR code generator based on ISO/IEC 18004 standard. Supports QR code versions 1-40 with multiple encoding modes and error correction levels.</p>
           <details class="notes" data-text="encoding modes written here are numeric, alphanumeric and byte (iso-8859-1 / utf-8, with eci). kanji mode is never written, japanese text goes out as utf-8 in byte mode; qrcodedecoder does read kanji segments other encoders produce, so the two directions are deliberately asymmetric.">
@@ -1262,30 +1265,30 @@
           </details>
           <div class="members">
             <div class="member" data-text="method public static qrcodecalculatedsize getrequiredbuffersize(readonlyspan&lt;char&gt; text, ecclevel ecclevel, bool utf8bom = false, ecimode ecimode = 0, int quietzonesize = 4); calculates the required buffer size for encoding the specified text as a qr code. ">
-              <h4><span class="kind">method</span> <span class="name">GetRequiredBufferSize</span> <span class="tag">obsolete</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeGenerator.cs#L294" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetRequiredBufferSize</a> <span class="tag">obsolete</span></h4>
               <pre class="sig"><code>public static QRCodeCalculatedSize GetRequiredBufferSize(ReadOnlySpan&lt;char&gt; text, ECCLevel eccLevel, bool utf8BOM = false, EciMode eciMode = 0, int quietZoneSize = 4);</code></pre>
               <p class="doc">Calculates the required buffer size for encoding the specified text as a QR code.</p>
             </div>
             <div class="member" data-text="method public static qrcodedata createqrcode(readonlyspan&lt;char&gt; textspan, ecclevel ecclevel, bool utf8bom = false, ecimode ecimode = 0, int requestedversion = -1, int quietzonesize = 4); creates a qr code from the provided plain text. ">
-              <h4><span class="kind">method</span> <span class="name">CreateQrCode</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeGenerator.cs#L73" title="View source on GitHub" target="_blank" rel="noopener noreferrer">CreateQrCode</a></h4>
               <pre class="sig"><code>public static QRCodeData CreateQrCode(ReadOnlySpan&lt;char&gt; textSpan, ECCLevel eccLevel, bool utf8BOM = false, EciMode eciMode = 0, int requestedVersion = -1, int quietZoneSize = 4);</code></pre>
               <p class="doc">Creates a QR code from the provided plain text.</p>
             </div>
             <div class="member" data-text="method public static qrcodedata createqrcode(readonlyspan&lt;char&gt; textspan, ecclevel ecclevel, in qrcodegeneratoroptions options); ">
-              <h4><span class="kind">method</span> <span class="name">CreateQrCode</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeGenerator.cs#L335" title="View source on GitHub" target="_blank" rel="noopener noreferrer">CreateQrCode</a></h4>
               <pre class="sig"><code>public static QRCodeData CreateQrCode(ReadOnlySpan&lt;char&gt; textSpan, ECCLevel eccLevel, in QRCodeGeneratorOptions options);</code></pre>
             </div>
             <div class="member" data-text="method public static qrcodedata createqrcode(string plaintext, ecclevel ecclevel, bool utf8bom = false, ecimode ecimode = 0, int requestedversion = -1, int quietzonesize = 4); creates a qr code from the provided plain text. ">
-              <h4><span class="kind">method</span> <span class="name">CreateQrCode</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeGenerator.cs#L58" title="View source on GitHub" target="_blank" rel="noopener noreferrer">CreateQrCode</a></h4>
               <pre class="sig"><code>public static QRCodeData CreateQrCode(string plainText, ECCLevel eccLevel, bool utf8BOM = false, EciMode eciMode = 0, int requestedVersion = -1, int quietZoneSize = 4);</code></pre>
               <p class="doc">Creates a QR code from the provided plain text.</p>
             </div>
             <div class="member" data-text="method public static qrcodedata createqrcode(string plaintext, ecclevel ecclevel, in qrcodegeneratoroptions options); ">
-              <h4><span class="kind">method</span> <span class="name">CreateQrCode</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeGenerator.cs#L328" title="View source on GitHub" target="_blank" rel="noopener noreferrer">CreateQrCode</a></h4>
               <pre class="sig"><code>public static QRCodeData CreateQrCode(string plainText, ECCLevel eccLevel, in QRCodeGeneratorOptions options);</code></pre>
             </div>
             <div class="member" data-text="method public static bool trygetrequiredbuffersize(readonlyspan&lt;char&gt; text, ecclevel ecclevel, out qrcodecalculatedsize size, in qrcodegeneratoroptions options = null); calculates the required buffer size, matrix size and version for encoding the specified text as a qr code, reporting content that does not fit as false rather than as an exception. false means the content does not fit, and nothing else: argument errors throw (rationale: specs/rmqr-encoder.md). when version is narrower than any , that means no version in that range holds the content, not merely that it exceeds version 40. boostecclevel has no effect here: the boost never changes the version, and the buffer size depends only on the version. pass the same options you will encode with: segmentation and ecimode can select different versions, so a buffer sized for one can be too small for the other.">
-              <h4><span class="kind">method</span> <span class="name">TryGetRequiredBufferSize</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeGenerator.cs#L398" title="View source on GitHub" target="_blank" rel="noopener noreferrer">TryGetRequiredBufferSize</a></h4>
               <pre class="sig"><code>public static bool TryGetRequiredBufferSize(ReadOnlySpan&lt;char&gt; text, ECCLevel eccLevel, out QRCodeCalculatedSize size, in QRCodeGeneratorOptions options = null);</code></pre>
               <p class="doc">Calculates the required buffer size, matrix size and version for encoding the specified text as a QR code, reporting content that does not fit as false rather than as an exception.</p>
               <details class="notes" data-text="false means the content does not fit, and nothing else: argument errors throw (rationale: specs/rmqr-encoder.md). when version is narrower than any , that means no version in that range holds the content, not merely that it exceeds version 40. boostecclevel has no effect here: the boost never changes the version, and the buffer size depends only on the version. pass the same options you will encode with: segmentation and ecimode can select different versions, so a buffer sized for one can be too small for the other.">
@@ -1294,7 +1297,7 @@
               </details>
             </div>
             <div class="member" data-text="method public static int createqrcode(readonlyspan&lt;char&gt; textspan, ecclevel ecclevel, span&lt;byte&gt; destination, bool utf8bom = false, ecimode ecimode = 0, int requestedversion = -1, int quietzonesize = 4); creates a qr code from the provided plain text and writes the module matrix into the caller-provided buffer without per-call heap allocation. output format: one byte per module (0 = light, 1 = dark), flat row-major order, quiet zone included. module at (row, col) is destination[row * qrsize + col] where qrsize is qrsize returned by trygetrequiredbuffersize . usage flow for allocation-free generation: if (!qrcodegenerator.trygetrequiredbuffersize(text, ecclevel.m, out var calculated, qrcodegeneratoroptions.default)) return; // content does not fit version 40 at this ecc level var buffer = arraypool&lt;byte&gt;.shared.rent(calculated.buffersize); var written = qrcodegenerator.createqrcode(text, ecclevel.m, buffer); var matrix = buffer.asspan(0, written); // ... consume matrix ... arraypool&lt;byte&gt;.shared.return(buffer); only the first buffersize bytes of destination are written (every byte of that region is written, so a dirty pooled buffer is fine); any remaining bytes are left untouched.">
-              <h4><span class="kind">method</span> <span class="name">CreateQrCode</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeGenerator.cs#L189" title="View source on GitHub" target="_blank" rel="noopener noreferrer">CreateQrCode</a></h4>
               <pre class="sig"><code>public static int CreateQrCode(ReadOnlySpan&lt;char&gt; textSpan, ECCLevel eccLevel, Span&lt;byte&gt; destination, bool utf8BOM = false, EciMode eciMode = 0, int requestedVersion = -1, int quietZoneSize = 4);</code></pre>
               <p class="doc">Creates a QR code from the provided plain text and writes the module matrix into the caller-provided buffer without per-call heap allocation.</p>
               <details class="notes" data-text="output format: one byte per module (0 = light, 1 = dark), flat row-major order, quiet zone included. module at (row, col) is destination[row * qrsize + col] where qrsize is qrsize returned by trygetrequiredbuffersize . usage flow for allocation-free generation: if (!qrcodegenerator.trygetrequiredbuffersize(text, ecclevel.m, out var calculated, qrcodegeneratoroptions.default)) return; // content does not fit version 40 at this ecc level var buffer = arraypool&lt;byte&gt;.shared.rent(calculated.buffersize); var written = qrcodegenerator.createqrcode(text, ecclevel.m, buffer); var matrix = buffer.asspan(0, written); // ... consume matrix ... arraypool&lt;byte&gt;.shared.return(buffer); only the first buffersize bytes of destination are written (every byte of that region is written, so a dirty pooled buffer is fine); any remaining bytes are left untouched.">
@@ -1303,22 +1306,22 @@
               </details>
             </div>
             <div class="member" data-text="method public static int createqrcode(readonlyspan&lt;char&gt; textspan, ecclevel ecclevel, span&lt;byte&gt; destination, in qrcodegeneratoroptions options); ">
-              <h4><span class="kind">method</span> <span class="name">CreateQrCode</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeGenerator.cs#L360" title="View source on GitHub" target="_blank" rel="noopener noreferrer">CreateQrCode</a></h4>
               <pre class="sig"><code>public static int CreateQrCode(ReadOnlySpan&lt;char&gt; textSpan, ECCLevel eccLevel, Span&lt;byte&gt; destination, in QRCodeGeneratorOptions options);</code></pre>
             </div>
             <div class="member" data-text="method public static int createqrcode(string plaintext, ecclevel ecclevel, span&lt;byte&gt; destination, bool utf8bom = false, ecimode ecimode = 0, int requestedversion = -1, int quietzonesize = 4); creates a qr code from the provided plain text and writes the module matrix into the caller-provided buffer without per-call heap allocation. ">
-              <h4><span class="kind">method</span> <span class="name">CreateQrCode</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeGenerator.cs#L149" title="View source on GitHub" target="_blank" rel="noopener noreferrer">CreateQrCode</a></h4>
               <pre class="sig"><code>public static int CreateQrCode(string plainText, ECCLevel eccLevel, Span&lt;byte&gt; destination, bool utf8BOM = false, EciMode eciMode = 0, int requestedVersion = -1, int quietZoneSize = 4);</code></pre>
               <p class="doc">Creates a QR code from the provided plain text and writes the module matrix into the caller-provided buffer without per-call heap allocation.</p>
             </div>
             <div class="member" data-text="method public static int createqrcode(string plaintext, ecclevel ecclevel, span&lt;byte&gt; destination, in qrcodegeneratoroptions options); ">
-              <h4><span class="kind">method</span> <span class="name">CreateQrCode</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeGenerator.cs#L352" title="View source on GitHub" target="_blank" rel="noopener noreferrer">CreateQrCode</a></h4>
               <pre class="sig"><code>public static int CreateQrCode(string plainText, ECCLevel eccLevel, Span&lt;byte&gt; destination, in QRCodeGeneratorOptions options);</code></pre>
             </div>
           </div>
         </article>
         <article class="type" id="SkiaSharp.QrCode.QRCodeGeneratorOptions" data-name="skiasharp.qrcode.qrcodegeneratoroptions" data-text="skiasharp.qrcode.qrcodegeneratoroptions public readonly struct qrcodegeneratoroptions : iequatable&lt;qrcodegeneratoroptions&gt; optional settings for qrcodegenerator . default is the complete default configuration, so set only what you need: new qrcodegeneratoroptions { ecimode = ecimode.utf8, quietzonesize = 0 }. standard qr specific rather than shared: the three generators agree on almost nothing. version is a different type in each, quietzonesize has a different specified default in each, micro qr has no eci, and rmqr carries fit options that mean nothing here. property public ecimode ecimode { get; init; } character encoding declaration. the default auto-detects ascii (no eci), iso-8859-1 (assignment 3) or utf-8 (assignment 26) from the content.  property public qrcodesegmentation segmentation { get; init; } how the content is split into encoding-mode segments (see qrcodesegmentation ). defaults to single . optimal never selects a larger version, emits the identical bit stream when a split would not shrink the symbol, and defers to the single-mode stream when utf8bom would actually write a byte order mark. size a destination buffer with the same value you encode with.  property public qrcodeversionrange version { get; init; } the versions the generator may choose from. defaults to any ; an int or int? converts implicitly, so version = 15 pins one and a null means automatic.  property public bool boostecclevel { get; init; } raise the error correction level above the requested one when the chosen version's capacity allows it, without changing the version. the requested level becomes the minimum; the version is still chosen for it, so boosting never produces a larger symbol, only spends padding that would otherwise be wasted. recommended when an icon or custom module shape overlays the symbol. off by default: a raised level rewrites the format information and can change the chosen mask, so a default of on would silently change every existing symbol. sizing is unaffected either way, the buffer size depends only on the version. property public bool utf8bom { get; init; } include a utf-8 byte order mark. ignored unless the content is written as utf-8 in byte mode. when a bom would be written, optimal emits the single-mode stream instead of a split (the bom is a stream-level prefix, and a split would relocate it into the middle of the decoded text).  property public int quietzonesize { get; init; } quiet zone width in modules. defaults to 4, the iso/iec 18004 value; 0 is valid.  property public int? maskpattern { get; init; } pin one of the eight iso/iec 18004 data mask patterns (0-7) instead of the automatic penalty-scored selection. null (the default) selects the lowest-penalty pattern. any pattern yields a valid, decodable symbol; the automatic choice merely optimizes scan reliability. for reproducing a symbol produced elsewhere byte-for-byte (the pattern another encoder chose is reported by maskpattern ), and for exercising a decoder against all eight patterns. like version , an invalid value is an argument error and is rejected here rather than when a generator reads it. property public static qrcodegeneratoroptions default { get; } the default configuration, identical to default. ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeGeneratorOptions" aria-label="Link to SkiaSharp.QrCode.QRCodeGeneratorOptions">#</a><span class="kind">struct</span> <span class="name">QRCodeGeneratorOptions</span></h3>
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeGeneratorOptions" aria-label="Link to SkiaSharp.QrCode.QRCodeGeneratorOptions">#</a><span class="kind">struct</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeGeneratorOptions.cs" title="View source file on GitHub" target="_blank" rel="noopener noreferrer">QRCodeGeneratorOptions</a></h3>
           <pre class="sig"><code>public readonly struct QRCodeGeneratorOptions : IEquatable&lt;QRCodeGeneratorOptions&gt;</code></pre>
           <p class="doc">Optional settings for QRCodeGenerator . default is the complete default configuration, so set only what you need: new QRCodeGeneratorOptions { EciMode = EciMode.Utf8, QuietZoneSize = 0 }.</p>
           <details class="notes" data-text="standard qr specific rather than shared: the three generators agree on almost nothing. version is a different type in each, quietzonesize has a different specified default in each, micro qr has no eci, and rmqr carries fit options that mean nothing here.">
@@ -1327,22 +1330,22 @@
           </details>
           <div class="members">
             <div class="member" data-text="property public ecimode ecimode { get; init; } character encoding declaration. the default auto-detects ascii (no eci), iso-8859-1 (assignment 3) or utf-8 (assignment 26) from the content. ">
-              <h4><span class="kind">property</span> <span class="name">EciMode</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeGeneratorOptions.cs#L34" title="View source on GitHub" target="_blank" rel="noopener noreferrer">EciMode</a></h4>
               <pre class="sig"><code>public EciMode EciMode { get; init; }</code></pre>
               <p class="doc">Character encoding declaration. The default auto-detects ASCII (no ECI), ISO-8859-1 (assignment 3) or UTF-8 (assignment 26) from the content.</p>
             </div>
             <div class="member" data-text="property public qrcodesegmentation segmentation { get; init; } how the content is split into encoding-mode segments (see qrcodesegmentation ). defaults to single . optimal never selects a larger version, emits the identical bit stream when a split would not shrink the symbol, and defers to the single-mode stream when utf8bom would actually write a byte order mark. size a destination buffer with the same value you encode with. ">
-              <h4><span class="kind">property</span> <span class="name">Segmentation</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeGeneratorOptions.cs#L109" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Segmentation</a></h4>
               <pre class="sig"><code>public QRCodeSegmentation Segmentation { get; init; }</code></pre>
               <p class="doc">How the content is split into encoding-mode segments (see QRCodeSegmentation ). Defaults to Single . Optimal never selects a larger version, emits the identical bit stream when a split would not shrink the symbol, and defers to the single-mode stream when Utf8BOM would actually write a byte order mark. Size a destination buffer with the same value you encode with.</p>
             </div>
             <div class="member" data-text="property public qrcodeversionrange version { get; init; } the versions the generator may choose from. defaults to any ; an int or int? converts implicitly, so version = 15 pins one and a null means automatic. ">
-              <h4><span class="kind">property</span> <span class="name">Version</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeGeneratorOptions.cs#L50" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Version</a></h4>
               <pre class="sig"><code>public QRCodeVersionRange Version { get; init; }</code></pre>
               <p class="doc">The versions the generator may choose from. Defaults to Any ; an int or int? converts implicitly, so Version = 15 pins one and a null means automatic.</p>
             </div>
             <div class="member" data-text="property public bool boostecclevel { get; init; } raise the error correction level above the requested one when the chosen version's capacity allows it, without changing the version. the requested level becomes the minimum; the version is still chosen for it, so boosting never produces a larger symbol, only spends padding that would otherwise be wasted. recommended when an icon or custom module shape overlays the symbol. off by default: a raised level rewrites the format information and can change the chosen mask, so a default of on would silently change every existing symbol. sizing is unaffected either way, the buffer size depends only on the version.">
-              <h4><span class="kind">property</span> <span class="name">BoostEccLevel</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeGeneratorOptions.cs#L98" title="View source on GitHub" target="_blank" rel="noopener noreferrer">BoostEccLevel</a></h4>
               <pre class="sig"><code>public bool BoostEccLevel { get; init; }</code></pre>
               <p class="doc">Raise the error correction level above the requested one when the chosen version's capacity allows it, without changing the version. The requested level becomes the minimum; the version is still chosen for it, so boosting never produces a larger symbol, only spends padding that would otherwise be wasted. Recommended when an icon or custom module shape overlays the symbol.</p>
               <details class="notes" data-text="off by default: a raised level rewrites the format information and can change the chosen mask, so a default of on would silently change every existing symbol. sizing is unaffected either way, the buffer size depends only on the version.">
@@ -1351,17 +1354,17 @@
               </details>
             </div>
             <div class="member" data-text="property public bool utf8bom { get; init; } include a utf-8 byte order mark. ignored unless the content is written as utf-8 in byte mode. when a bom would be written, optimal emits the single-mode stream instead of a split (the bom is a stream-level prefix, and a split would relocate it into the middle of the decoded text). ">
-              <h4><span class="kind">property</span> <span class="name">Utf8BOM</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeGeneratorOptions.cs#L43" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Utf8BOM</a></h4>
               <pre class="sig"><code>public bool Utf8BOM { get; init; }</code></pre>
               <p class="doc">Include a UTF-8 byte order mark. Ignored unless the content is written as UTF-8 in Byte mode. When a BOM would be written, Optimal emits the single-mode stream instead of a split (the BOM is a stream-level prefix, and a split would relocate it into the middle of the decoded text).</p>
             </div>
             <div class="member" data-text="property public int quietzonesize { get; init; } quiet zone width in modules. defaults to 4, the iso/iec 18004 value; 0 is valid. ">
-              <h4><span class="kind">property</span> <span class="name">QuietZoneSize</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeGeneratorOptions.cs#L57" title="View source on GitHub" target="_blank" rel="noopener noreferrer">QuietZoneSize</a></h4>
               <pre class="sig"><code>public int QuietZoneSize { get; init; }</code></pre>
               <p class="doc">Quiet zone width in modules. Defaults to 4, the ISO/IEC 18004 value; 0 is valid.</p>
             </div>
             <div class="member" data-text="property public int? maskpattern { get; init; } pin one of the eight iso/iec 18004 data mask patterns (0-7) instead of the automatic penalty-scored selection. null (the default) selects the lowest-penalty pattern. any pattern yields a valid, decodable symbol; the automatic choice merely optimizes scan reliability. for reproducing a symbol produced elsewhere byte-for-byte (the pattern another encoder chose is reported by maskpattern ), and for exercising a decoder against all eight patterns. like version , an invalid value is an argument error and is rejected here rather than when a generator reads it.">
-              <h4><span class="kind">property</span> <span class="name">MaskPattern</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeGeneratorOptions.cs#L77" title="View source on GitHub" target="_blank" rel="noopener noreferrer">MaskPattern</a></h4>
               <pre class="sig"><code>public int? MaskPattern { get; init; }</code></pre>
               <p class="doc">Pin one of the eight ISO/IEC 18004 data mask patterns (0-7) instead of the automatic penalty-scored selection. null (the default) selects the lowest-penalty pattern. Any pattern yields a valid, decodable symbol; the automatic choice merely optimizes scan reliability.</p>
               <details class="notes" data-text="for reproducing a symbol produced elsewhere byte-for-byte (the pattern another encoder chose is reported by maskpattern ), and for exercising a decoder against all eight patterns. like version , an invalid value is an argument error and is rejected here rather than when a generator reads it.">
@@ -1370,19 +1373,19 @@
               </details>
             </div>
             <div class="member" data-text="property public static qrcodegeneratoroptions default { get; } the default configuration, identical to default. ">
-              <h4><span class="kind">property</span> <span class="name">Default</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeGeneratorOptions.cs#L28" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Default</a></h4>
               <pre class="sig"><code>public static QRCodeGeneratorOptions Default { get; }</code></pre>
               <p class="doc">The default configuration, identical to default.</p>
             </div>
           </div>
         </article>
         <article class="type" id="SkiaSharp.QrCode.QRCodeRenderer" data-name="skiasharp.qrcode.qrcoderenderer" data-text="skiasharp.qrcode.qrcoderenderer public static class qrcoderenderer provides low-level rendering capabilities for qr codes to skiasharp canvases. offers fine-grained control over appearance, including colors, shapes, gradients, and icon overlays.  method public static skrect getfinderpatternrect(qrcodedata data, int patternindex, skrect renderarea); gets the rectangle area for a specified finder pattern in the rendered qr code area. the finder patterns are the large squares typically located at three corners of a qr code. this method calculates their positions based on the qr code's size and quiet zone, ensuring accurate placement within the specified rendering area. method public static valuetuple&lt;skrect, skrect&gt; geticonrects(qrcodedata data, skrect area, icondata icondata); calculates icon and border rectangles for the given qr code area. when iconsizemodules is set, sizing is module-based and percent/pixel values are ignored. module-based icons are validated against qr size and core occupancy at render time. icon rectangles are snapped to the module grid; even module sizes cannot be geometrically centered on an odd qr matrix. method public static void render(skcanvas canvas, skrect area, microqrcodedata data, skcolor? codecolor, skcolor? backgroundcolor, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); render the specified micro qr data into the given area of the target canvas. micro qr has a single finder pattern and no error-correction headroom for overlays, so the standard qr options for icons and custom finder pattern shapes are intentionally not available. see render for the module-run merge behavior shared with standard qr. method public static void render(skcanvas canvas, skrect area, qrcodedata data, skcolor? codecolor, skcolor? backgroundcolor, icondata? icondata = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null, finderpatternshape? finderpatternshape = null); render the specified data into the given area of the target canvas. with the default rectangle shape at modulesizepercent 1.0, horizontal runs of dark modules are drawn as single merged rectangles (fewer native draw calls). merged and per-module rendering are pixel-identical under axis-preserving canvas transforms (translation/scale); under rotation, shared-edge rounding may differ at sub-pixel level. any custom module shape or a module size below 1.0 falls back to per-module drawing. method public static void render(skcanvas canvas, skrect area, rmqrcodedata data, skcolor? codecolor, skcolor? backgroundcolor, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); renders an rmqr code onto the canvas. the rectangular symbol (quiet zone included) is drawn with a uniform module scale and centered in area (letterbox); the whole area receives the background. rmqr has one finder pattern and no error-correction headroom for overlays, so there are no icon or finder-shape options. module runs are merged as for the other symbologies (see render ).">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeRenderer" aria-label="Link to SkiaSharp.QrCode.QRCodeRenderer">#</a><span class="kind">class</span> <span class="name">QRCodeRenderer</span></h3>
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeRenderer" aria-label="Link to SkiaSharp.QrCode.QRCodeRenderer">#</a><span class="kind">class</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeRenderer.cs" title="View source file on GitHub" target="_blank" rel="noopener noreferrer">QRCodeRenderer</a></h3>
           <pre class="sig"><code>public static class QRCodeRenderer</code></pre>
           <p class="doc">Provides low-level rendering capabilities for QR codes to SkiaSharp canvases. Offers fine-grained control over appearance, including colors, shapes, gradients, and icon overlays.</p>
           <div class="members">
             <div class="member" data-text="method public static skrect getfinderpatternrect(qrcodedata data, int patternindex, skrect renderarea); gets the rectangle area for a specified finder pattern in the rendered qr code area. the finder patterns are the large squares typically located at three corners of a qr code. this method calculates their positions based on the qr code's size and quiet zone, ensuring accurate placement within the specified rendering area.">
-              <h4><span class="kind">method</span> <span class="name">GetFinderPatternRect</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeRenderer.cs#L413" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetFinderPatternRect</a></h4>
               <pre class="sig"><code>public static SKRect GetFinderPatternRect(QRCodeData data, int patternIndex, SKRect renderArea);</code></pre>
               <p class="doc">Gets the rectangle area for a specified finder pattern in the rendered QR code area.</p>
               <details class="notes" data-text="the finder patterns are the large squares typically located at three corners of a qr code. this method calculates their positions based on the qr code's size and quiet zone, ensuring accurate placement within the specified rendering area.">
@@ -1391,7 +1394,7 @@
               </details>
             </div>
             <div class="member" data-text="method public static valuetuple&lt;skrect, skrect&gt; geticonrects(qrcodedata data, skrect area, icondata icondata); calculates icon and border rectangles for the given qr code area. when iconsizemodules is set, sizing is module-based and percent/pixel values are ignored. module-based icons are validated against qr size and core occupancy at render time. icon rectangles are snapped to the module grid; even module sizes cannot be geometrically centered on an odd qr matrix.">
-              <h4><span class="kind">method</span> <span class="name">GetIconRects</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeRenderer.cs#L304" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetIconRects</a></h4>
               <pre class="sig"><code>public static ValueTuple&lt;SKRect, SKRect&gt; GetIconRects(QRCodeData data, SKRect area, IconData iconData);</code></pre>
               <p class="doc">Calculates icon and border rectangles for the given QR code area.</p>
               <details class="notes" data-text="when iconsizemodules is set, sizing is module-based and percent/pixel values are ignored. module-based icons are validated against qr size and core occupancy at render time. icon rectangles are snapped to the module grid; even module sizes cannot be geometrically centered on an odd qr matrix.">
@@ -1400,7 +1403,7 @@
               </details>
             </div>
             <div class="member" data-text="method public static void render(skcanvas canvas, skrect area, microqrcodedata data, skcolor? codecolor, skcolor? backgroundcolor, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); render the specified micro qr data into the given area of the target canvas. micro qr has a single finder pattern and no error-correction headroom for overlays, so the standard qr options for icons and custom finder pattern shapes are intentionally not available. see render for the module-run merge behavior shared with standard qr.">
-              <h4><span class="kind">method</span> <span class="name">Render</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeRenderer.cs#L171" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Render</a></h4>
               <pre class="sig"><code>public static void Render(SKCanvas canvas, SKRect area, MicroQRCodeData data, SKColor? codeColor, SKColor? backgroundColor, ModuleShape? moduleShape = null, float moduleSizePercent = 1, GradientOptions? gradientOptions = null);</code></pre>
               <p class="doc">Render the specified Micro QR data into the given area of the target canvas.</p>
               <details class="notes" data-text="micro qr has a single finder pattern and no error-correction headroom for overlays, so the standard qr options for icons and custom finder pattern shapes are intentionally not available. see render for the module-run merge behavior shared with standard qr.">
@@ -1409,7 +1412,7 @@
               </details>
             </div>
             <div class="member" data-text="method public static void render(skcanvas canvas, skrect area, qrcodedata data, skcolor? codecolor, skcolor? backgroundcolor, icondata? icondata = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null, finderpatternshape? finderpatternshape = null); render the specified data into the given area of the target canvas. with the default rectangle shape at modulesizepercent 1.0, horizontal runs of dark modules are drawn as single merged rectangles (fewer native draw calls). merged and per-module rendering are pixel-identical under axis-preserving canvas transforms (translation/scale); under rotation, shared-edge rounding may differ at sub-pixel level. any custom module shape or a module size below 1.0 falls back to per-module drawing.">
-              <h4><span class="kind">method</span> <span class="name">Render</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeRenderer.cs#L47" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Render</a></h4>
               <pre class="sig"><code>public static void Render(SKCanvas canvas, SKRect area, QRCodeData data, SKColor? codeColor, SKColor? backgroundColor, IconData? iconData = null, ModuleShape? moduleShape = null, float moduleSizePercent = 1, GradientOptions? gradientOptions = null, FinderPatternShape? finderPatternShape = null);</code></pre>
               <p class="doc">Render the specified data into the given area of the target canvas.</p>
               <details class="notes" data-text="with the default rectangle shape at modulesizepercent 1.0, horizontal runs of dark modules are drawn as single merged rectangles (fewer native draw calls). merged and per-module rendering are pixel-identical under axis-preserving canvas transforms (translation/scale); under rotation, shared-edge rounding may differ at sub-pixel level. any custom module shape or a module size below 1.0 falls back to per-module drawing.">
@@ -1418,7 +1421,7 @@
               </details>
             </div>
             <div class="member" data-text="method public static void render(skcanvas canvas, skrect area, rmqrcodedata data, skcolor? codecolor, skcolor? backgroundcolor, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); renders an rmqr code onto the canvas. the rectangular symbol (quiet zone included) is drawn with a uniform module scale and centered in area (letterbox); the whole area receives the background. rmqr has one finder pattern and no error-correction headroom for overlays, so there are no icon or finder-shape options. module runs are merged as for the other symbologies (see render ).">
-              <h4><span class="kind">method</span> <span class="name">Render</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeRenderer.cs#L239" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Render</a></h4>
               <pre class="sig"><code>public static void Render(SKCanvas canvas, SKRect area, RmQRCodeData data, SKColor? codeColor, SKColor? backgroundColor, ModuleShape? moduleShape = null, float moduleSizePercent = 1, GradientOptions? gradientOptions = null);</code></pre>
               <p class="doc">Renders an rMQR code onto the canvas. The rectangular symbol (quiet zone included) is drawn with a uniform module scale and centered in area (letterbox); the whole area receives the background.</p>
               <details class="notes" data-text="rmqr has one finder pattern and no error-correction headroom for overlays, so there are no icon or finder-shape options. module runs are merged as for the other symbologies (see render ).">
@@ -1448,7 +1451,7 @@
           </div>
         </article>
         <article class="type" id="SkiaSharp.QrCode.QRCodeVersionRange" data-name="skiasharp.qrcode.qrcodeversionrange" data-text="skiasharp.qrcode.qrcodeversionrange public readonly struct qrcodeversionrange : iequatable&lt;qrcodeversionrange&gt; the standard qr versions a generator may choose from: the smallest one in the range that holds the content is used. a fixed version is exactly , the degenerate case, rather than a separate setting. both bounds are inclusive, unlike range whose end is exclusive. that is why 1..40 is not usable here: it would read as 1 to 40 and mean 1 to 39. constant public const int maxversion; the highest version defined by iso/iec 18004.  constant public const int minversion; the lowest version defined by iso/iec 18004.  constructor public qrcodeversionrange(int min, int max); an inclusive range from min to max .  property public bool isany { get; } whether this range constrains nothing (the default).  property public bool isexact { get; } whether this range pins a single version.  property public int max { get; } the highest permitted version (40 when unbounded above).  property public int min { get; } the lowest permitted version (1 when unbounded below).  property public static qrcodeversionrange any { get; } every version, 1 to 40. identical to default.  method public bool contains(int version); whether version falls inside this range.  method public override string tostring();  method public static qrcodeversionrange atleast(int version); version or larger.  method public static qrcodeversionrange atmost(int version); version or smaller.  method public static qrcodeversionrange between(int min, int max); an inclusive range from min to max .  method public static qrcodeversionrange exactly(int version); exactly version , with no automatic selection.  operator public static qrcodeversionrange op_implicit(int version); a single version, as exactly . lets an option set read version = 15.  operator public static qrcodeversionrange op_implicit(int? version); a single version, or any when there is none. lets a caller whose version is optional pass it through without branching. -1 is not accepted as a second spelling of any : a mistyped or defaulted value must fail rather than silently produce an automatically sized symbol.">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeVersionRange" aria-label="Link to SkiaSharp.QrCode.QRCodeVersionRange">#</a><span class="kind">struct</span> <span class="name">QRCodeVersionRange</span></h3>
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeVersionRange" aria-label="Link to SkiaSharp.QrCode.QRCodeVersionRange">#</a><span class="kind">struct</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeVersionRange.cs" title="View source file on GitHub" target="_blank" rel="noopener noreferrer">QRCodeVersionRange</a></h3>
           <pre class="sig"><code>public readonly struct QRCodeVersionRange : IEquatable&lt;QRCodeVersionRange&gt;</code></pre>
           <p class="doc">The Standard QR versions a generator may choose from: the smallest one in the range that holds the content is used. A fixed version is Exactly , the degenerate case, rather than a separate setting.</p>
           <details class="notes" data-text="both bounds are inclusive, unlike range whose end is exclusive. that is why 1..40 is not usable here: it would read as 1 to 40 and mean 1 to 39.">
@@ -1467,71 +1470,71 @@
               <p class="doc">The lowest version defined by ISO/IEC 18004.</p>
             </div>
             <div class="member" data-text="constructor public qrcodeversionrange(int min, int max); an inclusive range from min to max . ">
-              <h4><span class="kind">constructor</span> <span class="name">QRCodeVersionRange</span></h4>
+              <h4><span class="kind">constructor</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeVersionRange.cs#L29" title="View source on GitHub" target="_blank" rel="noopener noreferrer">QRCodeVersionRange</a></h4>
               <pre class="sig"><code>public QRCodeVersionRange(int min, int max);</code></pre>
               <p class="doc">An inclusive range from min to max .</p>
             </div>
             <div class="member" data-text="property public bool isany { get; } whether this range constrains nothing (the default). ">
-              <h4><span class="kind">property</span> <span class="name">IsAny</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeVersionRange.cs#L46" title="View source on GitHub" target="_blank" rel="noopener noreferrer">IsAny</a></h4>
               <pre class="sig"><code>public bool IsAny { get; }</code></pre>
               <p class="doc">Whether this range constrains nothing (the default).</p>
             </div>
             <div class="member" data-text="property public bool isexact { get; } whether this range pins a single version. ">
-              <h4><span class="kind">property</span> <span class="name">IsExact</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeVersionRange.cs#L49" title="View source on GitHub" target="_blank" rel="noopener noreferrer">IsExact</a></h4>
               <pre class="sig"><code>public bool IsExact { get; }</code></pre>
               <p class="doc">Whether this range pins a single version.</p>
             </div>
             <div class="member" data-text="property public int max { get; } the highest permitted version (40 when unbounded above). ">
-              <h4><span class="kind">property</span> <span class="name">Max</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeVersionRange.cs#L43" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Max</a></h4>
               <pre class="sig"><code>public int Max { get; }</code></pre>
               <p class="doc">The highest permitted version (40 when unbounded above).</p>
             </div>
             <div class="member" data-text="property public int min { get; } the lowest permitted version (1 when unbounded below). ">
-              <h4><span class="kind">property</span> <span class="name">Min</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeVersionRange.cs#L40" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Min</a></h4>
               <pre class="sig"><code>public int Min { get; }</code></pre>
               <p class="doc">The lowest permitted version (1 when unbounded below).</p>
             </div>
             <div class="member" data-text="property public static qrcodeversionrange any { get; } every version, 1 to 40. identical to default. ">
-              <h4><span class="kind">property</span> <span class="name">Any</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeVersionRange.cs#L52" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Any</a></h4>
               <pre class="sig"><code>public static QRCodeVersionRange Any { get; }</code></pre>
               <p class="doc">Every version, 1 to 40. Identical to default.</p>
             </div>
             <div class="member" data-text="method public bool contains(int version); whether version falls inside this range. ">
-              <h4><span class="kind">method</span> <span class="name">Contains</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeVersionRange.cs#L84" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Contains</a></h4>
               <pre class="sig"><code>public bool Contains(int version);</code></pre>
               <p class="doc">Whether version falls inside this range.</p>
             </div>
             <div class="member" data-text="method public override string tostring(); ">
-              <h4><span class="kind">method</span> <span class="name">ToString</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeVersionRange.cs#L87" title="View source on GitHub" target="_blank" rel="noopener noreferrer">ToString</a></h4>
               <pre class="sig"><code>public override string ToString();</code></pre>
             </div>
             <div class="member" data-text="method public static qrcodeversionrange atleast(int version); version or larger. ">
-              <h4><span class="kind">method</span> <span class="name">AtLeast</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeVersionRange.cs#L60" title="View source on GitHub" target="_blank" rel="noopener noreferrer">AtLeast</a></h4>
               <pre class="sig"><code>public static QRCodeVersionRange AtLeast(int version);</code></pre>
               <p class="doc">version or larger.</p>
             </div>
             <div class="member" data-text="method public static qrcodeversionrange atmost(int version); version or smaller. ">
-              <h4><span class="kind">method</span> <span class="name">AtMost</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeVersionRange.cs#L64" title="View source on GitHub" target="_blank" rel="noopener noreferrer">AtMost</a></h4>
               <pre class="sig"><code>public static QRCodeVersionRange AtMost(int version);</code></pre>
               <p class="doc">version or smaller.</p>
             </div>
             <div class="member" data-text="method public static qrcodeversionrange between(int min, int max); an inclusive range from min to max . ">
-              <h4><span class="kind">method</span> <span class="name">Between</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeVersionRange.cs#L68" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Between</a></h4>
               <pre class="sig"><code>public static QRCodeVersionRange Between(int min, int max);</code></pre>
               <p class="doc">An inclusive range from min to max .</p>
             </div>
             <div class="member" data-text="method public static qrcodeversionrange exactly(int version); exactly version , with no automatic selection. ">
-              <h4><span class="kind">method</span> <span class="name">Exactly</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeVersionRange.cs#L56" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Exactly</a></h4>
               <pre class="sig"><code>public static QRCodeVersionRange Exactly(int version);</code></pre>
               <p class="doc">Exactly version , with no automatic selection.</p>
             </div>
             <div class="member" data-text="operator public static qrcodeversionrange op_implicit(int version); a single version, as exactly . lets an option set read version = 15. ">
-              <h4><span class="kind">operator</span> <span class="name">op_Implicit</span></h4>
+              <h4><span class="kind">operator</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeVersionRange.cs#L72" title="View source on GitHub" target="_blank" rel="noopener noreferrer">op_Implicit</a></h4>
               <pre class="sig"><code>public static QRCodeVersionRange op_Implicit(int version);</code></pre>
               <p class="doc">A single version, as Exactly . Lets an option set read Version = 15.</p>
             </div>
             <div class="member" data-text="operator public static qrcodeversionrange op_implicit(int? version); a single version, or any when there is none. lets a caller whose version is optional pass it through without branching. -1 is not accepted as a second spelling of any : a mistyped or defaulted value must fail rather than silently produce an automatically sized symbol.">
-              <h4><span class="kind">operator</span> <span class="name">op_Implicit</span></h4>
+              <h4><span class="kind">operator</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/QRCodeVersionRange.cs#L81" title="View source on GitHub" target="_blank" rel="noopener noreferrer">op_Implicit</a></h4>
               <pre class="sig"><code>public static QRCodeVersionRange op_Implicit(int? version);</code></pre>
               <p class="doc">A single version, or Any when there is none.</p>
               <details class="notes" data-text="lets a caller whose version is optional pass it through without branching. -1 is not accepted as a second spelling of any : a mistyped or defaulted value must fail rather than silently produce an automatically sized symbol.">
@@ -1542,34 +1545,34 @@
           </div>
         </article>
         <article class="type" id="SkiaSharp.QrCode.RmQRCodeCalculatedSize" data-name="skiasharp.qrcode.rmqrcodecalculatedsize" data-text="skiasharp.qrcode.rmqrcodecalculatedsize public readonly struct rmqrcodecalculatedsize result of trygetrequiredbuffersize : the byte count of the byte-per-module matrix, its dimensions (quiet zone included) and the version that will be used.  property public rmqrversion version { get; } the rmqr version that will be generated (requested or automatically selected).  property public int buffersize { get; } required destination size in bytes ( width × height ).  property public int height { get; } matrix height in modules, quiet zone included.  property public int width { get; } matrix width in modules, quiet zone included. ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.RmQRCodeCalculatedSize" aria-label="Link to SkiaSharp.QrCode.RmQRCodeCalculatedSize">#</a><span class="kind">struct</span> <span class="name">RmQRCodeCalculatedSize</span></h3>
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.RmQRCodeCalculatedSize" aria-label="Link to SkiaSharp.QrCode.RmQRCodeCalculatedSize">#</a><span class="kind">struct</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeCalculatedSize.cs" title="View source file on GitHub" target="_blank" rel="noopener noreferrer">RmQRCodeCalculatedSize</a></h3>
           <pre class="sig"><code>public readonly struct RmQRCodeCalculatedSize</code></pre>
           <p class="doc">Result of TryGetRequiredBufferSize : the byte count of the byte-per-module matrix, its dimensions (quiet zone included) and the version that will be used.</p>
           <div class="members">
             <div class="member" data-text="property public rmqrversion version { get; } the rmqr version that will be generated (requested or automatically selected). ">
-              <h4><span class="kind">property</span> <span class="name">Version</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeCalculatedSize.cs#L28" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Version</a></h4>
               <pre class="sig"><code>public RmQRVersion Version { get; }</code></pre>
               <p class="doc">The rMQR version that will be generated (requested or automatically selected).</p>
             </div>
             <div class="member" data-text="property public int buffersize { get; } required destination size in bytes ( width × height ). ">
-              <h4><span class="kind">property</span> <span class="name">BufferSize</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeCalculatedSize.cs#L19" title="View source on GitHub" target="_blank" rel="noopener noreferrer">BufferSize</a></h4>
               <pre class="sig"><code>public int BufferSize { get; }</code></pre>
               <p class="doc">Required destination size in bytes ( Width × Height ).</p>
             </div>
             <div class="member" data-text="property public int height { get; } matrix height in modules, quiet zone included. ">
-              <h4><span class="kind">property</span> <span class="name">Height</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeCalculatedSize.cs#L25" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Height</a></h4>
               <pre class="sig"><code>public int Height { get; }</code></pre>
               <p class="doc">Matrix height in modules, quiet zone included.</p>
             </div>
             <div class="member" data-text="property public int width { get; } matrix width in modules, quiet zone included. ">
-              <h4><span class="kind">property</span> <span class="name">Width</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeCalculatedSize.cs#L22" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Width</a></h4>
               <pre class="sig"><code>public int Width { get; }</code></pre>
               <p class="doc">Matrix width in modules, quiet zone included.</p>
             </div>
           </div>
         </article>
         <article class="type" id="SkiaSharp.QrCode.RmQRCodeData" data-name="skiasharp.qrcode.rmqrcodedata" data-text="skiasharp.qrcode.rmqrcodedata public class rmqrcodedata represents rmqr code data as a 2d boolean matrix (versions r7x43-r17x139, rectangular: 7-17 modules high, 27-139 modules wide). storage mirrors microqrcodedata : core modules only (no quiet zone), bit-packed msb-first in flat row-major order; the quiet zone is virtual and always reads light. serialization uses the &quot;qrx&quot; container: &quot;qrx&quot; + symbol type (1 byte, 2 = rmqr) + width (1 byte) + height (1 byte) + packed core bits. micro qr (symbol type 1) and the legacy standard qr &quot;qrr&quot; streams are rejected. constructor public rmqrcodedata(readonlyspan&lt;byte&gt; rawdata, int quietzonesize);  constructor public rmqrcodedata(rmqrversion version, int quietzonesize); initializes an empty (all light) matrix for the specified version.  constructor public rmqrcodedata(byte[] rawdata, int quietzonesize); deserializes rmqr data previously produced by getrawdata .  property public rmqrversion version { get; } gets the rmqr version (r7x43-r17x139).  indexer public bool this[int row, int col] { get; } gets the module state at the specified position (quiet zone included). quiet zone positions always read false.  property public int height { get; } gets the matrix height in modules, including the quiet zone.  property public int width { get; } gets the matrix width in modules, including the quiet zone.  method public modulerect[] getmodulerectangles(); gets the dark modules as merged rectangles in module coordinates, for rendering with any graphics api without skiasharp (svg path data, draw calls, vector output). coordinates use the same space as the indexer (this[row, col]): one unit is one module, origin at the top-left including the quiet zone, x is the column and y is the row. consumers scale by the pixel size of one module; width and height give the total extent in modules. three properties are contractual: rectangles never overlap, cover only dark modules, and cover every dark module. the decomposition shape and ordering are unspecified and may change between versions (currently maximal horizontal runs in row-major order, the same merge the built-in renderer draws). method public bool trygetmodulerectangles(span&lt;modulerect&gt; destination, out int written); writes the dark modules as merged rectangles into a caller-provided buffer. same contract as getmodulerectangles without allocations.  method public byte[] getrawdata(); serializes the core modules (quiet zone excluded) to a new byte array.  method public int getmodulerectanglesmaxcount(); gets an upper bound on the number of rectangles getmodulerectangles can return, suitable for sizing a pooled buffer for trygetmodulerectangles . o(1), no matrix scan.  method public int getrawdata(ibufferwriter&lt;byte&gt; writer); writes the serialized data to the specified buffer writer without intermediate allocation.  method public int getrawdatasize(); gets the serialized size in bytes (&quot;qrx&quot; header + packed core bits). ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.RmQRCodeData" aria-label="Link to SkiaSharp.QrCode.RmQRCodeData">#</a><span class="kind">class</span> <span class="name">RmQRCodeData</span></h3>
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.RmQRCodeData" aria-label="Link to SkiaSharp.QrCode.RmQRCodeData">#</a><span class="kind">class</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeData.cs" title="View source file on GitHub" target="_blank" rel="noopener noreferrer">RmQRCodeData</a></h3>
           <pre class="sig"><code>public class RmQRCodeData</code></pre>
           <p class="doc">Represents rMQR code data as a 2D boolean matrix (versions R7x43-R17x139, rectangular: 7-17 modules high, 27-139 modules wide).</p>
           <details class="notes" data-text="storage mirrors microqrcodedata : core modules only (no quiet zone), bit-packed msb-first in flat row-major order; the quiet zone is virtual and always reads light. serialization uses the &quot;qrx&quot; container: &quot;qrx&quot; + symbol type (1 byte, 2 = rmqr) + width (1 byte) + height (1 byte) + packed core bits. micro qr (symbol type 1) and the legacy standard qr &quot;qrr&quot; streams are rejected.">
@@ -1578,41 +1581,41 @@
           </details>
           <div class="members">
             <div class="member" data-text="constructor public rmqrcodedata(readonlyspan&lt;byte&gt; rawdata, int quietzonesize); ">
-              <h4><span class="kind">constructor</span> <span class="name">RmQRCodeData</span></h4>
+              <h4><span class="kind">constructor</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeData.cs#L99" title="View source on GitHub" target="_blank" rel="noopener noreferrer">RmQRCodeData</a></h4>
               <pre class="sig"><code>public RmQRCodeData(ReadOnlySpan&lt;byte&gt; rawData, int quietZoneSize);</code></pre>
             </div>
             <div class="member" data-text="constructor public rmqrcodedata(rmqrversion version, int quietzonesize); initializes an empty (all light) matrix for the specified version. ">
-              <h4><span class="kind">constructor</span> <span class="name">RmQRCodeData</span></h4>
+              <h4><span class="kind">constructor</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeData.cs#L71" title="View source on GitHub" target="_blank" rel="noopener noreferrer">RmQRCodeData</a></h4>
               <pre class="sig"><code>public RmQRCodeData(RmQRVersion version, int quietZoneSize);</code></pre>
               <p class="doc">Initializes an empty (all light) matrix for the specified version.</p>
             </div>
             <div class="member" data-text="constructor public rmqrcodedata(byte[] rawdata, int quietzonesize); deserializes rmqr data previously produced by getrawdata . ">
-              <h4><span class="kind">constructor</span> <span class="name">RmQRCodeData</span></h4>
+              <h4><span class="kind">constructor</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeData.cs#L94" title="View source on GitHub" target="_blank" rel="noopener noreferrer">RmQRCodeData</a></h4>
               <pre class="sig"><code>public RmQRCodeData(byte[] rawData, int quietZoneSize);</code></pre>
               <p class="doc">Deserializes rMQR data previously produced by GetRawData .</p>
             </div>
             <div class="member" data-text="property public rmqrversion version { get; } gets the rmqr version (r7x43-r17x139). ">
-              <h4><span class="kind">property</span> <span class="name">Version</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeData.cs#L35" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Version</a></h4>
               <pre class="sig"><code>public RmQRVersion Version { get; }</code></pre>
               <p class="doc">Gets the rMQR version (R7x43-R17x139).</p>
             </div>
             <div class="member" data-text="indexer public bool this[int row, int col] { get; } gets the module state at the specified position (quiet zone included). quiet zone positions always read false. ">
-              <h4><span class="kind">indexer</span> <span class="name">this[int row, int col]</span></h4>
+              <h4><span class="kind">indexer</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeData.cs#L48" title="View source on GitHub" target="_blank" rel="noopener noreferrer">this[int row, int col]</a></h4>
               <pre class="sig"><code>public bool this[int row, int col] { get; }</code></pre>
               <p class="doc">Gets the module state at the specified position (quiet zone included). Quiet zone positions always read false.</p>
             </div>
             <div class="member" data-text="property public int height { get; } gets the matrix height in modules, including the quiet zone. ">
-              <h4><span class="kind">property</span> <span class="name">Height</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeData.cs#L32" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Height</a></h4>
               <pre class="sig"><code>public int Height { get; }</code></pre>
               <p class="doc">Gets the matrix height in modules, including the quiet zone.</p>
             </div>
             <div class="member" data-text="property public int width { get; } gets the matrix width in modules, including the quiet zone. ">
-              <h4><span class="kind">property</span> <span class="name">Width</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeData.cs#L29" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Width</a></h4>
               <pre class="sig"><code>public int Width { get; }</code></pre>
               <p class="doc">Gets the matrix width in modules, including the quiet zone.</p>
             </div>
             <div class="member" data-text="method public modulerect[] getmodulerectangles(); gets the dark modules as merged rectangles in module coordinates, for rendering with any graphics api without skiasharp (svg path data, draw calls, vector output). coordinates use the same space as the indexer (this[row, col]): one unit is one module, origin at the top-left including the quiet zone, x is the column and y is the row. consumers scale by the pixel size of one module; width and height give the total extent in modules. three properties are contractual: rectangles never overlap, cover only dark modules, and cover every dark module. the decomposition shape and ordering are unspecified and may change between versions (currently maximal horizontal runs in row-major order, the same merge the built-in renderer draws).">
-              <h4><span class="kind">method</span> <span class="name">GetModuleRectangles</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeData.cs#L210" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetModuleRectangles</a></h4>
               <pre class="sig"><code>public ModuleRect[] GetModuleRectangles();</code></pre>
               <p class="doc">Gets the dark modules as merged rectangles in module coordinates, for rendering with any graphics API without SkiaSharp (SVG path data, draw calls, vector output).</p>
               <details class="notes" data-text="coordinates use the same space as the indexer (this[row, col]): one unit is one module, origin at the top-left including the quiet zone, x is the column and y is the row. consumers scale by the pixel size of one module; width and height give the total extent in modules. three properties are contractual: rectangles never overlap, cover only dark modules, and cover every dark module. the decomposition shape and ordering are unspecified and may change between versions (currently maximal horizontal runs in row-major order, the same merge the built-in renderer draws).">
@@ -1621,61 +1624,61 @@
               </details>
             </div>
             <div class="member" data-text="method public bool trygetmodulerectangles(span&lt;modulerect&gt; destination, out int written); writes the dark modules as merged rectangles into a caller-provided buffer. same contract as getmodulerectangles without allocations. ">
-              <h4><span class="kind">method</span> <span class="name">TryGetModuleRectangles</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeData.cs#L223" title="View source on GitHub" target="_blank" rel="noopener noreferrer">TryGetModuleRectangles</a></h4>
               <pre class="sig"><code>public bool TryGetModuleRectangles(Span&lt;ModuleRect&gt; destination, out int written);</code></pre>
               <p class="doc">Writes the dark modules as merged rectangles into a caller-provided buffer. Same contract as GetModuleRectangles without allocations.</p>
             </div>
             <div class="member" data-text="method public byte[] getrawdata(); serializes the core modules (quiet zone excluded) to a new byte array. ">
-              <h4><span class="kind">method</span> <span class="name">GetRawData</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeData.cs#L151" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetRawData</a></h4>
               <pre class="sig"><code>public byte[] GetRawData();</code></pre>
               <p class="doc">Serializes the core modules (quiet zone excluded) to a new byte array.</p>
             </div>
             <div class="member" data-text="method public int getmodulerectanglesmaxcount(); gets an upper bound on the number of rectangles getmodulerectangles can return, suitable for sizing a pooled buffer for trygetmodulerectangles . o(1), no matrix scan. ">
-              <h4><span class="kind">method</span> <span class="name">GetModuleRectanglesMaxCount</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeData.cs#L187" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetModuleRectanglesMaxCount</a></h4>
               <pre class="sig"><code>public int GetModuleRectanglesMaxCount();</code></pre>
               <p class="doc">Gets an upper bound on the number of rectangles GetModuleRectangles can return, suitable for sizing a pooled buffer for TryGetModuleRectangles . O(1), no matrix scan.</p>
             </div>
             <div class="member" data-text="method public int getrawdata(ibufferwriter&lt;byte&gt; writer); writes the serialized data to the specified buffer writer without intermediate allocation. ">
-              <h4><span class="kind">method</span> <span class="name">GetRawData</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeData.cs#L163" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetRawData</a></h4>
               <pre class="sig"><code>public int GetRawData(IBufferWriter&lt;byte&gt; writer);</code></pre>
               <p class="doc">Writes the serialized data to the specified buffer writer without intermediate allocation.</p>
             </div>
             <div class="member" data-text="method public int getrawdatasize(); gets the serialized size in bytes (&quot;qrx&quot; header + packed core bits). ">
-              <h4><span class="kind">method</span> <span class="name">GetRawDataSize</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeData.cs#L145" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetRawDataSize</a></h4>
               <pre class="sig"><code>public int GetRawDataSize();</code></pre>
               <p class="doc">Gets the serialized size in bytes (&quot;QRX&quot; header + packed core bits).</p>
             </div>
           </div>
         </article>
         <article class="type" id="SkiaSharp.QrCode.RmQRCodeDecodeInfo" data-name="skiasharp.qrcode.rmqrcodedecodeinfo" data-text="skiasharp.qrcode.rmqrcodedecodeinfo public readonly struct rmqrcodedecodeinfo diagnostic information from an rmqr decode attempt ( rmqrcodedecoder ): status, and when the format information could be read, the version and ecc level plus the number of reed-solomon codeword corrections applied. rmqr has a single data mask, so there is no mask pattern to report.  property public qrcodedecodestatus status { get; } decode outcome; success when text was produced.  property public rmqrecclevel ecclevel { get; } the ecc level read from the format information (valid once the format decoded).  property public rmqrversion version { get; } the symbol version (from the physical dimensions), or 0 when the input is not an rmqr matrix.  property public int errorscorrected { get; } total reed-solomon codeword corrections across all blocks (0 for a clean symbol). ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.RmQRCodeDecodeInfo" aria-label="Link to SkiaSharp.QrCode.RmQRCodeDecodeInfo">#</a><span class="kind">struct</span> <span class="name">RmQRCodeDecodeInfo</span></h3>
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.RmQRCodeDecodeInfo" aria-label="Link to SkiaSharp.QrCode.RmQRCodeDecodeInfo">#</a><span class="kind">struct</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeDecodeInfo.cs" title="View source file on GitHub" target="_blank" rel="noopener noreferrer">RmQRCodeDecodeInfo</a></h3>
           <pre class="sig"><code>public readonly struct RmQRCodeDecodeInfo</code></pre>
           <p class="doc">Diagnostic information from an rMQR decode attempt ( RmQRCodeDecoder ): status, and when the format information could be read, the version and ECC level plus the number of Reed-Solomon codeword corrections applied. rMQR has a single data mask, so there is no mask pattern to report.</p>
           <div class="members">
             <div class="member" data-text="property public qrcodedecodestatus status { get; } decode outcome; success when text was produced. ">
-              <h4><span class="kind">property</span> <span class="name">Status</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeDecodeInfo.cs#L20" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Status</a></h4>
               <pre class="sig"><code>public QRCodeDecodeStatus Status { get; }</code></pre>
               <p class="doc">Decode outcome; Success when text was produced.</p>
             </div>
             <div class="member" data-text="property public rmqrecclevel ecclevel { get; } the ecc level read from the format information (valid once the format decoded). ">
-              <h4><span class="kind">property</span> <span class="name">EccLevel</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeDecodeInfo.cs#L26" title="View source on GitHub" target="_blank" rel="noopener noreferrer">EccLevel</a></h4>
               <pre class="sig"><code>public RmQREccLevel EccLevel { get; }</code></pre>
               <p class="doc">The ECC level read from the format information (valid once the format decoded).</p>
             </div>
             <div class="member" data-text="property public rmqrversion version { get; } the symbol version (from the physical dimensions), or 0 when the input is not an rmqr matrix. ">
-              <h4><span class="kind">property</span> <span class="name">Version</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeDecodeInfo.cs#L23" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Version</a></h4>
               <pre class="sig"><code>public RmQRVersion Version { get; }</code></pre>
               <p class="doc">The symbol version (from the physical dimensions), or 0 when the input is not an rMQR matrix.</p>
             </div>
             <div class="member" data-text="property public int errorscorrected { get; } total reed-solomon codeword corrections across all blocks (0 for a clean symbol). ">
-              <h4><span class="kind">property</span> <span class="name">ErrorsCorrected</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeDecodeInfo.cs#L29" title="View source on GitHub" target="_blank" rel="noopener noreferrer">ErrorsCorrected</a></h4>
               <pre class="sig"><code>public int ErrorsCorrected { get; }</code></pre>
               <p class="doc">Total Reed-Solomon codeword corrections across all blocks (0 for a clean symbol).</p>
             </div>
           </div>
         </article>
         <article class="type" id="SkiaSharp.QrCode.RmQRCodeDecoder" data-name="skiasharp.qrcode.rmqrcodedecoder" data-text="skiasharp.qrcode.rmqrcodedecoder public static class rmqrcodedecoder rmqr code (iso/iec 23941) decoder: module matrix → text. sibling of qrcodedecoder and microqrcodedecoder ; explicitly typed so standard qr scanning stays unaffected. matrix-level and image-level decoding ( trydecode / trydecodeimage ). every overload accepts an rmqr matrix with or without a light quiet zone: the dark bounding box (finder corner top-left, sub-finder corner bottom-right, timing patterns on all four edges) locates the core, so uniform and asymmetric borders are stripped automatically. reed-solomon corrections are applied at full block strength (⌊ecc/2⌋ per block) and reported in errorscorrected . numeric, alphanumeric and byte segments (iso-8859-1 / utf-8, with or without eci) are supported, plus kanji segments decoded as jis x 0208; the generator never emits kanji, so it is a read-only mode here. a kanji cell outside the jis x 0208 repertoire fails the whole symbol with unmappedcharacter rather than substituting a replacement character. method public static bool trydecode(readonlyspan&lt;byte&gt; modules, int width, int height, span&lt;char&gt; destination, out int charswritten, out rmqrcodedecodeinfo info); decodes the text content from a module matrix into a caller-provided buffer without per-call heap allocation.  method public static bool trydecode(readonlyspan&lt;byte&gt; modules, int width, int height, out string text, out rmqrcodedecodeinfo info); decodes the text content from a module matrix.  method public static bool trydecode(rmqrcodedata data, out string text); decodes the text content of an rmqrcodedata matrix.  method public static bool trydecode(rmqrcodedata data, out string text, out rmqrcodedecodeinfo info); decodes the text content of an rmqrcodedata matrix with diagnostics.  method public static bool trydecode(skbitmap bitmap, out string text); detects and decodes an rmqr code from a bitmap image. targets clean, well-lit images such as screenshots, rendered symbols and scans: arbitrary rotation, mirroring, reflectance reversal (light-on-dark), uniform or non-uniform scaling, translation and mild perspective distortion are handled. strong perspective, uneven lighting and blur are out of scope. method public static bool trydecode(skbitmap bitmap, out string text, out rmqrcodedecodeinfo info); detects and decodes an rmqr code from a bitmap image, with diagnostic information. see trydecode for the supported image envelope. method public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, span&lt;char&gt; destination, out int charswritten, out rmqrcodedecodeinfo info); detects and decodes an rmqr code from grayscale image pixels into a caller-provided buffer without per-call heap allocation.  method public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, out string text, out rmqrcodedecodeinfo info); detects and decodes an rmqr code from grayscale image pixels.  method public static int getmaxdecodedlength(rmqrversion version); calculates the maximum possible decoded character count for an rmqr version, across ecc levels and encoding modes. use to size the destination buffer for the allocation-free trydecode overload. ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.RmQRCodeDecoder" aria-label="Link to SkiaSharp.QrCode.RmQRCodeDecoder">#</a><span class="kind">class</span> <span class="name">RmQRCodeDecoder</span></h3>
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.RmQRCodeDecoder" aria-label="Link to SkiaSharp.QrCode.RmQRCodeDecoder">#</a><span class="kind">class</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeDecoder.cs" title="View source file on GitHub" target="_blank" rel="noopener noreferrer">RmQRCodeDecoder</a></h3>
           <pre class="sig"><code>public static class RmQRCodeDecoder</code></pre>
           <p class="doc">rMQR Code (ISO/IEC 23941) decoder: module matrix → text. Sibling of QRCodeDecoder and MicroQRCodeDecoder ; explicitly typed so Standard QR scanning stays unaffected. Matrix-level and image-level decoding ( TryDecode / TryDecodeImage ).</p>
           <details class="notes" data-text="every overload accepts an rmqr matrix with or without a light quiet zone: the dark bounding box (finder corner top-left, sub-finder corner bottom-right, timing patterns on all four edges) locates the core, so uniform and asymmetric borders are stripped automatically. reed-solomon corrections are applied at full block strength (⌊ecc/2⌋ per block) and reported in errorscorrected . numeric, alphanumeric and byte segments (iso-8859-1 / utf-8, with or without eci) are supported, plus kanji segments decoded as jis x 0208; the generator never emits kanji, so it is a read-only mode here. a kanji cell outside the jis x 0208 repertoire fails the whole symbol with unmappedcharacter rather than substituting a replacement character.">
@@ -1684,27 +1687,27 @@
           </details>
           <div class="members">
             <div class="member" data-text="method public static bool trydecode(readonlyspan&lt;byte&gt; modules, int width, int height, span&lt;char&gt; destination, out int charswritten, out rmqrcodedecodeinfo info); decodes the text content from a module matrix into a caller-provided buffer without per-call heap allocation. ">
-              <h4><span class="kind">method</span> <span class="name">TryDecode</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeDecoder.cs#L119" title="View source on GitHub" target="_blank" rel="noopener noreferrer">TryDecode</a></h4>
               <pre class="sig"><code>public static bool TryDecode(ReadOnlySpan&lt;byte&gt; modules, int width, int height, Span&lt;char&gt; destination, out int charsWritten, out RmQRCodeDecodeInfo info);</code></pre>
               <p class="doc">Decodes the text content from a module matrix into a caller-provided buffer without per-call heap allocation.</p>
             </div>
             <div class="member" data-text="method public static bool trydecode(readonlyspan&lt;byte&gt; modules, int width, int height, out string text, out rmqrcodedecodeinfo info); decodes the text content from a module matrix. ">
-              <h4><span class="kind">method</span> <span class="name">TryDecode</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeDecoder.cs#L81" title="View source on GitHub" target="_blank" rel="noopener noreferrer">TryDecode</a></h4>
               <pre class="sig"><code>public static bool TryDecode(ReadOnlySpan&lt;byte&gt; modules, int width, int height, out string text, out RmQRCodeDecodeInfo info);</code></pre>
               <p class="doc">Decodes the text content from a module matrix.</p>
             </div>
             <div class="member" data-text="method public static bool trydecode(rmqrcodedata data, out string text); decodes the text content of an rmqrcodedata matrix. ">
-              <h4><span class="kind">method</span> <span class="name">TryDecode</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeDecoder.cs#L35" title="View source on GitHub" target="_blank" rel="noopener noreferrer">TryDecode</a></h4>
               <pre class="sig"><code>public static bool TryDecode(RmQRCodeData data, out string text);</code></pre>
               <p class="doc">Decodes the text content of an RmQRCodeData matrix.</p>
             </div>
             <div class="member" data-text="method public static bool trydecode(rmqrcodedata data, out string text, out rmqrcodedecodeinfo info); decodes the text content of an rmqrcodedata matrix with diagnostics. ">
-              <h4><span class="kind">method</span> <span class="name">TryDecode</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeDecoder.cs#L46" title="View source on GitHub" target="_blank" rel="noopener noreferrer">TryDecode</a></h4>
               <pre class="sig"><code>public static bool TryDecode(RmQRCodeData data, out string text, out RmQRCodeDecodeInfo info);</code></pre>
               <p class="doc">Decodes the text content of an RmQRCodeData matrix with diagnostics.</p>
             </div>
             <div class="member" data-text="method public static bool trydecode(skbitmap bitmap, out string text); detects and decodes an rmqr code from a bitmap image. targets clean, well-lit images such as screenshots, rendered symbols and scans: arbitrary rotation, mirroring, reflectance reversal (light-on-dark), uniform or non-uniform scaling, translation and mild perspective distortion are handled. strong perspective, uneven lighting and blur are out of scope.">
-              <h4><span class="kind">method</span> <span class="name">TryDecode</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeDecoder.cs#L159" title="View source on GitHub" target="_blank" rel="noopener noreferrer">TryDecode</a></h4>
               <pre class="sig"><code>public static bool TryDecode(SKBitmap bitmap, out string text);</code></pre>
               <p class="doc">Detects and decodes an rMQR Code from a bitmap image.</p>
               <details class="notes" data-text="targets clean, well-lit images such as screenshots, rendered symbols and scans: arbitrary rotation, mirroring, reflectance reversal (light-on-dark), uniform or non-uniform scaling, translation and mild perspective distortion are handled. strong perspective, uneven lighting and blur are out of scope.">
@@ -1713,7 +1716,7 @@
               </details>
             </div>
             <div class="member" data-text="method public static bool trydecode(skbitmap bitmap, out string text, out rmqrcodedecodeinfo info); detects and decodes an rmqr code from a bitmap image, with diagnostic information. see trydecode for the supported image envelope.">
-              <h4><span class="kind">method</span> <span class="name">TryDecode</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeDecoder.cs#L173" title="View source on GitHub" target="_blank" rel="noopener noreferrer">TryDecode</a></h4>
               <pre class="sig"><code>public static bool TryDecode(SKBitmap bitmap, out string text, out RmQRCodeDecodeInfo info);</code></pre>
               <p class="doc">Detects and decodes an rMQR Code from a bitmap image, with diagnostic information.</p>
               <details class="notes" data-text="see trydecode for the supported image envelope.">
@@ -1722,24 +1725,24 @@
               </details>
             </div>
             <div class="member" data-text="method public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, span&lt;char&gt; destination, out int charswritten, out rmqrcodedecodeinfo info); detects and decodes an rmqr code from grayscale image pixels into a caller-provided buffer without per-call heap allocation. ">
-              <h4><span class="kind">method</span> <span class="name">TryDecodeImage</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeDecoder.cs#L243" title="View source on GitHub" target="_blank" rel="noopener noreferrer">TryDecodeImage</a></h4>
               <pre class="sig"><code>public static bool TryDecodeImage(ReadOnlySpan&lt;byte&gt; luminance, int width, int height, Span&lt;char&gt; destination, out int charsWritten, out RmQRCodeDecodeInfo info);</code></pre>
               <p class="doc">Detects and decodes an rMQR Code from grayscale image pixels into a caller-provided buffer without per-call heap allocation.</p>
             </div>
             <div class="member" data-text="method public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, out string text, out rmqrcodedecodeinfo info); detects and decodes an rmqr code from grayscale image pixels. ">
-              <h4><span class="kind">method</span> <span class="name">TryDecodeImage</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeDecoder.cs#L211" title="View source on GitHub" target="_blank" rel="noopener noreferrer">TryDecodeImage</a></h4>
               <pre class="sig"><code>public static bool TryDecodeImage(ReadOnlySpan&lt;byte&gt; luminance, int width, int height, out string text, out RmQRCodeDecodeInfo info);</code></pre>
               <p class="doc">Detects and decodes an rMQR Code from grayscale image pixels.</p>
             </div>
             <div class="member" data-text="method public static int getmaxdecodedlength(rmqrversion version); calculates the maximum possible decoded character count for an rmqr version, across ecc levels and encoding modes. use to size the destination buffer for the allocation-free trydecode overload. ">
-              <h4><span class="kind">method</span> <span class="name">GetMaxDecodedLength</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeDecoder.cs#L259" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetMaxDecodedLength</a></h4>
               <pre class="sig"><code>public static int GetMaxDecodedLength(RmQRVersion version);</code></pre>
               <p class="doc">Calculates the maximum possible decoded character count for an rMQR version, across ECC levels and encoding modes. Use to size the destination buffer for the allocation-free TryDecode overload.</p>
             </div>
           </div>
         </article>
         <article class="type" id="SkiaSharp.QrCode.RmQRCodeGenerator" data-name="skiasharp.qrcode.rmqrcodegenerator" data-text="skiasharp.qrcode.rmqrcodegenerator public static class rmqrcodegenerator rmqr code (iso/iec 23941, r7x43-r17x139) generator: text → rectangular module matrix. sibling of qrcodegenerator and microqrcodegenerator with rmqr-typed version, ecc and fit parameters. version selection: an exact rmqrversion , or automatic fit among the versions that hold the content by rmqrfitstrategy (default minimizearea : fewest modules, the choice both reference encoders make; note it can prefer a taller, narrower symbol, e.g. 12 digits at m give r11x27 (297 modules) rather than r7x43 (301); use minimizeheight or a fixed rmqrheight for the flattest symbol), optionally restricted to one height. modes: numeric, alphanumeric and byte. byte mode emits eci assignment 3 for iso-8859-1 and assignment 26 for utf-8 (automatically selected by default, or explicitly requested). kanji is not written, use utf-8 instead; rmqrcodedecoder does read the kanji segments other encoders produce, so the two directions are deliberately asymmetric. the quiet zone defaults to the iso/iec 23941 value of 2 modules. method public static rmqrcodedata creatermqrcode(readonlyspan&lt;char&gt; textspan, rmqrecclevel ecclevel, in rmqrcodegeneratoroptions options = null);  method public static rmqrcodedata creatermqrcode(string plaintext, rmqrecclevel ecclevel, in rmqrcodegeneratoroptions options = null); creates an rmqr code from the provided plain text.  method public static bool trygetrequiredbuffersize(readonlyspan&lt;char&gt; text, rmqrecclevel ecclevel, out rmqrcodecalculatedsize size, in rmqrcodegeneratoroptions options = null); calculates the required buffer size, dimensions and version for encoding the specified text as an rmqr code, reporting a content overflow as false rather than as an exception. false means the content does not fit, and nothing else: argument errors throw (rationale: specs/rmqr-encoder.md). rmqr holds 5-150 bytes, so an overflow is an ordinary answer here rather than a defect, which is why this is the only sizing method on this type. pass the same options you will encode with: segmentation and eci can select different versions, so a buffer sized for one can be too small for the other. method public static int creatermqrcode(readonlyspan&lt;char&gt; textspan, rmqrecclevel ecclevel, span&lt;byte&gt; destination, in rmqrcodegeneratoroptions options = null); creates an rmqr code and writes the module matrix into the caller-provided buffer without per-call heap allocation. output format matches the other generators: one byte per module (0 = light, 1 = dark), flat row-major over the full width, quiet zone included. use trygetrequiredbuffersize to size the destination.">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.RmQRCodeGenerator" aria-label="Link to SkiaSharp.QrCode.RmQRCodeGenerator">#</a><span class="kind">class</span> <span class="name">RmQRCodeGenerator</span></h3>
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.RmQRCodeGenerator" aria-label="Link to SkiaSharp.QrCode.RmQRCodeGenerator">#</a><span class="kind">class</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeGenerator.cs" title="View source file on GitHub" target="_blank" rel="noopener noreferrer">RmQRCodeGenerator</a></h3>
           <pre class="sig"><code>public static class RmQRCodeGenerator</code></pre>
           <p class="doc">rMQR Code (ISO/IEC 23941, R7x43-R17x139) generator: text → rectangular module matrix. Sibling of QRCodeGenerator and MicroQRCodeGenerator with rMQR-typed version, ECC and fit parameters.</p>
           <details class="notes" data-text="version selection: an exact rmqrversion , or automatic fit among the versions that hold the content by rmqrfitstrategy (default minimizearea : fewest modules, the choice both reference encoders make; note it can prefer a taller, narrower symbol, e.g. 12 digits at m give r11x27 (297 modules) rather than r7x43 (301); use minimizeheight or a fixed rmqrheight for the flattest symbol), optionally restricted to one height. modes: numeric, alphanumeric and byte. byte mode emits eci assignment 3 for iso-8859-1 and assignment 26 for utf-8 (automatically selected by default, or explicitly requested). kanji is not written, use utf-8 instead; rmqrcodedecoder does read the kanji segments other encoders produce, so the two directions are deliberately asymmetric. the quiet zone defaults to the iso/iec 23941 value of 2 modules.">
@@ -1748,16 +1751,16 @@
           </details>
           <div class="members">
             <div class="member" data-text="method public static rmqrcodedata creatermqrcode(readonlyspan&lt;char&gt; textspan, rmqrecclevel ecclevel, in rmqrcodegeneratoroptions options = null); ">
-              <h4><span class="kind">method</span> <span class="name">CreateRmQRCode</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeGenerator.cs#L55" title="View source on GitHub" target="_blank" rel="noopener noreferrer">CreateRmQRCode</a></h4>
               <pre class="sig"><code>public static RmQRCodeData CreateRmQRCode(ReadOnlySpan&lt;char&gt; textSpan, RmQREccLevel eccLevel, in RmQRCodeGeneratorOptions options = null);</code></pre>
             </div>
             <div class="member" data-text="method public static rmqrcodedata creatermqrcode(string plaintext, rmqrecclevel ecclevel, in rmqrcodegeneratoroptions options = null); creates an rmqr code from the provided plain text. ">
-              <h4><span class="kind">method</span> <span class="name">CreateRmQRCode</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeGenerator.cs#L48" title="View source on GitHub" target="_blank" rel="noopener noreferrer">CreateRmQRCode</a></h4>
               <pre class="sig"><code>public static RmQRCodeData CreateRmQRCode(string plainText, RmQREccLevel eccLevel, in RmQRCodeGeneratorOptions options = null);</code></pre>
               <p class="doc">Creates an rMQR code from the provided plain text.</p>
             </div>
             <div class="member" data-text="method public static bool trygetrequiredbuffersize(readonlyspan&lt;char&gt; text, rmqrecclevel ecclevel, out rmqrcodecalculatedsize size, in rmqrcodegeneratoroptions options = null); calculates the required buffer size, dimensions and version for encoding the specified text as an rmqr code, reporting a content overflow as false rather than as an exception. false means the content does not fit, and nothing else: argument errors throw (rationale: specs/rmqr-encoder.md). rmqr holds 5-150 bytes, so an overflow is an ordinary answer here rather than a defect, which is why this is the only sizing method on this type. pass the same options you will encode with: segmentation and eci can select different versions, so a buffer sized for one can be too small for the other.">
-              <h4><span class="kind">method</span> <span class="name">TryGetRequiredBufferSize</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeGenerator.cs#L166" title="View source on GitHub" target="_blank" rel="noopener noreferrer">TryGetRequiredBufferSize</a></h4>
               <pre class="sig"><code>public static bool TryGetRequiredBufferSize(ReadOnlySpan&lt;char&gt; text, RmQREccLevel eccLevel, out RmQRCodeCalculatedSize size, in RmQRCodeGeneratorOptions options = null);</code></pre>
               <p class="doc">Calculates the required buffer size, dimensions and version for encoding the specified text as an rMQR code, reporting a content overflow as false rather than as an exception.</p>
               <details class="notes" data-text="false means the content does not fit, and nothing else: argument errors throw (rationale: specs/rmqr-encoder.md). rmqr holds 5-150 bytes, so an overflow is an ordinary answer here rather than a defect, which is why this is the only sizing method on this type. pass the same options you will encode with: segmentation and eci can select different versions, so a buffer sized for one can be too small for the other.">
@@ -1766,7 +1769,7 @@
               </details>
             </div>
             <div class="member" data-text="method public static int creatermqrcode(readonlyspan&lt;char&gt; textspan, rmqrecclevel ecclevel, span&lt;byte&gt; destination, in rmqrcodegeneratoroptions options = null); creates an rmqr code and writes the module matrix into the caller-provided buffer without per-call heap allocation. output format matches the other generators: one byte per module (0 = light, 1 = dark), flat row-major over the full width, quiet zone included. use trygetrequiredbuffersize to size the destination.">
-              <h4><span class="kind">method</span> <span class="name">CreateRmQRCode</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeGenerator.cs#L101" title="View source on GitHub" target="_blank" rel="noopener noreferrer">CreateRmQRCode</a></h4>
               <pre class="sig"><code>public static int CreateRmQRCode(ReadOnlySpan&lt;char&gt; textSpan, RmQREccLevel eccLevel, Span&lt;byte&gt; destination, in RmQRCodeGeneratorOptions options = null);</code></pre>
               <p class="doc">Creates an rMQR code and writes the module matrix into the caller-provided buffer without per-call heap allocation.</p>
               <details class="notes" data-text="output format matches the other generators: one byte per module (0 = light, 1 = dark), flat row-major over the full width, quiet zone included. use trygetrequiredbuffersize to size the destination.">
@@ -1777,7 +1780,7 @@
           </div>
         </article>
         <article class="type" id="SkiaSharp.QrCode.RmQRCodeGeneratorOptions" data-name="skiasharp.qrcode.rmqrcodegeneratoroptions" data-text="skiasharp.qrcode.rmqrcodegeneratoroptions public readonly struct rmqrcodegeneratoroptions : iequatable&lt;rmqrcodegeneratoroptions&gt; optional settings for rmqrcodegenerator . default is the complete default configuration and is what an omitted argument sends, so the shortest correct call is creatermqrcode(text, ecclevel). rmqr specific rather than shared: version is a different type in each symbology, quietzonesize has a different specified default, and fitstrategy , height and segmentation have no meaning outside rmqr. there is no version range here because rmqr's 32 versions are not totally ordered; fit is constrained by strategy and height instead. property public ecimode ecimode { get; init; } character encoding declaration. the default auto-detects ascii (no eci), iso-8859-1 (assignment 3) or utf-8 (assignment 26) from the content. only default , iso8859_1 and utf8 are accepted. declaring latin-1 over content it cannot represent throws rather than silently re-encoding. property public rmqrfitstrategy fitstrategy { get; init; } how to choose among the versions that hold the content. defaults to minimizearea , the choice both reference encoders make.  property public rmqrheight? height { get; init; } restrict automatic fitting to one symbol height, or null (the default) to consider every height. must agree with version when both are set.  property public rmqrsegmentation segmentation { get; init; } whether to split the content into mixed-mode segments. defaults to single . size a destination buffer with the same value you encode with: the two modes can select different versions.  property public rmqrversion? version { get; init; } a specific version, or null (the default) to fit one automatically by fitstrategy and height .  property public int quietzonesize { get; init; } quiet zone width in modules. defaults to 2, the iso/iec 23941 value; 0 is valid.  property public static rmqrcodegeneratoroptions default { get; } the default configuration, identical to default. ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.RmQRCodeGeneratorOptions" aria-label="Link to SkiaSharp.QrCode.RmQRCodeGeneratorOptions">#</a><span class="kind">struct</span> <span class="name">RmQRCodeGeneratorOptions</span></h3>
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.RmQRCodeGeneratorOptions" aria-label="Link to SkiaSharp.QrCode.RmQRCodeGeneratorOptions">#</a><span class="kind">struct</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeGeneratorOptions.cs" title="View source file on GitHub" target="_blank" rel="noopener noreferrer">RmQRCodeGeneratorOptions</a></h3>
           <pre class="sig"><code>public readonly struct RmQRCodeGeneratorOptions : IEquatable&lt;RmQRCodeGeneratorOptions&gt;</code></pre>
           <p class="doc">Optional settings for RmQRCodeGenerator . default is the complete default configuration and is what an omitted argument sends, so the shortest correct call is CreateRmQRCode(text, eccLevel).</p>
           <details class="notes" data-text="rmqr specific rather than shared: version is a different type in each symbology, quietzonesize has a different specified default, and fitstrategy , height and segmentation have no meaning outside rmqr. there is no version range here because rmqr's 32 versions are not totally ordered; fit is constrained by strategy and height instead.">
@@ -1786,7 +1789,7 @@
           </details>
           <div class="members">
             <div class="member" data-text="property public ecimode ecimode { get; init; } character encoding declaration. the default auto-detects ascii (no eci), iso-8859-1 (assignment 3) or utf-8 (assignment 26) from the content. only default , iso8859_1 and utf8 are accepted. declaring latin-1 over content it cannot represent throws rather than silently re-encoding.">
-              <h4><span class="kind">property</span> <span class="name">EciMode</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeGeneratorOptions.cs#L37" title="View source on GitHub" target="_blank" rel="noopener noreferrer">EciMode</a></h4>
               <pre class="sig"><code>public EciMode EciMode { get; init; }</code></pre>
               <p class="doc">Character encoding declaration. The default auto-detects ASCII (no ECI), ISO-8859-1 (assignment 3) or UTF-8 (assignment 26) from the content.</p>
               <details class="notes" data-text="only default , iso8859_1 and utf8 are accepted. declaring latin-1 over content it cannot represent throws rather than silently re-encoding.">
@@ -1795,32 +1798,32 @@
               </details>
             </div>
             <div class="member" data-text="property public rmqrfitstrategy fitstrategy { get; init; } how to choose among the versions that hold the content. defaults to minimizearea , the choice both reference encoders make. ">
-              <h4><span class="kind">property</span> <span class="name">FitStrategy</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeGeneratorOptions.cs#L49" title="View source on GitHub" target="_blank" rel="noopener noreferrer">FitStrategy</a></h4>
               <pre class="sig"><code>public RmQRFitStrategy FitStrategy { get; init; }</code></pre>
               <p class="doc">How to choose among the versions that hold the content. Defaults to MinimizeArea , the choice both reference encoders make.</p>
             </div>
             <div class="member" data-text="property public rmqrheight? height { get; init; } restrict automatic fitting to one symbol height, or null (the default) to consider every height. must agree with version when both are set. ">
-              <h4><span class="kind">property</span> <span class="name">Height</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeGeneratorOptions.cs#L55" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Height</a></h4>
               <pre class="sig"><code>public RmQRHeight? Height { get; init; }</code></pre>
               <p class="doc">Restrict automatic fitting to one symbol height, or null (the default) to consider every height. Must agree with Version when both are set.</p>
             </div>
             <div class="member" data-text="property public rmqrsegmentation segmentation { get; init; } whether to split the content into mixed-mode segments. defaults to single . size a destination buffer with the same value you encode with: the two modes can select different versions. ">
-              <h4><span class="kind">property</span> <span class="name">Segmentation</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeGeneratorOptions.cs#L71" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Segmentation</a></h4>
               <pre class="sig"><code>public RmQRSegmentation Segmentation { get; init; }</code></pre>
               <p class="doc">Whether to split the content into mixed-mode segments. Defaults to Single . Size a destination buffer with the same value you encode with: the two modes can select different versions.</p>
             </div>
             <div class="member" data-text="property public rmqrversion? version { get; init; } a specific version, or null (the default) to fit one automatically by fitstrategy and height . ">
-              <h4><span class="kind">property</span> <span class="name">Version</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeGeneratorOptions.cs#L43" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Version</a></h4>
               <pre class="sig"><code>public RmQRVersion? Version { get; init; }</code></pre>
               <p class="doc">A specific version, or null (the default) to fit one automatically by FitStrategy and Height .</p>
             </div>
             <div class="member" data-text="property public int quietzonesize { get; init; } quiet zone width in modules. defaults to 2, the iso/iec 23941 value; 0 is valid. ">
-              <h4><span class="kind">property</span> <span class="name">QuietZoneSize</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeGeneratorOptions.cs#L62" title="View source on GitHub" target="_blank" rel="noopener noreferrer">QuietZoneSize</a></h4>
               <pre class="sig"><code>public int QuietZoneSize { get; init; }</code></pre>
               <p class="doc">Quiet zone width in modules. Defaults to 2, the ISO/IEC 23941 value; 0 is valid.</p>
             </div>
             <div class="member" data-text="property public static rmqrcodegeneratoroptions default { get; } the default configuration, identical to default. ">
-              <h4><span class="kind">property</span> <span class="name">Default</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/RmQRCodeGeneratorOptions.cs#L26" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Default</a></h4>
               <pre class="sig"><code>public static RmQRCodeGeneratorOptions Default { get; }</code></pre>
               <p class="doc">The default configuration, identical to default.</p>
             </div>
@@ -2049,7 +2052,7 @@
       <section class="ns">
         <h2>namespace SkiaSharp.QrCode.Image</h2>
         <article class="type" id="SkiaSharp.QrCode.Image.CircleFinderPatternShape" data-name="skiasharp.qrcode.image.circlefinderpatternshape" data-text="skiasharp.qrcode.image.circlefinderpatternshape public sealed class circlefinderpatternshape : finderpatternshape circular finder pattern. (three nested circles, 7x7, 5x5, 3x3)  field public static readonly circlefinderpatternshape default; gets the default instance.  property public bool requiresantialiasing { get; } requires antialiasing to prevent jagged edges on curves.  method public override void draw(skcanvas canvas, skrect rect, skpaint paint);  method public override void draw(skcanvas canvas, skrect rect, skpaint paint, skcolor backgroundcolor);  method public override void draw(skcanvas canvas, skrect rect, skpaint paint, skpaint backgroundpaint); ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.CircleFinderPatternShape" aria-label="Link to SkiaSharp.QrCode.Image.CircleFinderPatternShape">#</a><span class="kind">class</span> <span class="name">CircleFinderPatternShape</span></h3>
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.CircleFinderPatternShape" aria-label="Link to SkiaSharp.QrCode.Image.CircleFinderPatternShape">#</a><span class="kind">class</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/FinderPatternShape.cs" title="View source file on GitHub" target="_blank" rel="noopener noreferrer">CircleFinderPatternShape</a></h3>
           <pre class="sig"><code>public sealed class CircleFinderPatternShape : FinderPatternShape</code></pre>
           <p class="doc">Circular finder pattern. (three nested circles, 7x7, 5x5, 3x3)</p>
           <div class="members">
@@ -2059,26 +2062,26 @@
               <p class="doc">Gets the default instance.</p>
             </div>
             <div class="member" data-text="property public bool requiresantialiasing { get; } requires antialiasing to prevent jagged edges on curves. ">
-              <h4><span class="kind">property</span> <span class="name">RequiresAntialiasing</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/FinderPatternShape.cs#L137" title="View source on GitHub" target="_blank" rel="noopener noreferrer">RequiresAntialiasing</a></h4>
               <pre class="sig"><code>public bool RequiresAntialiasing { get; }</code></pre>
               <p class="doc">Requires antialiasing to prevent jagged edges on curves.</p>
             </div>
             <div class="member" data-text="method public override void draw(skcanvas canvas, skrect rect, skpaint paint); ">
-              <h4><span class="kind">method</span> <span class="name">Draw</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/FinderPatternShape.cs#L141" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Draw</a></h4>
               <pre class="sig"><code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint);</code></pre>
             </div>
             <div class="member" data-text="method public override void draw(skcanvas canvas, skrect rect, skpaint paint, skcolor backgroundcolor); ">
-              <h4><span class="kind">method</span> <span class="name">Draw</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/FinderPatternShape.cs#L147" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Draw</a></h4>
               <pre class="sig"><code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint, SKColor backgroundColor);</code></pre>
             </div>
             <div class="member" data-text="method public override void draw(skcanvas canvas, skrect rect, skpaint paint, skpaint backgroundpaint); ">
-              <h4><span class="kind">method</span> <span class="name">Draw</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/FinderPatternShape.cs#L154" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Draw</a></h4>
               <pre class="sig"><code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint, SKPaint backgroundPaint);</code></pre>
             </div>
           </div>
         </article>
         <article class="type" id="SkiaSharp.QrCode.Image.CircleModuleShape" data-name="skiasharp.qrcode.image.circlemoduleshape" data-text="skiasharp.qrcode.image.circlemoduleshape public sealed class circlemoduleshape : moduleshape draws modules as circles.  field public static readonly circlemoduleshape default; gets the default instance.  property public bool requiresantialiasing { get; } requires antialiasing to prevent jagged edges on curves.  method public override void draw(skcanvas canvas, skrect rect, skpaint paint); ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.CircleModuleShape" aria-label="Link to SkiaSharp.QrCode.Image.CircleModuleShape">#</a><span class="kind">class</span> <span class="name">CircleModuleShape</span></h3>
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.CircleModuleShape" aria-label="Link to SkiaSharp.QrCode.Image.CircleModuleShape">#</a><span class="kind">class</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/ModuleShape.cs" title="View source file on GitHub" target="_blank" rel="noopener noreferrer">CircleModuleShape</a></h3>
           <pre class="sig"><code>public sealed class CircleModuleShape : ModuleShape</code></pre>
           <p class="doc">Draws modules as circles.</p>
           <div class="members">
@@ -2088,18 +2091,18 @@
               <p class="doc">Gets the default instance.</p>
             </div>
             <div class="member" data-text="property public bool requiresantialiasing { get; } requires antialiasing to prevent jagged edges on curves. ">
-              <h4><span class="kind">property</span> <span class="name">RequiresAntialiasing</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/ModuleShape.cs#L60" title="View source on GitHub" target="_blank" rel="noopener noreferrer">RequiresAntialiasing</a></h4>
               <pre class="sig"><code>public bool RequiresAntialiasing { get; }</code></pre>
               <p class="doc">Requires antialiasing to prevent jagged edges on curves.</p>
             </div>
             <div class="member" data-text="method public override void draw(skcanvas canvas, skrect rect, skpaint paint); ">
-              <h4><span class="kind">method</span> <span class="name">Draw</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/ModuleShape.cs#L67" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Draw</a></h4>
               <pre class="sig"><code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint);</code></pre>
             </div>
           </div>
         </article>
         <article class="type" id="SkiaSharp.QrCode.Image.FinderPatternShape" data-name="skiasharp.qrcode.image.finderpatternshape" data-text="skiasharp.qrcode.image.finderpatternshape public abstract class finderpatternshape defines the shape of qr code finder pattern (position detection patterns).  constructor protected finderpatternshape();  property public bool requiresantialiasing { get; } gets whether this shape requires antialiasing for smooth rendering. curved shapes such as circles and rounded rectangles should return true ; straight-edged shapes such as rectangles can return false .  method public abstract void draw(skcanvas canvas, skrect rect, skpaint paint); draw a finder pattern at the specified location.  method public virtual void draw(skcanvas canvas, skrect rect, skpaint paint, skcolor backgroundcolor); draw a finder pattern at the specified location with background color support.  method public virtual void draw(skcanvas canvas, skrect rect, skpaint paint, skpaint backgroundpaint); draw a finder pattern at the specified location using an existing background paint. the default implementation preserves compatibility with custom finder shapes that override the color-based overload. built-in shapes override this overload so the renderer can reuse its background paint. the renderer may set the paint's blend mode to clear while drawing on an isolated layer so transparent and translucent light modules reveal the background rendered beneath the finder pattern. implementations should therefore draw with this paint directly instead of copying only its color. the renderer owns backgroundpaint and may reuse it across calls; implementations must not modify or dispose it. custom shapes should override this overload when they need to reuse the renderer's configured background paint or when they must support non-opaque backgrounds (blend modes). existing custom shapes may continue to override draw , but that overload cannot use the renderer's blend mode.">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.FinderPatternShape" aria-label="Link to SkiaSharp.QrCode.Image.FinderPatternShape">#</a><span class="kind">class</span> <span class="name">FinderPatternShape</span></h3>
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.FinderPatternShape" aria-label="Link to SkiaSharp.QrCode.Image.FinderPatternShape">#</a><span class="kind">class</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/FinderPatternShape.cs" title="View source file on GitHub" target="_blank" rel="noopener noreferrer">FinderPatternShape</a></h3>
           <pre class="sig"><code>public abstract class FinderPatternShape</code></pre>
           <p class="doc">Defines the shape of QR code finder pattern (position detection patterns).</p>
           <div class="members">
@@ -2108,7 +2111,7 @@
               <pre class="sig"><code>protected FinderPatternShape();</code></pre>
             </div>
             <div class="member" data-text="property public bool requiresantialiasing { get; } gets whether this shape requires antialiasing for smooth rendering. curved shapes such as circles and rounded rectangles should return true ; straight-edged shapes such as rectangles can return false . ">
-              <h4><span class="kind">property</span> <span class="name">RequiresAntialiasing</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/FinderPatternShape.cs#L13" title="View source on GitHub" target="_blank" rel="noopener noreferrer">RequiresAntialiasing</a></h4>
               <pre class="sig"><code>public bool RequiresAntialiasing { get; }</code></pre>
               <p class="doc">Gets whether this shape requires antialiasing for smooth rendering. Curved shapes such as circles and rounded rectangles should return true ; straight-edged shapes such as rectangles can return false .</p>
             </div>
@@ -2118,12 +2121,12 @@
               <p class="doc">Draw a finder pattern at the specified location.</p>
             </div>
             <div class="member" data-text="method public virtual void draw(skcanvas canvas, skrect rect, skpaint paint, skcolor backgroundcolor); draw a finder pattern at the specified location with background color support. ">
-              <h4><span class="kind">method</span> <span class="name">Draw</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/FinderPatternShape.cs#L31" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Draw</a></h4>
               <pre class="sig"><code>public virtual void Draw(SKCanvas canvas, SKRect rect, SKPaint paint, SKColor backgroundColor);</code></pre>
               <p class="doc">Draw a finder pattern at the specified location with background color support.</p>
             </div>
             <div class="member" data-text="method public virtual void draw(skcanvas canvas, skrect rect, skpaint paint, skpaint backgroundpaint); draw a finder pattern at the specified location using an existing background paint. the default implementation preserves compatibility with custom finder shapes that override the color-based overload. built-in shapes override this overload so the renderer can reuse its background paint. the renderer may set the paint's blend mode to clear while drawing on an isolated layer so transparent and translucent light modules reveal the background rendered beneath the finder pattern. implementations should therefore draw with this paint directly instead of copying only its color. the renderer owns backgroundpaint and may reuse it across calls; implementations must not modify or dispose it. custom shapes should override this overload when they need to reuse the renderer's configured background paint or when they must support non-opaque backgrounds (blend modes). existing custom shapes may continue to override draw , but that overload cannot use the renderer's blend mode.">
-              <h4><span class="kind">method</span> <span class="name">Draw</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/FinderPatternShape.cs#L59" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Draw</a></h4>
               <pre class="sig"><code>public virtual void Draw(SKCanvas canvas, SKRect rect, SKPaint paint, SKPaint backgroundPaint);</code></pre>
               <p class="doc">Draw a finder pattern at the specified location using an existing background paint.</p>
               <details class="notes" data-text="the default implementation preserves compatibility with custom finder shapes that override the color-based overload. built-in shapes override this overload so the renderer can reuse its background paint. the renderer may set the paint's blend mode to clear while drawing on an isolated layer so transparent and translucent light modules reveal the background rendered beneath the finder pattern. implementations should therefore draw with this paint directly instead of copying only its color. the renderer owns backgroundpaint and may reuse it across calls; implementations must not modify or dispose it. custom shapes should override this overload when they need to reuse the renderer's configured background paint or when they must support non-opaque backgrounds (blend modes). existing custom shapes may continue to override draw , but that overload cannot use the renderer's blend mode.">
@@ -2181,7 +2184,7 @@
           </div>
         </article>
         <article class="type" id="SkiaSharp.QrCode.Image.GradientOptions" data-name="skiasharp.qrcode.image.gradientoptions" data-text="skiasharp.qrcode.image.gradientoptions public class gradientoptions : iequatable&lt;gradientoptions&gt; defines gradient configuration for qr code rendering. this record configures linear gradients that are applied across the entire qr code. gradients can flow in various directions (horizontal, vertical, diagonal). for simple two-color gradients, specify two colors in colors . for multi-color gradients, provide additional colors and optionally specify colorpositions . field public static readonly gradientoptions default; a ready-made gradient: dark orange to firebrick, running from the top-left corner to the bottom-right. use it when you want a gradient without choosing colors.  constructor public gradientoptions(skcolor[] colors, gradientdirection direction = 1, float[]? colorpositions = null); initializes a new instance of the gradientoptions record.  property public gradientdirection direction { get; init; } the gradient direction. determines the start and end points of the gradient across the qr code area. property public skcolor[] colors { get; init; } gradient colors for multi-color gradients. at least 2 colors are required. the gradient flows from the first color to the last color in the direction specified by direction . property public float[]? colorpositions { get; init; } optional color stops (0.0 to 1.0) for the gradient. if null, colors are evenly distributed across the gradient. if specified, the array length must match colors length. values must be in ascending order from 0.0 (start) to 1.0 (end). for example: [0.0f, 0.3f, 1.0f] for three colors.">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.GradientOptions" aria-label="Link to SkiaSharp.QrCode.Image.GradientOptions">#</a><span class="kind">class</span> <span class="name">GradientOptions</span></h3>
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.GradientOptions" aria-label="Link to SkiaSharp.QrCode.Image.GradientOptions">#</a><span class="kind">class</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/GradientOptions.cs" title="View source file on GitHub" target="_blank" rel="noopener noreferrer">GradientOptions</a></h3>
           <pre class="sig"><code>public class GradientOptions : IEquatable&lt;GradientOptions&gt;</code></pre>
           <p class="doc">Defines gradient configuration for QR code rendering.</p>
           <details class="notes" data-text="this record configures linear gradients that are applied across the entire qr code. gradients can flow in various directions (horizontal, vertical, diagonal). for simple two-color gradients, specify two colors in colors . for multi-color gradients, provide additional colors and optionally specify colorpositions .">
@@ -2195,12 +2198,12 @@
               <p class="doc">A ready-made gradient: dark orange to firebrick, running from the top-left corner to the bottom-right. Use it when you want a gradient without choosing colors.</p>
             </div>
             <div class="member" data-text="constructor public gradientoptions(skcolor[] colors, gradientdirection direction = 1, float[]? colorpositions = null); initializes a new instance of the gradientoptions record. ">
-              <h4><span class="kind">constructor</span> <span class="name">GradientOptions</span></h4>
+              <h4><span class="kind">constructor</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/GradientOptions.cs#L32" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GradientOptions</a></h4>
               <pre class="sig"><code>public GradientOptions(SKColor[] colors, GradientDirection direction = 1, float[]? colorPositions = null);</code></pre>
               <p class="doc">Initializes a new instance of the GradientOptions record.</p>
             </div>
             <div class="member" data-text="property public gradientdirection direction { get; init; } the gradient direction. determines the start and end points of the gradient across the qr code area.">
-              <h4><span class="kind">property</span> <span class="name">Direction</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/GradientOptions.cs#L61" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Direction</a></h4>
               <pre class="sig"><code>public GradientDirection Direction { get; init; }</code></pre>
               <p class="doc">The gradient direction.</p>
               <details class="notes" data-text="determines the start and end points of the gradient across the qr code area.">
@@ -2209,7 +2212,7 @@
               </details>
             </div>
             <div class="member" data-text="property public skcolor[] colors { get; init; } gradient colors for multi-color gradients. at least 2 colors are required. the gradient flows from the first color to the last color in the direction specified by direction .">
-              <h4><span class="kind">property</span> <span class="name">Colors</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/GradientOptions.cs#L53" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Colors</a></h4>
               <pre class="sig"><code>public SKColor[] Colors { get; init; }</code></pre>
               <p class="doc">Gradient colors for multi-color gradients.</p>
               <details class="notes" data-text="at least 2 colors are required. the gradient flows from the first color to the last color in the direction specified by direction .">
@@ -2218,7 +2221,7 @@
               </details>
             </div>
             <div class="member" data-text="property public float[]? colorpositions { get; init; } optional color stops (0.0 to 1.0) for the gradient. if null, colors are evenly distributed across the gradient. if specified, the array length must match colors length. values must be in ascending order from 0.0 (start) to 1.0 (end). for example: [0.0f, 0.3f, 1.0f] for three colors.">
-              <h4><span class="kind">property</span> <span class="name">ColorPositions</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/GradientOptions.cs#L76" title="View source on GitHub" target="_blank" rel="noopener noreferrer">ColorPositions</a></h4>
               <pre class="sig"><code>public float[]? ColorPositions { get; init; }</code></pre>
               <p class="doc">Optional color stops (0.0 to 1.0) for the gradient.</p>
               <details class="notes" data-text="if null, colors are evenly distributed across the gradient. if specified, the array length must match colors length. values must be in ascending order from 0.0 (start) to 1.0 (end). for example: [0.0f, 0.3f, 1.0f] for three colors.">
@@ -2229,7 +2232,7 @@
           </div>
         </article>
         <article class="type" id="SkiaSharp.QrCode.Image.IconData" data-name="skiasharp.qrcode.image.icondata" data-text="skiasharp.qrcode.image.icondata public class icondata the logo or image drawn at the center of a qr code, and its size. the icon covers modules, so the symbol relies on error correction to stay readable. use the highest error correction level ( h ) and keep the icon small. when the size is given in modules, rendering throws if the icon and its border span more than maxcoreoccupancypercent percent of the core width; sizes given as a percentage of the image are not checked against the symbol at all. constructor [obsolete] public icondata();  property public iconshape icon { get; set; } the icon shape to overlay on the qr code.  property public int iconborderwidth { get; set; } the border width around the icon in pixels. creates a background-colored padding around the icon. ignored when iconsizemodules is set.  property public int iconsizepercent { get; set; } the size of the icon as a percentage of the qr code size (1-100). ignored when iconsizemodules is set.  property public int maxcoreoccupancypercent { get; set; } maximum allowed icon occupancy of the qr core area, as a percentage (1-100). used only for module-based sizing. default is 30.  property public int? iconbordermodules { get; set; } the border width around the icon in qr modules. when iconsizemodules is set and this is null, defaults to 1.  property public int? iconsizemodules { get; set; } the size of the icon body in qr modules. when set, module-based sizing is used and iconsizepercent / iconborderwidth are ignored.  method public static icondata fromimage(skbitmap image, int iconsizepercent = 10, int iconborderwidth = 2); create icondata from a bitmap image using percent/pixel sizing.  method public static icondata fromimagebymodules(skbitmap image, int iconsizemodules, int iconbordermodules = 1, int maxcoreoccupancypercent = 30); create icondata from a bitmap image using module-based sizing. prefer combining this with withmodulepixelsize so each module maps to an integer pixel size. optional withsize can then set a larger canvas; content is centered and padded. validation against qr size/core occupancy happens at render time.">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.IconData" aria-label="Link to SkiaSharp.QrCode.Image.IconData">#</a><span class="kind">class</span> <span class="name">IconData</span></h3>
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.IconData" aria-label="Link to SkiaSharp.QrCode.Image.IconData">#</a><span class="kind">class</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/IconData.cs" title="View source file on GitHub" target="_blank" rel="noopener noreferrer">IconData</a></h3>
           <pre class="sig"><code>public class IconData</code></pre>
           <p class="doc">The logo or image drawn at the center of a QR code, and its size.</p>
           <details class="notes" data-text="the icon covers modules, so the symbol relies on error correction to stay readable. use the highest error correction level ( h ) and keep the icon small. when the size is given in modules, rendering throws if the icon and its border span more than maxcoreoccupancypercent percent of the core width; sizes given as a percentage of the image are not checked against the symbol at all.">
@@ -2238,46 +2241,46 @@
           </details>
           <div class="members">
             <div class="member" data-text="constructor public icondata(); ">
-              <h4><span class="kind">constructor</span> <span class="name">IconData</span> <span class="tag">obsolete</span></h4>
+              <h4><span class="kind">constructor</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/IconData.cs#L24" title="View source on GitHub" target="_blank" rel="noopener noreferrer">IconData</a> <span class="tag">obsolete</span></h4>
               <pre class="sig"><code>public IconData();</code></pre>
             </div>
             <div class="member" data-text="property public iconshape icon { get; set; } the icon shape to overlay on the qr code. ">
-              <h4><span class="kind">property</span> <span class="name">Icon</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/IconData.cs#L18" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Icon</a></h4>
               <pre class="sig"><code>public IconShape Icon { get; set; }</code></pre>
               <p class="doc">The icon shape to overlay on the QR code.</p>
             </div>
             <div class="member" data-text="property public int iconborderwidth { get; set; } the border width around the icon in pixels. creates a background-colored padding around the icon. ignored when iconsizemodules is set. ">
-              <h4><span class="kind">property</span> <span class="name">IconBorderWidth</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/IconData.cs#L30" title="View source on GitHub" target="_blank" rel="noopener noreferrer">IconBorderWidth</a></h4>
               <pre class="sig"><code>public int IconBorderWidth { get; set; }</code></pre>
               <p class="doc">The border width around the icon in pixels. Creates a background-colored padding around the icon. Ignored when IconSizeModules is set.</p>
             </div>
             <div class="member" data-text="property public int iconsizepercent { get; set; } the size of the icon as a percentage of the qr code size (1-100). ignored when iconsizemodules is set. ">
-              <h4><span class="kind">property</span> <span class="name">IconSizePercent</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/IconData.cs#L24" title="View source on GitHub" target="_blank" rel="noopener noreferrer">IconSizePercent</a></h4>
               <pre class="sig"><code>public int IconSizePercent { get; set; }</code></pre>
               <p class="doc">The size of the icon as a percentage of the QR code size (1-100). Ignored when IconSizeModules is set.</p>
             </div>
             <div class="member" data-text="property public int maxcoreoccupancypercent { get; set; } maximum allowed icon occupancy of the qr core area, as a percentage (1-100). used only for module-based sizing. default is 30. ">
-              <h4><span class="kind">property</span> <span class="name">MaxCoreOccupancyPercent</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/IconData.cs#L48" title="View source on GitHub" target="_blank" rel="noopener noreferrer">MaxCoreOccupancyPercent</a></h4>
               <pre class="sig"><code>public int MaxCoreOccupancyPercent { get; set; }</code></pre>
               <p class="doc">Maximum allowed icon occupancy of the QR core area, as a percentage (1-100). Used only for module-based sizing. Default is 30.</p>
             </div>
             <div class="member" data-text="property public int? iconbordermodules { get; set; } the border width around the icon in qr modules. when iconsizemodules is set and this is null, defaults to 1. ">
-              <h4><span class="kind">property</span> <span class="name">IconBorderModules</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/IconData.cs#L42" title="View source on GitHub" target="_blank" rel="noopener noreferrer">IconBorderModules</a></h4>
               <pre class="sig"><code>public int? IconBorderModules { get; set; }</code></pre>
               <p class="doc">The border width around the icon in QR modules. When IconSizeModules is set and this is null, defaults to 1.</p>
             </div>
             <div class="member" data-text="property public int? iconsizemodules { get; set; } the size of the icon body in qr modules. when set, module-based sizing is used and iconsizepercent / iconborderwidth are ignored. ">
-              <h4><span class="kind">property</span> <span class="name">IconSizeModules</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/IconData.cs#L36" title="View source on GitHub" target="_blank" rel="noopener noreferrer">IconSizeModules</a></h4>
               <pre class="sig"><code>public int? IconSizeModules { get; set; }</code></pre>
               <p class="doc">The size of the icon body in QR modules. When set, module-based sizing is used and IconSizePercent / IconBorderWidth are ignored.</p>
             </div>
             <div class="member" data-text="method public static icondata fromimage(skbitmap image, int iconsizepercent = 10, int iconborderwidth = 2); create icondata from a bitmap image using percent/pixel sizing. ">
-              <h4><span class="kind">method</span> <span class="name">FromImage</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/IconData.cs#L58" title="View source on GitHub" target="_blank" rel="noopener noreferrer">FromImage</a></h4>
               <pre class="sig"><code>public static IconData FromImage(SKBitmap image, int iconSizePercent = 10, int iconBorderWidth = 2);</code></pre>
               <p class="doc">Create IconData from a bitmap image using percent/pixel sizing.</p>
             </div>
             <div class="member" data-text="method public static icondata fromimagebymodules(skbitmap image, int iconsizemodules, int iconbordermodules = 1, int maxcoreoccupancypercent = 30); create icondata from a bitmap image using module-based sizing. prefer combining this with withmodulepixelsize so each module maps to an integer pixel size. optional withsize can then set a larger canvas; content is centered and padded. validation against qr size/core occupancy happens at render time.">
-              <h4><span class="kind">method</span> <span class="name">FromImageByModules</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/IconData.cs#L90" title="View source on GitHub" target="_blank" rel="noopener noreferrer">FromImageByModules</a></h4>
               <pre class="sig"><code>public static IconData FromImageByModules(SKBitmap image, int iconSizeModules, int iconBorderModules = 1, int maxCoreOccupancyPercent = 30);</code></pre>
               <p class="doc">Create IconData from a bitmap image using module-based sizing.</p>
               <details class="notes" data-text="prefer combining this with withmodulepixelsize so each module maps to an integer pixel size. optional withsize can then set a larger canvas; content is centered and padded. validation against qr size/core occupancy happens at render time.">
@@ -2304,39 +2307,39 @@
           </div>
         </article>
         <article class="type" id="SkiaSharp.QrCode.Image.ImageIconShape" data-name="skiasharp.qrcode.image.imageiconshape" data-text="skiasharp.qrcode.image.imageiconshape public sealed class imageiconshape : iconshape icon shape that draws an image.  constructor public imageiconshape(skbitmap image); creates an icon from an image.  method public override void draw(skcanvas canvas, skrect rect, skrect borderrect, skcolor backgroundcolor); ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.ImageIconShape" aria-label="Link to SkiaSharp.QrCode.Image.ImageIconShape">#</a><span class="kind">class</span> <span class="name">ImageIconShape</span></h3>
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.ImageIconShape" aria-label="Link to SkiaSharp.QrCode.Image.ImageIconShape">#</a><span class="kind">class</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/IconShape.cs" title="View source file on GitHub" target="_blank" rel="noopener noreferrer">ImageIconShape</a></h3>
           <pre class="sig"><code>public sealed class ImageIconShape : IconShape</code></pre>
           <p class="doc">Icon shape that draws an image.</p>
           <div class="members">
             <div class="member" data-text="constructor public imageiconshape(skbitmap image); creates an icon from an image. ">
-              <h4><span class="kind">constructor</span> <span class="name">ImageIconShape</span></h4>
+              <h4><span class="kind">constructor</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/IconShape.cs#L51" title="View source on GitHub" target="_blank" rel="noopener noreferrer">ImageIconShape</a></h4>
               <pre class="sig"><code>public ImageIconShape(SKBitmap image);</code></pre>
               <p class="doc">Creates an icon from an image.</p>
             </div>
             <div class="member" data-text="method public override void draw(skcanvas canvas, skrect rect, skrect borderrect, skcolor backgroundcolor); ">
-              <h4><span class="kind">method</span> <span class="name">Draw</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/IconShape.cs#L58" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Draw</a></h4>
               <pre class="sig"><code>public override void Draw(SKCanvas canvas, SKRect rect, SKRect borderRect, SKColor backgroundColor);</code></pre>
             </div>
           </div>
         </article>
         <article class="type" id="SkiaSharp.QrCode.Image.ImageTextIconShape" data-name="skiasharp.qrcode.image.imagetexticonshape" data-text="skiasharp.qrcode.image.imagetexticonshape public sealed class imagetexticonshape : iconshape icon shape that draws an image with text positioned relative to it.  constructor public imagetexticonshape(skbitmap image, string text, skcolor textcolor, skfont font, sktextalign horizontalalign = 1, textverticalalignment verticalalign = 0, int textpadding = 0); creates an icon shape that displays an image with text positioned relative to it.  method public override void draw(skcanvas canvas, skrect rect, skrect borderrect, skcolor backgroundcolor); ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.ImageTextIconShape" aria-label="Link to SkiaSharp.QrCode.Image.ImageTextIconShape">#</a><span class="kind">class</span> <span class="name">ImageTextIconShape</span></h3>
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.ImageTextIconShape" aria-label="Link to SkiaSharp.QrCode.Image.ImageTextIconShape">#</a><span class="kind">class</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/IconShape.cs" title="View source file on GitHub" target="_blank" rel="noopener noreferrer">ImageTextIconShape</a></h3>
           <pre class="sig"><code>public sealed class ImageTextIconShape : IconShape</code></pre>
           <p class="doc">Icon shape that draws an image with text positioned relative to it.</p>
           <div class="members">
             <div class="member" data-text="constructor public imagetexticonshape(skbitmap image, string text, skcolor textcolor, skfont font, sktextalign horizontalalign = 1, textverticalalignment verticalalign = 0, int textpadding = 0); creates an icon shape that displays an image with text positioned relative to it. ">
-              <h4><span class="kind">constructor</span> <span class="name">ImageTextIconShape</span></h4>
+              <h4><span class="kind">constructor</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/IconShape.cs#L99" title="View source on GitHub" target="_blank" rel="noopener noreferrer">ImageTextIconShape</a></h4>
               <pre class="sig"><code>public ImageTextIconShape(SKBitmap image, string text, SKColor textColor, SKFont font, SKTextAlign horizontalAlign = 1, TextVerticalAlignment verticalAlign = 0, int textPadding = 0);</code></pre>
               <p class="doc">Creates an icon shape that displays an image with text positioned relative to it.</p>
             </div>
             <div class="member" data-text="method public override void draw(skcanvas canvas, skrect rect, skrect borderrect, skcolor backgroundcolor); ">
-              <h4><span class="kind">method</span> <span class="name">Draw</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/IconShape.cs#L112" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Draw</a></h4>
               <pre class="sig"><code>public override void Draw(SKCanvas canvas, SKRect rect, SKRect borderRect, SKColor backgroundColor);</code></pre>
             </div>
           </div>
         </article>
         <article class="type" id="SkiaSharp.QrCode.Image.MicroQRCodeImageBuilder" data-name="skiasharp.qrcode.image.microqrcodeimagebuilder" data-text="skiasharp.qrcode.image.microqrcodeimagebuilder public class microqrcodeimagebuilder : qrcodeimagebuilderbase&lt;microqrcodeimagebuilder&gt; high-level builder for creating micro qr code images with fluent configuration and static methods. this builder mirrors qrcodeimagebuilder for the micro qr symbology (iso/iec 18004, versions m1-m4). version and error correction use the micro qr-typed microqrversion / microqrecclevel , and the default quiet zone is the 2 modules the specification requires (standard qr uses 4). micro qr has a single finder pattern and no high error-correction headroom, so the standard qr styling options that depend on those (icon overlays and custom finder pattern shapes) are intentionally not offered. constructor public microqrcodeimagebuilder(microqrcodedata microqrcodedata); starts a builder that draws a micro qr code you have already generated. the symbol is used exactly as given, so only the appearance options apply. every encoding option throws invalidoperationexception on a builder created this way.  constructor public microqrcodeimagebuilder(string content); starts a builder that will encode content when you ask for an image. error correction, version and every other option keep their defaults until you set them.  method public microqrcodeimagebuilder witherrorcorrection(microqrecclevel ecclevel); configure the error correction level for the micro qr code. legal combinations are version-dependent: m1 supports errordetectiononly only, m2/m3 support l and m, m4 supports l, m, and q. illegal combinations throw when the symbol is generated. method public microqrcodeimagebuilder withmaskpattern(int? maskpattern); pin one of the four micro qr data mask patterns (0-3) instead of the automatic edge-score selection; see maskpattern .  method public microqrcodeimagebuilder withsegmentation(microqrsegmentation segmentation); split the content into mixed-mode segments when that lowers the version (see microqrsegmentation ). defaults to single . never selects a larger version, and produces the identical symbol when a split would not shrink it.  method public microqrcodeimagebuilder withversion(microqrversion version); configure the micro qr version to generate. the pinned-version case of the withversion overload. method public microqrcodeimagebuilder withversion(microqrversionrange versionrange); configure the versions the generator may choose from, rather than a single one. see microqrversionrange for which empty ranges throw and which are a poor fit. method public static byte[] getimagebytes(microqrcodedata microqrcodedata, skencodedimageformat format, int size = 512, int quality = 100); generate a micro qr code as image byte array with specified format.  method public static byte[] getimagebytes(string content, skencodedimageformat format, microqrecclevel ecclevel = 2, int size = 512, int quality = 100); generate a micro qr code as image byte array with specified format.  method public static byte[] getpngbytes(microqrcodedata microqrcodedata, int size = 512); generate a micro qr code as png byte array with default settings.  method public static byte[] getpngbytes(string content, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code as png byte array with default settings.  method public static byte[] getsvgbytes(microqrcodedata microqrcodedata, int size = 512); generate a micro qr code as svg (utf-8 encoded) byte array with default settings.  method public static byte[] getsvgbytes(string content, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code as svg (utf-8 encoded) byte array with default settings.  method public static string getsvgstring(microqrcodedata microqrcodedata, int size = 512); generate a micro qr code as svg document string with default settings.  method public static string getsvgstring(string content, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code as svg document string with default settings.  method public static void savepng(microqrcodedata microqrcodedata, stream output, int size = 512); generate a micro qr code and save to stream with default png settings.  method public static void savepng(string content, stream output, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code and save to stream with default png settings.  method public static void savesvg(microqrcodedata microqrcodedata, stream output, int size = 512); generate a micro qr code and save as svg to stream with default settings.  method public static void savesvg(string content, stream output, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code and save as svg to stream with default settings.  method public static void writeimage(microqrcodedata microqrcodedata, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, int size = 512, int quality = 100); generate a micro qr code and write to an ibufferwriter with specified format.  method public static void writeimage(string content, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, microqrecclevel ecclevel = 2, int size = 512, int quality = 100); generate a micro qr code and write to an ibufferwriter with specified format.  method public static void writepng(microqrcodedata microqrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate a micro qr code and write to an ibufferwriter with default png settings.  method public static void writepng(string content, ibufferwriter&lt;byte&gt; writer, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code and write to an ibufferwriter with default png settings.  method public static void writesvg(microqrcodedata microqrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate a micro qr code and write as svg (utf-8 encoded) to an ibufferwriter with default settings.  method public static void writesvg(string content, ibufferwriter&lt;byte&gt; writer, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code and write as svg (utf-8 encoded) to an ibufferwriter with default settings. ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.MicroQRCodeImageBuilder" aria-label="Link to SkiaSharp.QrCode.Image.MicroQRCodeImageBuilder">#</a><span class="kind">class</span> <span class="name">MicroQRCodeImageBuilder</span></h3>
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.MicroQRCodeImageBuilder" aria-label="Link to SkiaSharp.QrCode.Image.MicroQRCodeImageBuilder">#</a><span class="kind">class</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/MicroQRCodeImageBuilder.cs" title="View source file on GitHub" target="_blank" rel="noopener noreferrer">MicroQRCodeImageBuilder</a></h3>
           <pre class="sig"><code>public class MicroQRCodeImageBuilder : QRCodeImageBuilderBase&lt;MicroQRCodeImageBuilder&gt;</code></pre>
           <p class="doc">High-level builder for creating Micro QR code images with fluent configuration and static methods.</p>
           <details class="notes" data-text="this builder mirrors qrcodeimagebuilder for the micro qr symbology (iso/iec 18004, versions m1-m4). version and error correction use the micro qr-typed microqrversion / microqrecclevel , and the default quiet zone is the 2 modules the specification requires (standard qr uses 4). micro qr has a single finder pattern and no high error-correction headroom, so the standard qr styling options that depend on those (icon overlays and custom finder pattern shapes) are intentionally not offered.">
@@ -2345,17 +2348,17 @@
           </details>
           <div class="members">
             <div class="member" data-text="constructor public microqrcodeimagebuilder(microqrcodedata microqrcodedata); starts a builder that draws a micro qr code you have already generated. the symbol is used exactly as given, so only the appearance options apply. every encoding option throws invalidoperationexception on a builder created this way. ">
-              <h4><span class="kind">constructor</span> <span class="name">MicroQRCodeImageBuilder</span></h4>
+              <h4><span class="kind">constructor</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/MicroQRCodeImageBuilder.cs#L28" title="View source on GitHub" target="_blank" rel="noopener noreferrer">MicroQRCodeImageBuilder</a></h4>
               <pre class="sig"><code>public MicroQRCodeImageBuilder(MicroQRCodeData microQrCodeData);</code></pre>
               <p class="doc">Starts a builder that draws a Micro QR code you have already generated. The symbol is used exactly as given, so only the appearance options apply. Every encoding option throws InvalidOperationException on a builder created this way.</p>
             </div>
             <div class="member" data-text="constructor public microqrcodeimagebuilder(string content); starts a builder that will encode content when you ask for an image. error correction, version and every other option keep their defaults until you set them. ">
-              <h4><span class="kind">constructor</span> <span class="name">MicroQRCodeImageBuilder</span></h4>
+              <h4><span class="kind">constructor</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/MicroQRCodeImageBuilder.cs#L28" title="View source on GitHub" target="_blank" rel="noopener noreferrer">MicroQRCodeImageBuilder</a></h4>
               <pre class="sig"><code>public MicroQRCodeImageBuilder(string content);</code></pre>
               <p class="doc">Starts a builder that will encode content when you ask for an image. Error correction, version and every other option keep their defaults until you set them.</p>
             </div>
             <div class="member" data-text="method public microqrcodeimagebuilder witherrorcorrection(microqrecclevel ecclevel); configure the error correction level for the micro qr code. legal combinations are version-dependent: m1 supports errordetectiononly only, m2/m3 support l and m, m4 supports l, m, and q. illegal combinations throw when the symbol is generated.">
-              <h4><span class="kind">method</span> <span class="name">WithErrorCorrection</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/MicroQRCodeImageBuilder.cs#L336" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WithErrorCorrection</a></h4>
               <pre class="sig"><code>public MicroQRCodeImageBuilder WithErrorCorrection(MicroQREccLevel eccLevel);</code></pre>
               <p class="doc">Configure the error correction level for the Micro QR code.</p>
               <details class="notes" data-text="legal combinations are version-dependent: m1 supports errordetectiononly only, m2/m3 support l and m, m4 supports l, m, and q. illegal combinations throw when the symbol is generated.">
@@ -2364,17 +2367,17 @@
               </details>
             </div>
             <div class="member" data-text="method public microqrcodeimagebuilder withmaskpattern(int? maskpattern); pin one of the four micro qr data mask patterns (0-3) instead of the automatic edge-score selection; see maskpattern . ">
-              <h4><span class="kind">method</span> <span class="name">WithMaskPattern</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/MicroQRCodeImageBuilder.cs#L388" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WithMaskPattern</a></h4>
               <pre class="sig"><code>public MicroQRCodeImageBuilder WithMaskPattern(int? maskPattern);</code></pre>
               <p class="doc">Pin one of the four Micro QR data mask patterns (0-3) instead of the automatic edge-score selection; see MaskPattern .</p>
             </div>
             <div class="member" data-text="method public microqrcodeimagebuilder withsegmentation(microqrsegmentation segmentation); split the content into mixed-mode segments when that lowers the version (see microqrsegmentation ). defaults to single . never selects a larger version, and produces the identical symbol when a split would not shrink it. ">
-              <h4><span class="kind">method</span> <span class="name">WithSegmentation</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/MicroQRCodeImageBuilder.cs#L409" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WithSegmentation</a></h4>
               <pre class="sig"><code>public MicroQRCodeImageBuilder WithSegmentation(MicroQRSegmentation segmentation);</code></pre>
               <p class="doc">Split the content into mixed-mode segments when that lowers the version (see MicroQRSegmentation ). Defaults to Single . Never selects a larger version, and produces the identical symbol when a split would not shrink it.</p>
             </div>
             <div class="member" data-text="method public microqrcodeimagebuilder withversion(microqrversion version); configure the micro qr version to generate. the pinned-version case of the withversion overload.">
-              <h4><span class="kind">method</span> <span class="name">WithVersion</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/MicroQRCodeImageBuilder.cs#L353" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WithVersion</a></h4>
               <pre class="sig"><code>public MicroQRCodeImageBuilder WithVersion(MicroQRVersion version);</code></pre>
               <p class="doc">Configure the Micro QR version to generate.</p>
               <details class="notes" data-text="the pinned-version case of the withversion overload.">
@@ -2383,7 +2386,7 @@
               </details>
             </div>
             <div class="member" data-text="method public microqrcodeimagebuilder withversion(microqrversionrange versionrange); configure the versions the generator may choose from, rather than a single one. see microqrversionrange for which empty ranges throw and which are a poor fit.">
-              <h4><span class="kind">method</span> <span class="name">WithVersion</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/MicroQRCodeImageBuilder.cs#L371" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WithVersion</a></h4>
               <pre class="sig"><code>public MicroQRCodeImageBuilder WithVersion(MicroQRVersionRange versionRange);</code></pre>
               <p class="doc">Configure the versions the generator may choose from, rather than a single one.</p>
               <details class="notes" data-text="see microqrversionrange for which empty ranges throw and which are a poor fit.">
@@ -2392,92 +2395,92 @@
               </details>
             </div>
             <div class="member" data-text="method public static byte[] getimagebytes(microqrcodedata microqrcodedata, skencodedimageformat format, int size = 512, int quality = 100); generate a micro qr code as image byte array with specified format. ">
-              <h4><span class="kind">method</span> <span class="name">GetImageBytes</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/MicroQRCodeImageBuilder.cs#L114" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetImageBytes</a></h4>
               <pre class="sig"><code>public static byte[] GetImageBytes(MicroQRCodeData microQrCodeData, SKEncodedImageFormat format, int size = 512, int quality = 100);</code></pre>
               <p class="doc">Generate a Micro QR code as image byte array with specified format.</p>
             </div>
             <div class="member" data-text="method public static byte[] getimagebytes(string content, skencodedimageformat format, microqrecclevel ecclevel = 2, int size = 512, int quality = 100); generate a micro qr code as image byte array with specified format. ">
-              <h4><span class="kind">method</span> <span class="name">GetImageBytes</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/MicroQRCodeImageBuilder.cs#L97" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetImageBytes</a></h4>
               <pre class="sig"><code>public static byte[] GetImageBytes(string content, SKEncodedImageFormat format, MicroQREccLevel eccLevel = 2, int size = 512, int quality = 100);</code></pre>
               <p class="doc">Generate a Micro QR code as image byte array with specified format.</p>
             </div>
             <div class="member" data-text="method public static byte[] getpngbytes(microqrcodedata microqrcodedata, int size = 512); generate a micro qr code as png byte array with default settings. ">
-              <h4><span class="kind">method</span> <span class="name">GetPngBytes</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/MicroQRCodeImageBuilder.cs#L83" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetPngBytes</a></h4>
               <pre class="sig"><code>public static byte[] GetPngBytes(MicroQRCodeData microQrCodeData, int size = 512);</code></pre>
               <p class="doc">Generate a Micro QR code as PNG byte array with default settings.</p>
             </div>
             <div class="member" data-text="method public static byte[] getpngbytes(string content, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code as png byte array with default settings. ">
-              <h4><span class="kind">method</span> <span class="name">GetPngBytes</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/MicroQRCodeImageBuilder.cs#L72" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetPngBytes</a></h4>
               <pre class="sig"><code>public static byte[] GetPngBytes(string content, MicroQREccLevel eccLevel = 2, int size = 512);</code></pre>
               <p class="doc">Generate a Micro QR code as PNG byte array with default settings.</p>
             </div>
             <div class="member" data-text="method public static byte[] getsvgbytes(microqrcodedata microqrcodedata, int size = 512); generate a micro qr code as svg (utf-8 encoded) byte array with default settings. ">
-              <h4><span class="kind">method</span> <span class="name">GetSvgBytes</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/MicroQRCodeImageBuilder.cs#L173" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetSvgBytes</a></h4>
               <pre class="sig"><code>public static byte[] GetSvgBytes(MicroQRCodeData microQrCodeData, int size = 512);</code></pre>
               <p class="doc">Generate a Micro QR code as SVG (UTF-8 encoded) byte array with default settings.</p>
             </div>
             <div class="member" data-text="method public static byte[] getsvgbytes(string content, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code as svg (utf-8 encoded) byte array with default settings. ">
-              <h4><span class="kind">method</span> <span class="name">GetSvgBytes</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/MicroQRCodeImageBuilder.cs#L157" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetSvgBytes</a></h4>
               <pre class="sig"><code>public static byte[] GetSvgBytes(string content, MicroQREccLevel eccLevel = 2, int size = 512);</code></pre>
               <p class="doc">Generate a Micro QR code as SVG (UTF-8 encoded) byte array with default settings.</p>
             </div>
             <div class="member" data-text="method public static string getsvgstring(microqrcodedata microqrcodedata, int size = 512); generate a micro qr code as svg document string with default settings. ">
-              <h4><span class="kind">method</span> <span class="name">GetSvgString</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/MicroQRCodeImageBuilder.cs#L231" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetSvgString</a></h4>
               <pre class="sig"><code>public static string GetSvgString(MicroQRCodeData microQrCodeData, int size = 512);</code></pre>
               <p class="doc">Generate a Micro QR code as SVG document string with default settings.</p>
             </div>
             <div class="member" data-text="method public static string getsvgstring(string content, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code as svg document string with default settings. ">
-              <h4><span class="kind">method</span> <span class="name">GetSvgString</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/MicroQRCodeImageBuilder.cs#L217" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetSvgString</a></h4>
               <pre class="sig"><code>public static string GetSvgString(string content, MicroQREccLevel eccLevel = 2, int size = 512);</code></pre>
               <p class="doc">Generate a Micro QR code as SVG document string with default settings.</p>
             </div>
             <div class="member" data-text="method public static void savepng(microqrcodedata microqrcodedata, stream output, int size = 512); generate a micro qr code and save to stream with default png settings. ">
-              <h4><span class="kind">method</span> <span class="name">SavePng</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/MicroQRCodeImageBuilder.cs#L143" title="View source on GitHub" target="_blank" rel="noopener noreferrer">SavePng</a></h4>
               <pre class="sig"><code>public static void SavePng(MicroQRCodeData microQrCodeData, Stream output, int size = 512);</code></pre>
               <p class="doc">Generate a Micro QR code and save to stream with default PNG settings.</p>
             </div>
             <div class="member" data-text="method public static void savepng(string content, stream output, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code and save to stream with default png settings. ">
-              <h4><span class="kind">method</span> <span class="name">SavePng</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/MicroQRCodeImageBuilder.cs#L129" title="View source on GitHub" target="_blank" rel="noopener noreferrer">SavePng</a></h4>
               <pre class="sig"><code>public static void SavePng(string content, Stream output, MicroQREccLevel eccLevel = 2, int size = 512);</code></pre>
               <p class="doc">Generate a Micro QR code and save to stream with default PNG settings.</p>
             </div>
             <div class="member" data-text="method public static void savesvg(microqrcodedata microqrcodedata, stream output, int size = 512); generate a micro qr code and save as svg to stream with default settings. ">
-              <h4><span class="kind">method</span> <span class="name">SaveSvg</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/MicroQRCodeImageBuilder.cs#L203" title="View source on GitHub" target="_blank" rel="noopener noreferrer">SaveSvg</a></h4>
               <pre class="sig"><code>public static void SaveSvg(MicroQRCodeData microQrCodeData, Stream output, int size = 512);</code></pre>
               <p class="doc">Generate a Micro QR code and save as SVG to stream with default settings.</p>
             </div>
             <div class="member" data-text="method public static void savesvg(string content, stream output, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code and save as svg to stream with default settings. ">
-              <h4><span class="kind">method</span> <span class="name">SaveSvg</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/MicroQRCodeImageBuilder.cs#L189" title="View source on GitHub" target="_blank" rel="noopener noreferrer">SaveSvg</a></h4>
               <pre class="sig"><code>public static void SaveSvg(string content, Stream output, MicroQREccLevel eccLevel = 2, int size = 512);</code></pre>
               <p class="doc">Generate a Micro QR code and save as SVG to stream with default settings.</p>
             </div>
             <div class="member" data-text="method public static void writeimage(microqrcodedata microqrcodedata, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, int size = 512, int quality = 100); generate a micro qr code and write to an ibufferwriter with specified format. ">
-              <h4><span class="kind">method</span> <span class="name">WriteImage</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/MicroQRCodeImageBuilder.cs#L315" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WriteImage</a></h4>
               <pre class="sig"><code>public static void WriteImage(MicroQRCodeData microQrCodeData, IBufferWriter&lt;byte&gt; writer, SKEncodedImageFormat format, int size = 512, int quality = 100);</code></pre>
               <p class="doc">Generate a Micro QR code and write to an IBufferWriter with specified format.</p>
             </div>
             <div class="member" data-text="method public static void writeimage(string content, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, microqrecclevel ecclevel = 2, int size = 512, int quality = 100); generate a micro qr code and write to an ibufferwriter with specified format. ">
-              <h4><span class="kind">method</span> <span class="name">WriteImage</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/MicroQRCodeImageBuilder.cs#L298" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WriteImage</a></h4>
               <pre class="sig"><code>public static void WriteImage(string content, IBufferWriter&lt;byte&gt; writer, SKEncodedImageFormat format, MicroQREccLevel eccLevel = 2, int size = 512, int quality = 100);</code></pre>
               <p class="doc">Generate a Micro QR code and write to an IBufferWriter with specified format.</p>
             </div>
             <div class="member" data-text="method public static void writepng(microqrcodedata microqrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate a micro qr code and write to an ibufferwriter with default png settings. ">
-              <h4><span class="kind">method</span> <span class="name">WritePng</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/MicroQRCodeImageBuilder.cs#L284" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WritePng</a></h4>
               <pre class="sig"><code>public static void WritePng(MicroQRCodeData microQrCodeData, IBufferWriter&lt;byte&gt; writer, int size = 512);</code></pre>
               <p class="doc">Generate a Micro QR code and write to an IBufferWriter with default PNG settings.</p>
             </div>
             <div class="member" data-text="method public static void writepng(string content, ibufferwriter&lt;byte&gt; writer, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code and write to an ibufferwriter with default png settings. ">
-              <h4><span class="kind">method</span> <span class="name">WritePng</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/MicroQRCodeImageBuilder.cs#L273" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WritePng</a></h4>
               <pre class="sig"><code>public static void WritePng(string content, IBufferWriter&lt;byte&gt; writer, MicroQREccLevel eccLevel = 2, int size = 512);</code></pre>
               <p class="doc">Generate a Micro QR code and write to an IBufferWriter with default PNG settings.</p>
             </div>
             <div class="member" data-text="method public static void writesvg(microqrcodedata microqrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate a micro qr code and write as svg (utf-8 encoded) to an ibufferwriter with default settings. ">
-              <h4><span class="kind">method</span> <span class="name">WriteSvg</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/MicroQRCodeImageBuilder.cs#L259" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WriteSvg</a></h4>
               <pre class="sig"><code>public static void WriteSvg(MicroQRCodeData microQrCodeData, IBufferWriter&lt;byte&gt; writer, int size = 512);</code></pre>
               <p class="doc">Generate a Micro QR code and write as SVG (UTF-8 encoded) to an IBufferWriter with default settings.</p>
             </div>
             <div class="member" data-text="method public static void writesvg(string content, ibufferwriter&lt;byte&gt; writer, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code and write as svg (utf-8 encoded) to an ibufferwriter with default settings. ">
-              <h4><span class="kind">method</span> <span class="name">WriteSvg</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/MicroQRCodeImageBuilder.cs#L245" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WriteSvg</a></h4>
               <pre class="sig"><code>public static void WriteSvg(string content, IBufferWriter&lt;byte&gt; writer, MicroQREccLevel eccLevel = 2, int size = 512);</code></pre>
               <p class="doc">Generate a Micro QR code and write as SVG (UTF-8 encoded) to an IBufferWriter with default settings.</p>
             </div>
@@ -2505,7 +2508,7 @@
           </div>
         </article>
         <article class="type" id="SkiaSharp.QrCode.Image.QRCodeImageBuilder" data-name="skiasharp.qrcode.image.qrcodeimagebuilder" data-text="skiasharp.qrcode.image.qrcodeimagebuilder public class qrcodeimagebuilder : qrcodeimagebuilderbase&lt;qrcodeimagebuilder&gt; high-level builder for creating qr code images with fluent configuration and static methods. this builder provides both simple static methods for quick qr code generation and a fluent api for advanced customization. quick generation (static methods): use static methods like getpngbytes for one-liner qr code creation with default settings. advanced configuration (fluent api): chain the shared options ( qrcodeimagebuilderbase , qrcodeimagebuilderbase , qrcodeimagebuilderbase , qrcodeimagebuilderbase , qrcodeimagebuilderbase ) with the standard qr-specific options ( witherrorcorrection , withversion , withicon , withfinderpatternshape ) to customize appearance. constructor public qrcodeimagebuilder(qrcodedata qrcodedata); starts a builder that draws a qr code you have already generated. the symbol is used exactly as given, so only the appearance options apply. most encoding options throw invalidoperationexception on a builder created this way; witherrorcorrection and withecimode are accepted and then ignored, because they shipped that way in 1.1.1.  constructor public qrcodeimagebuilder(string content); starts a builder that will encode content when you ask for an image. error correction, version and every other option keep their defaults until you set them.  method public qrcodeimagebuilder withecimode(ecimode ecimode); configure the eci (extended channel interpretation) mode for character encoding.  method public qrcodeimagebuilder witherrorcorrection(ecclevel ecclevel); configure the error correction level for the qr code.  method public qrcodeimagebuilder witherrorcorrectionboost(bool boostecclevel = true); raise the error correction level above the one configured with witherrorcorrection when the chosen version's capacity allows it, without changing the version or the symbol size. recommended together with withicon : the spare capacity absorbs the modules the icon covers.  method public qrcodeimagebuilder withfinderpatternshape(finderpatternshape? finderpatternshape); configure the shape of the finder patterns.  method public qrcodeimagebuilder withicon(icondata? icondata); configure an icon to overlay on the center of the qr code.  method public qrcodeimagebuilder withmaskpattern(int? maskpattern); pin one of the eight data mask patterns (0-7) instead of the automatic penalty-scored selection; see maskpattern .  method public qrcodeimagebuilder withsegmentation(qrcodesegmentation segmentation); split the content into mixed-mode segments when that lowers the version (see qrcodesegmentation ). defaults to single . never selects a larger version, and produces the identical symbol when a split would not shrink it.  method public qrcodeimagebuilder withversion(qrcodeversionrange versionrange); configure the versions the generator may choose from, rather than a single one. for a symbol that must reach, or not exceed, a physical size. an int? converts implicitly, so an optional version needs no branch. method public qrcodeimagebuilder withversion(int version); configure the qr code version to generate. the pinned case of withversion ; -1 is any . method public static byte[] getimagebytes(qrcodedata qrcodedata, skencodedimageformat format, int size = 512, int quality = 100); generate a qr code as image byte array with specified format.  method public static byte[] getimagebytes(string content, skencodedimageformat format, ecclevel ecclevel = 1, int size = 512, int quality = 100); generate a qr code as image byte array with specified format.  method public static byte[] getpngbytes(qrcodedata qrcodedata, int size = 512); generate a qr code as png byte array with default settings.  method public static byte[] getpngbytes(string content, ecclevel ecclevel = 1, int size = 512); generate a qr code as png byte array with default settings.  method public static byte[] getsvgbytes(qrcodedata qrcodedata, int size = 512); generate a qr code as svg (utf-8 encoded) byte array with default settings.  method public static byte[] getsvgbytes(string content, ecclevel ecclevel = 1, int size = 512); generate a qr code as svg (utf-8 encoded) byte array with default settings.  method public static string getsvgstring(qrcodedata qrcodedata, int size = 512); generate a qr code as svg document string with default settings.  method public static string getsvgstring(string content, ecclevel ecclevel = 1, int size = 512); generate a qr code as svg document string with default settings.  method public static void savepng(qrcodedata qrcodedata, stream output, int size = 512); generate a qr code and save to stream with default png settings.  method public static void savepng(string content, stream output, ecclevel ecclevel = 1, int size = 512); generate a qr code and save to stream with default png settings.  method public static void savesvg(qrcodedata qrcodedata, stream output, int size = 512); generate a qr code and save as svg to stream with default settings.  method public static void savesvg(string content, stream output, ecclevel ecclevel = 1, int size = 512); generate a qr code and save as svg to stream with default settings.  method public static void writeimage(qrcodedata qrcodedata, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, int size = 512, int quality = 100); generate a qr code and write to an ibufferwriter with specified format.  method public static void writeimage(string content, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, ecclevel ecclevel = 1, int size = 512, int quality = 100); generate a qr code and write to an ibufferwriter with specified format.  method public static void writepng(qrcodedata qrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate a qr code and write to an ibufferwriter with default png settings.  method public static void writepng(string content, ibufferwriter&lt;byte&gt; writer, ecclevel ecclevel = 1, int size = 512); generate a qr code and write to an ibufferwriter with default png settings.  method public static void writesvg(qrcodedata qrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate a qr code and write as svg (utf-8 encoded) to an ibufferwriter with default settings.  method public static void writesvg(string content, ibufferwriter&lt;byte&gt; writer, ecclevel ecclevel = 1, int size = 512); generate a qr code and write as svg (utf-8 encoded) to an ibufferwriter with default settings. ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.QRCodeImageBuilder" aria-label="Link to SkiaSharp.QrCode.Image.QRCodeImageBuilder">#</a><span class="kind">class</span> <span class="name">QRCodeImageBuilder</span></h3>
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.QRCodeImageBuilder" aria-label="Link to SkiaSharp.QrCode.Image.QRCodeImageBuilder">#</a><span class="kind">class</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs" title="View source file on GitHub" target="_blank" rel="noopener noreferrer">QRCodeImageBuilder</a></h3>
           <pre class="sig"><code>public class QRCodeImageBuilder : QRCodeImageBuilderBase&lt;QRCodeImageBuilder&gt;</code></pre>
           <p class="doc">High-level builder for creating QR code images with fluent configuration and static methods.</p>
           <details class="notes" data-text="this builder provides both simple static methods for quick qr code generation and a fluent api for advanced customization. quick generation (static methods): use static methods like getpngbytes for one-liner qr code creation with default settings. advanced configuration (fluent api): chain the shared options ( qrcodeimagebuilderbase , qrcodeimagebuilderbase , qrcodeimagebuilderbase , qrcodeimagebuilderbase , qrcodeimagebuilderbase ) with the standard qr-specific options ( witherrorcorrection , withversion , withicon , withfinderpatternshape ) to customize appearance.">
@@ -2514,52 +2517,52 @@
           </details>
           <div class="members">
             <div class="member" data-text="constructor public qrcodeimagebuilder(qrcodedata qrcodedata); starts a builder that draws a qr code you have already generated. the symbol is used exactly as given, so only the appearance options apply. most encoding options throw invalidoperationexception on a builder created this way; witherrorcorrection and withecimode are accepted and then ignored, because they shipped that way in 1.1.1. ">
-              <h4><span class="kind">constructor</span> <span class="name">QRCodeImageBuilder</span></h4>
+              <h4><span class="kind">constructor</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs#L36" title="View source on GitHub" target="_blank" rel="noopener noreferrer">QRCodeImageBuilder</a></h4>
               <pre class="sig"><code>public QRCodeImageBuilder(QRCodeData qrCodeData);</code></pre>
               <p class="doc">Starts a builder that draws a QR code you have already generated. The symbol is used exactly as given, so only the appearance options apply. Most encoding options throw InvalidOperationException on a builder created this way; WithErrorCorrection and WithEciMode are accepted and then ignored, because they shipped that way in 1.1.1.</p>
             </div>
             <div class="member" data-text="constructor public qrcodeimagebuilder(string content); starts a builder that will encode content when you ask for an image. error correction, version and every other option keep their defaults until you set them. ">
-              <h4><span class="kind">constructor</span> <span class="name">QRCodeImageBuilder</span></h4>
+              <h4><span class="kind">constructor</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs#L36" title="View source on GitHub" target="_blank" rel="noopener noreferrer">QRCodeImageBuilder</a></h4>
               <pre class="sig"><code>public QRCodeImageBuilder(string content);</code></pre>
               <p class="doc">Starts a builder that will encode content when you ask for an image. Error correction, version and every other option keep their defaults until you set them.</p>
             </div>
             <div class="member" data-text="method public qrcodeimagebuilder withecimode(ecimode ecimode); configure the eci (extended channel interpretation) mode for character encoding. ">
-              <h4><span class="kind">method</span> <span class="name">WithEciMode</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs#L377" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WithEciMode</a></h4>
               <pre class="sig"><code>public QRCodeImageBuilder WithEciMode(EciMode eciMode);</code></pre>
               <p class="doc">Configure the ECI (Extended Channel Interpretation) mode for character encoding.</p>
             </div>
             <div class="member" data-text="method public qrcodeimagebuilder witherrorcorrection(ecclevel ecclevel); configure the error correction level for the qr code. ">
-              <h4><span class="kind">method</span> <span class="name">WithErrorCorrection</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs#L347" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WithErrorCorrection</a></h4>
               <pre class="sig"><code>public QRCodeImageBuilder WithErrorCorrection(ECCLevel eccLevel);</code></pre>
               <p class="doc">Configure the error correction level for the QR code.</p>
             </div>
             <div class="member" data-text="method public qrcodeimagebuilder witherrorcorrectionboost(bool boostecclevel = true); raise the error correction level above the one configured with witherrorcorrection when the chosen version's capacity allows it, without changing the version or the symbol size. recommended together with withicon : the spare capacity absorbs the modules the icon covers. ">
-              <h4><span class="kind">method</span> <span class="name">WithErrorCorrectionBoost</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs#L363" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WithErrorCorrectionBoost</a></h4>
               <pre class="sig"><code>public QRCodeImageBuilder WithErrorCorrectionBoost(bool boostEccLevel = true);</code></pre>
               <p class="doc">Raise the error correction level above the one configured with WithErrorCorrection when the chosen version's capacity allows it, without changing the version or the symbol size. Recommended together with WithIcon : the spare capacity absorbs the modules the icon covers.</p>
             </div>
             <div class="member" data-text="method public qrcodeimagebuilder withfinderpatternshape(finderpatternshape? finderpatternshape); configure the shape of the finder patterns. ">
-              <h4><span class="kind">method</span> <span class="name">WithFinderPatternShape</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs#L474" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WithFinderPatternShape</a></h4>
               <pre class="sig"><code>public QRCodeImageBuilder WithFinderPatternShape(FinderPatternShape? finderPatternShape);</code></pre>
               <p class="doc">Configure the shape of the finder patterns.</p>
             </div>
             <div class="member" data-text="method public qrcodeimagebuilder withicon(icondata? icondata); configure an icon to overlay on the center of the qr code. ">
-              <h4><span class="kind">method</span> <span class="name">WithIcon</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs#L463" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WithIcon</a></h4>
               <pre class="sig"><code>public QRCodeImageBuilder WithIcon(IconData? iconData);</code></pre>
               <p class="doc">Configure an icon to overlay on the center of the QR code.</p>
             </div>
             <div class="member" data-text="method public qrcodeimagebuilder withmaskpattern(int? maskpattern); pin one of the eight data mask patterns (0-7) instead of the automatic penalty-scored selection; see maskpattern . ">
-              <h4><span class="kind">method</span> <span class="name">WithMaskPattern</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs#L426" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WithMaskPattern</a></h4>
               <pre class="sig"><code>public QRCodeImageBuilder WithMaskPattern(int? maskPattern);</code></pre>
               <p class="doc">Pin one of the eight data mask patterns (0-7) instead of the automatic penalty-scored selection; see MaskPattern .</p>
             </div>
             <div class="member" data-text="method public qrcodeimagebuilder withsegmentation(qrcodesegmentation segmentation); split the content into mixed-mode segments when that lowers the version (see qrcodesegmentation ). defaults to single . never selects a larger version, and produces the identical symbol when a split would not shrink it. ">
-              <h4><span class="kind">method</span> <span class="name">WithSegmentation</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs#L447" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WithSegmentation</a></h4>
               <pre class="sig"><code>public QRCodeImageBuilder WithSegmentation(QRCodeSegmentation segmentation);</code></pre>
               <p class="doc">Split the content into mixed-mode segments when that lowers the version (see QRCodeSegmentation ). Defaults to Single . Never selects a larger version, and produces the identical symbol when a split would not shrink it.</p>
             </div>
             <div class="member" data-text="method public qrcodeimagebuilder withversion(qrcodeversionrange versionrange); configure the versions the generator may choose from, rather than a single one. for a symbol that must reach, or not exceed, a physical size. an int? converts implicitly, so an optional version needs no branch.">
-              <h4><span class="kind">method</span> <span class="name">WithVersion</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs#L409" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WithVersion</a></h4>
               <pre class="sig"><code>public QRCodeImageBuilder WithVersion(QRCodeVersionRange versionRange);</code></pre>
               <p class="doc">Configure the versions the generator may choose from, rather than a single one.</p>
               <details class="notes" data-text="for a symbol that must reach, or not exceed, a physical size. an int? converts implicitly, so an optional version needs no branch.">
@@ -2568,7 +2571,7 @@
               </details>
             </div>
             <div class="member" data-text="method public qrcodeimagebuilder withversion(int version); configure the qr code version to generate. the pinned case of withversion ; -1 is any .">
-              <h4><span class="kind">method</span> <span class="name">WithVersion</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs#L391" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WithVersion</a></h4>
               <pre class="sig"><code>public QRCodeImageBuilder WithVersion(int version);</code></pre>
               <p class="doc">Configure the QR code version to generate.</p>
               <details class="notes" data-text="the pinned case of withversion ; -1 is any .">
@@ -2577,99 +2580,99 @@
               </details>
             </div>
             <div class="member" data-text="method public static byte[] getimagebytes(qrcodedata qrcodedata, skencodedimageformat format, int size = 512, int quality = 100); generate a qr code as image byte array with specified format. ">
-              <h4><span class="kind">method</span> <span class="name">GetImageBytes</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs#L131" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetImageBytes</a></h4>
               <pre class="sig"><code>public static byte[] GetImageBytes(QRCodeData qrCodeData, SKEncodedImageFormat format, int size = 512, int quality = 100);</code></pre>
               <p class="doc">Generate a QR code as image byte array with specified format.</p>
             </div>
             <div class="member" data-text="method public static byte[] getimagebytes(string content, skencodedimageformat format, ecclevel ecclevel = 1, int size = 512, int quality = 100); generate a qr code as image byte array with specified format. ">
-              <h4><span class="kind">method</span> <span class="name">GetImageBytes</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs#L114" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetImageBytes</a></h4>
               <pre class="sig"><code>public static byte[] GetImageBytes(string content, SKEncodedImageFormat format, ECCLevel eccLevel = 1, int size = 512, int quality = 100);</code></pre>
               <p class="doc">Generate a QR code as image byte array with specified format.</p>
             </div>
             <div class="member" data-text="method public static byte[] getpngbytes(qrcodedata qrcodedata, int size = 512); generate a qr code as png byte array with default settings. ">
-              <h4><span class="kind">method</span> <span class="name">GetPngBytes</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs#L100" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetPngBytes</a></h4>
               <pre class="sig"><code>public static byte[] GetPngBytes(QRCodeData qrCodeData, int size = 512);</code></pre>
               <p class="doc">Generate a QR code as PNG byte array with default settings.</p>
             </div>
             <div class="member" data-text="method public static byte[] getpngbytes(string content, ecclevel ecclevel = 1, int size = 512); generate a qr code as png byte array with default settings. ">
-              <h4><span class="kind">method</span> <span class="name">GetPngBytes</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs#L89" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetPngBytes</a></h4>
               <pre class="sig"><code>public static byte[] GetPngBytes(string content, ECCLevel eccLevel = 1, int size = 512);</code></pre>
               <p class="doc">Generate a QR code as PNG byte array with default settings.</p>
             </div>
             <div class="member" data-text="method public static byte[] getsvgbytes(qrcodedata qrcodedata, int size = 512); generate a qr code as svg (utf-8 encoded) byte array with default settings. ">
-              <h4><span class="kind">method</span> <span class="name">GetSvgBytes</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs#L190" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetSvgBytes</a></h4>
               <pre class="sig"><code>public static byte[] GetSvgBytes(QRCodeData qrCodeData, int size = 512);</code></pre>
               <p class="doc">Generate a QR code as SVG (UTF-8 encoded) byte array with default settings.</p>
             </div>
             <div class="member" data-text="method public static byte[] getsvgbytes(string content, ecclevel ecclevel = 1, int size = 512); generate a qr code as svg (utf-8 encoded) byte array with default settings. ">
-              <h4><span class="kind">method</span> <span class="name">GetSvgBytes</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs#L174" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetSvgBytes</a></h4>
               <pre class="sig"><code>public static byte[] GetSvgBytes(string content, ECCLevel eccLevel = 1, int size = 512);</code></pre>
               <p class="doc">Generate a QR code as SVG (UTF-8 encoded) byte array with default settings.</p>
             </div>
             <div class="member" data-text="method public static string getsvgstring(qrcodedata qrcodedata, int size = 512); generate a qr code as svg document string with default settings. ">
-              <h4><span class="kind">method</span> <span class="name">GetSvgString</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs#L248" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetSvgString</a></h4>
               <pre class="sig"><code>public static string GetSvgString(QRCodeData qrCodeData, int size = 512);</code></pre>
               <p class="doc">Generate a QR code as SVG document string with default settings.</p>
             </div>
             <div class="member" data-text="method public static string getsvgstring(string content, ecclevel ecclevel = 1, int size = 512); generate a qr code as svg document string with default settings. ">
-              <h4><span class="kind">method</span> <span class="name">GetSvgString</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs#L234" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetSvgString</a></h4>
               <pre class="sig"><code>public static string GetSvgString(string content, ECCLevel eccLevel = 1, int size = 512);</code></pre>
               <p class="doc">Generate a QR code as SVG document string with default settings.</p>
             </div>
             <div class="member" data-text="method public static void savepng(qrcodedata qrcodedata, stream output, int size = 512); generate a qr code and save to stream with default png settings. ">
-              <h4><span class="kind">method</span> <span class="name">SavePng</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs#L160" title="View source on GitHub" target="_blank" rel="noopener noreferrer">SavePng</a></h4>
               <pre class="sig"><code>public static void SavePng(QRCodeData qrCodeData, Stream output, int size = 512);</code></pre>
               <p class="doc">Generate a QR code and save to stream with default PNG settings.</p>
             </div>
             <div class="member" data-text="method public static void savepng(string content, stream output, ecclevel ecclevel = 1, int size = 512); generate a qr code and save to stream with default png settings. ">
-              <h4><span class="kind">method</span> <span class="name">SavePng</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs#L146" title="View source on GitHub" target="_blank" rel="noopener noreferrer">SavePng</a></h4>
               <pre class="sig"><code>public static void SavePng(string content, Stream output, ECCLevel eccLevel = 1, int size = 512);</code></pre>
               <p class="doc">Generate a QR code and save to stream with default PNG settings.</p>
             </div>
             <div class="member" data-text="method public static void savesvg(qrcodedata qrcodedata, stream output, int size = 512); generate a qr code and save as svg to stream with default settings. ">
-              <h4><span class="kind">method</span> <span class="name">SaveSvg</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs#L220" title="View source on GitHub" target="_blank" rel="noopener noreferrer">SaveSvg</a></h4>
               <pre class="sig"><code>public static void SaveSvg(QRCodeData qrCodeData, Stream output, int size = 512);</code></pre>
               <p class="doc">Generate a QR code and save as SVG to stream with default settings.</p>
             </div>
             <div class="member" data-text="method public static void savesvg(string content, stream output, ecclevel ecclevel = 1, int size = 512); generate a qr code and save as svg to stream with default settings. ">
-              <h4><span class="kind">method</span> <span class="name">SaveSvg</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs#L206" title="View source on GitHub" target="_blank" rel="noopener noreferrer">SaveSvg</a></h4>
               <pre class="sig"><code>public static void SaveSvg(string content, Stream output, ECCLevel eccLevel = 1, int size = 512);</code></pre>
               <p class="doc">Generate a QR code and save as SVG to stream with default settings.</p>
             </div>
             <div class="member" data-text="method public static void writeimage(qrcodedata qrcodedata, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, int size = 512, int quality = 100); generate a qr code and write to an ibufferwriter with specified format. ">
-              <h4><span class="kind">method</span> <span class="name">WriteImage</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs#L332" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WriteImage</a></h4>
               <pre class="sig"><code>public static void WriteImage(QRCodeData qrCodeData, IBufferWriter&lt;byte&gt; writer, SKEncodedImageFormat format, int size = 512, int quality = 100);</code></pre>
               <p class="doc">Generate a QR code and write to an IBufferWriter with specified format.</p>
             </div>
             <div class="member" data-text="method public static void writeimage(string content, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, ecclevel ecclevel = 1, int size = 512, int quality = 100); generate a qr code and write to an ibufferwriter with specified format. ">
-              <h4><span class="kind">method</span> <span class="name">WriteImage</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs#L315" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WriteImage</a></h4>
               <pre class="sig"><code>public static void WriteImage(string content, IBufferWriter&lt;byte&gt; writer, SKEncodedImageFormat format, ECCLevel eccLevel = 1, int size = 512, int quality = 100);</code></pre>
               <p class="doc">Generate a QR code and write to an IBufferWriter with specified format.</p>
             </div>
             <div class="member" data-text="method public static void writepng(qrcodedata qrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate a qr code and write to an ibufferwriter with default png settings. ">
-              <h4><span class="kind">method</span> <span class="name">WritePng</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs#L301" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WritePng</a></h4>
               <pre class="sig"><code>public static void WritePng(QRCodeData qrCodeData, IBufferWriter&lt;byte&gt; writer, int size = 512);</code></pre>
               <p class="doc">Generate a QR code and write to an IBufferWriter with default PNG settings.</p>
             </div>
             <div class="member" data-text="method public static void writepng(string content, ibufferwriter&lt;byte&gt; writer, ecclevel ecclevel = 1, int size = 512); generate a qr code and write to an ibufferwriter with default png settings. ">
-              <h4><span class="kind">method</span> <span class="name">WritePng</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs#L290" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WritePng</a></h4>
               <pre class="sig"><code>public static void WritePng(string content, IBufferWriter&lt;byte&gt; writer, ECCLevel eccLevel = 1, int size = 512);</code></pre>
               <p class="doc">Generate a QR code and write to an IBufferWriter with default PNG settings.</p>
             </div>
             <div class="member" data-text="method public static void writesvg(qrcodedata qrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate a qr code and write as svg (utf-8 encoded) to an ibufferwriter with default settings. ">
-              <h4><span class="kind">method</span> <span class="name">WriteSvg</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs#L276" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WriteSvg</a></h4>
               <pre class="sig"><code>public static void WriteSvg(QRCodeData qrCodeData, IBufferWriter&lt;byte&gt; writer, int size = 512);</code></pre>
               <p class="doc">Generate a QR code and write as SVG (UTF-8 encoded) to an IBufferWriter with default settings.</p>
             </div>
             <div class="member" data-text="method public static void writesvg(string content, ibufferwriter&lt;byte&gt; writer, ecclevel ecclevel = 1, int size = 512); generate a qr code and write as svg (utf-8 encoded) to an ibufferwriter with default settings. ">
-              <h4><span class="kind">method</span> <span class="name">WriteSvg</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs#L262" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WriteSvg</a></h4>
               <pre class="sig"><code>public static void WriteSvg(string content, IBufferWriter&lt;byte&gt; writer, ECCLevel eccLevel = 1, int size = 512);</code></pre>
               <p class="doc">Generate a QR code and write as SVG (UTF-8 encoded) to an IBufferWriter with default settings.</p>
             </div>
           </div>
         </article>
         <article class="type" id="SkiaSharp.QrCode.Image.QRCodeImageBuilderBase" data-name="skiasharp.qrcode.image.qrcodeimagebuilderbase" data-text="skiasharp.qrcode.image.qrcodeimagebuilderbase public abstract class qrcodeimagebuilderbase&lt;tself&gt; shared implementation for the symbology-specific qr image builders ( qrcodeimagebuilder , microqrcodeimagebuilder ): the fluent options every symbology supports, canvas layout, and the complete raster/svg output surface. symbology-specific concerns, error correction and version types, icon overlays, finder pattern styling, live on the derived builders. the self-referential type parameter keeps fluent chains typed to the concrete builder, so shared and symbology-specific options mix freely without casts: new microqrcodeimagebuilder(&quot;...&quot;).withsize(256, 256).withversion(microqrversion.m4). deriving from this class outside the library is not supported: the abstract hooks that connect a symbology's data model to the shared output pipeline are private protected. method public qrcodeimagebuilderbase.tself withcolors(skcolor? codecolor = null, skcolor? backgroundcolor = null, skcolor? clearcolor = null); configure the colors used in the image.  method public qrcodeimagebuilderbase.tself withformat(skencodedimageformat format, int quality = 100); configure the output image format and quality.  method public qrcodeimagebuilderbase.tself withgradient(gradientoptions? gradientoptions); configure gradient options for the modules.  method public qrcodeimagebuilderbase.tself withmodulepixelsize(int modulepixelsize); configure content size from pixels-per-module. sets each module to an exact integer pixel size. content side length is matrixsize * modulepixelsize. used alone, the output image matches the content size. used with qrcodeimagebuilderbase , the content is centered on the larger canvas and padded with clearcolor. if the canvas is smaller than the content, rendering throws. method public qrcodeimagebuilderbase.tself withmoduleshape(moduleshape? moduleshape, float sizepercent = 1); configure the shape of the modules. note: custom module shapes reduce scan margin; sizes below 0.8 may affect readability. on standard qr they also affect finder patterns unless a custom finder pattern shape is explicitly set via its withfinderpatternshape option. method public qrcodeimagebuilderbase.tself withquietzone(int size); configure the quiet zone size (light border) around the symbol. when not called, the builder uses its symbology's specification default: 4 modules for standard qr, 2 for micro qr and rmqr. ignored when the builder was given pre-built symbol data (the data already carries its quiet zone). method public qrcodeimagebuilderbase.tself withsize(int width, int height); configure the output image size in absolute pixels. used alone, this sets an exact canvas size. for the square symbologies the module pixel size then becomes imagesize / matrixsize, which may be fractional and can change when the version changes; the rectangular rmqr builder fits the symbol into the canvas with a uniform module scale instead (letterbox, the leftover pad keeps clearcolor). used with qrcodeimagebuilderbase , this sets the canvas size while module pixels define the content size (matrixsize * modulepixelsize). the canvas must be at least as large as the content on both sides; extra space is padded and the content is centered. padding uses clearcolor from qrcodeimagebuilderbase . method public skbitmap tobitmap(); generate the symbol image and return as skbitmap.  method public skimage toimage(); generate the symbol image and return as skimage.  method public byte[] tobytearray(); generate the symbol image and return as byte array.  method public string tosvgstring(); generate the symbol and return as svg document string. see qrcodeimagebuilderbase for rendering behavior. method public void saveto(ibufferwriter&lt;byte&gt; writer); generate the symbol image and write to an ibufferwriter. this is more efficient than saveto(stream) as it avoids intermediate buffering.  method public void saveto(stream output); generate the symbol image and save to stream.  method public void savetosvg(ibufferwriter&lt;byte&gt; writer); generate the symbol and write as svg document to an ibufferwriter. see qrcodeimagebuilderbase for rendering behavior. data is written in writer-provided segments, so segmented writers (e.g. pipewriter) work without a single contiguous buffer for the whole document. method public void savetosvg(stream output); generate the symbol and save as svg document to stream. the symbol is drawn as vector shapes via sksvgcanvas , so the output scales without quality loss. all builder options apply. the root element carries a viewbox, so the document scales its content when embedded at a different size (img element, css). for plain rectangular modules, shape-rendering=&quot;crispedges&quot; is added to avoid antialiasing seams between modules; custom shapes keep antialiasing for smooth curves. qrcodeimagebuilderbase is ignored, svg is a vector format, not an skencodedimageformat . size options ( qrcodeimagebuilderbase , qrcodeimagebuilderbase , or the symbology's default canvas) define the svg viewport in units. the stream is left open after writing.">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.QRCodeImageBuilderBase" aria-label="Link to SkiaSharp.QrCode.Image.QRCodeImageBuilderBase">#</a><span class="kind">class</span> <span class="name">QRCodeImageBuilderBase</span></h3>
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.QRCodeImageBuilderBase" aria-label="Link to SkiaSharp.QrCode.Image.QRCodeImageBuilderBase">#</a><span class="kind">class</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilderBase.cs" title="View source file on GitHub" target="_blank" rel="noopener noreferrer">QRCodeImageBuilderBase</a></h3>
           <pre class="sig"><code>public abstract class QRCodeImageBuilderBase&lt;TSelf&gt;</code></pre>
           <p class="doc">Shared implementation for the symbology-specific QR image builders ( QRCodeImageBuilder , MicroQRCodeImageBuilder ): the fluent options every symbology supports, canvas layout, and the complete raster/SVG output surface. Symbology-specific concerns, error correction and version types, icon overlays, finder pattern styling, live on the derived builders.</p>
           <details class="notes" data-text="the self-referential type parameter keeps fluent chains typed to the concrete builder, so shared and symbology-specific options mix freely without casts: new microqrcodeimagebuilder(&quot;...&quot;).withsize(256, 256).withversion(microqrversion.m4). deriving from this class outside the library is not supported: the abstract hooks that connect a symbology's data model to the shared output pipeline are private protected.">
@@ -2678,22 +2681,22 @@
           </details>
           <div class="members">
             <div class="member" data-text="method public qrcodeimagebuilderbase.tself withcolors(skcolor? codecolor = null, skcolor? backgroundcolor = null, skcolor? clearcolor = null); configure the colors used in the image. ">
-              <h4><span class="kind">method</span> <span class="name">WithColors</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilderBase.cs#L184" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WithColors</a></h4>
               <pre class="sig"><code>public QRCodeImageBuilderBase.TSelf WithColors(SKColor? codeColor = null, SKColor? backgroundColor = null, SKColor? clearColor = null);</code></pre>
               <p class="doc">Configure the colors used in the image.</p>
             </div>
             <div class="member" data-text="method public qrcodeimagebuilderbase.tself withformat(skencodedimageformat format, int quality = 100); configure the output image format and quality. ">
-              <h4><span class="kind">method</span> <span class="name">WithFormat</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilderBase.cs#L148" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WithFormat</a></h4>
               <pre class="sig"><code>public QRCodeImageBuilderBase.TSelf WithFormat(SKEncodedImageFormat format, int quality = 100);</code></pre>
               <p class="doc">Configure the output image format and quality.</p>
             </div>
             <div class="member" data-text="method public qrcodeimagebuilderbase.tself withgradient(gradientoptions? gradientoptions); configure gradient options for the modules. ">
-              <h4><span class="kind">method</span> <span class="name">WithGradient</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilderBase.cs#L219" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WithGradient</a></h4>
               <pre class="sig"><code>public QRCodeImageBuilderBase.TSelf WithGradient(GradientOptions? gradientOptions);</code></pre>
               <p class="doc">Configure gradient options for the modules.</p>
             </div>
             <div class="member" data-text="method public qrcodeimagebuilderbase.tself withmodulepixelsize(int modulepixelsize); configure content size from pixels-per-module. sets each module to an exact integer pixel size. content side length is matrixsize * modulepixelsize. used alone, the output image matches the content size. used with qrcodeimagebuilderbase , the content is centered on the larger canvas and padded with clearcolor. if the canvas is smaller than the content, rendering throws.">
-              <h4><span class="kind">method</span> <span class="name">WithModulePixelSize</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilderBase.cs#L132" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WithModulePixelSize</a></h4>
               <pre class="sig"><code>public QRCodeImageBuilderBase.TSelf WithModulePixelSize(int modulePixelSize);</code></pre>
               <p class="doc">Configure content size from pixels-per-module.</p>
               <details class="notes" data-text="sets each module to an exact integer pixel size. content side length is matrixsize * modulepixelsize. used alone, the output image matches the content size. used with qrcodeimagebuilderbase , the content is centered on the larger canvas and padded with clearcolor. if the canvas is smaller than the content, rendering throws.">
@@ -2702,7 +2705,7 @@
               </details>
             </div>
             <div class="member" data-text="method public qrcodeimagebuilderbase.tself withmoduleshape(moduleshape? moduleshape, float sizepercent = 1); configure the shape of the modules. note: custom module shapes reduce scan margin; sizes below 0.8 may affect readability. on standard qr they also affect finder patterns unless a custom finder pattern shape is explicitly set via its withfinderpatternshape option.">
-              <h4><span class="kind">method</span> <span class="name">WithModuleShape</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilderBase.cs#L204" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WithModuleShape</a></h4>
               <pre class="sig"><code>public QRCodeImageBuilderBase.TSelf WithModuleShape(ModuleShape? moduleShape, float sizePercent = 1);</code></pre>
               <p class="doc">Configure the shape of the modules.</p>
               <details class="notes" data-text="note: custom module shapes reduce scan margin; sizes below 0.8 may affect readability. on standard qr they also affect finder patterns unless a custom finder pattern shape is explicitly set via its withfinderpatternshape option.">
@@ -2711,7 +2714,7 @@
               </details>
             </div>
             <div class="member" data-text="method public qrcodeimagebuilderbase.tself withquietzone(int size); configure the quiet zone size (light border) around the symbol. when not called, the builder uses its symbology's specification default: 4 modules for standard qr, 2 for micro qr and rmqr. ignored when the builder was given pre-built symbol data (the data already carries its quiet zone).">
-              <h4><span class="kind">method</span> <span class="name">WithQuietZone</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilderBase.cs#L169" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WithQuietZone</a></h4>
               <pre class="sig"><code>public QRCodeImageBuilderBase.TSelf WithQuietZone(int size);</code></pre>
               <p class="doc">Configure the quiet zone size (light border) around the symbol.</p>
               <details class="notes" data-text="when not called, the builder uses its symbology's specification default: 4 modules for standard qr, 2 for micro qr and rmqr. ignored when the builder was given pre-built symbol data (the data already carries its quiet zone).">
@@ -2720,7 +2723,7 @@
               </details>
             </div>
             <div class="member" data-text="method public qrcodeimagebuilderbase.tself withsize(int width, int height); configure the output image size in absolute pixels. used alone, this sets an exact canvas size. for the square symbologies the module pixel size then becomes imagesize / matrixsize, which may be fractional and can change when the version changes; the rectangular rmqr builder fits the symbol into the canvas with a uniform module scale instead (letterbox, the leftover pad keeps clearcolor). used with qrcodeimagebuilderbase , this sets the canvas size while module pixels define the content size (matrixsize * modulepixelsize). the canvas must be at least as large as the content on both sides; extra space is padded and the content is centered. padding uses clearcolor from qrcodeimagebuilderbase .">
-              <h4><span class="kind">method</span> <span class="name">WithSize</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilderBase.cs#L104" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WithSize</a></h4>
               <pre class="sig"><code>public QRCodeImageBuilderBase.TSelf WithSize(int width, int height);</code></pre>
               <p class="doc">Configure the output image size in absolute pixels.</p>
               <details class="notes" data-text="used alone, this sets an exact canvas size. for the square symbologies the module pixel size then becomes imagesize / matrixsize, which may be fractional and can change when the version changes; the rectangular rmqr builder fits the symbol into the canvas with a uniform module scale instead (letterbox, the leftover pad keeps clearcolor). used with qrcodeimagebuilderbase , this sets the canvas size while module pixels define the content size (matrixsize * modulepixelsize). the canvas must be at least as large as the content on both sides; extra space is padded and the content is centered. padding uses clearcolor from qrcodeimagebuilderbase .">
@@ -2729,22 +2732,22 @@
               </details>
             </div>
             <div class="member" data-text="method public skbitmap tobitmap(); generate the symbol image and return as skbitmap. ">
-              <h4><span class="kind">method</span> <span class="name">ToBitmap</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilderBase.cs#L357" title="View source on GitHub" target="_blank" rel="noopener noreferrer">ToBitmap</a></h4>
               <pre class="sig"><code>public SKBitmap ToBitmap();</code></pre>
               <p class="doc">Generate the symbol image and return as SKBitmap.</p>
             </div>
             <div class="member" data-text="method public skimage toimage(); generate the symbol image and return as skimage. ">
-              <h4><span class="kind">method</span> <span class="name">ToImage</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilderBase.cs#L348" title="View source on GitHub" target="_blank" rel="noopener noreferrer">ToImage</a></h4>
               <pre class="sig"><code>public SKImage ToImage();</code></pre>
               <p class="doc">Generate the symbol image and return as SKImage.</p>
             </div>
             <div class="member" data-text="method public byte[] tobytearray(); generate the symbol image and return as byte array. ">
-              <h4><span class="kind">method</span> <span class="name">ToByteArray</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilderBase.cs#L337" title="View source on GitHub" target="_blank" rel="noopener noreferrer">ToByteArray</a></h4>
               <pre class="sig"><code>public byte[] ToByteArray();</code></pre>
               <p class="doc">Generate the symbol image and return as byte array.</p>
             </div>
             <div class="member" data-text="method public string tosvgstring(); generate the symbol and return as svg document string. see qrcodeimagebuilderbase for rendering behavior.">
-              <h4><span class="kind">method</span> <span class="name">ToSvgString</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilderBase.cs#L326" title="View source on GitHub" target="_blank" rel="noopener noreferrer">ToSvgString</a></h4>
               <pre class="sig"><code>public string ToSvgString();</code></pre>
               <p class="doc">Generate the symbol and return as SVG document string.</p>
               <details class="notes" data-text="see qrcodeimagebuilderbase for rendering behavior.">
@@ -2753,17 +2756,17 @@
               </details>
             </div>
             <div class="member" data-text="method public void saveto(ibufferwriter&lt;byte&gt; writer); generate the symbol image and write to an ibufferwriter. this is more efficient than saveto(stream) as it avoids intermediate buffering. ">
-              <h4><span class="kind">method</span> <span class="name">SaveTo</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilderBase.cs#L253" title="View source on GitHub" target="_blank" rel="noopener noreferrer">SaveTo</a></h4>
               <pre class="sig"><code>public void SaveTo(IBufferWriter&lt;byte&gt; writer);</code></pre>
               <p class="doc">Generate the symbol image and write to an IBufferWriter. This is more efficient than SaveTo(Stream) as it avoids intermediate buffering.</p>
             </div>
             <div class="member" data-text="method public void saveto(stream output); generate the symbol image and save to stream. ">
-              <h4><span class="kind">method</span> <span class="name">SaveTo</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilderBase.cs#L233" title="View source on GitHub" target="_blank" rel="noopener noreferrer">SaveTo</a></h4>
               <pre class="sig"><code>public void SaveTo(Stream output);</code></pre>
               <p class="doc">Generate the symbol image and save to stream.</p>
             </div>
             <div class="member" data-text="method public void savetosvg(ibufferwriter&lt;byte&gt; writer); generate the symbol and write as svg document to an ibufferwriter. see qrcodeimagebuilderbase for rendering behavior. data is written in writer-provided segments, so segmented writers (e.g. pipewriter) work without a single contiguous buffer for the whole document.">
-              <h4><span class="kind">method</span> <span class="name">SaveToSvg</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilderBase.cs#L310" title="View source on GitHub" target="_blank" rel="noopener noreferrer">SaveToSvg</a></h4>
               <pre class="sig"><code>public void SaveToSvg(IBufferWriter&lt;byte&gt; writer);</code></pre>
               <p class="doc">Generate the symbol and write as SVG document to an IBufferWriter.</p>
               <details class="notes" data-text="see qrcodeimagebuilderbase for rendering behavior. data is written in writer-provided segments, so segmented writers (e.g. pipewriter) work without a single contiguous buffer for the whole document.">
@@ -2772,7 +2775,7 @@
               </details>
             </div>
             <div class="member" data-text="method public void savetosvg(stream output); generate the symbol and save as svg document to stream. the symbol is drawn as vector shapes via sksvgcanvas , so the output scales without quality loss. all builder options apply. the root element carries a viewbox, so the document scales its content when embedded at a different size (img element, css). for plain rectangular modules, shape-rendering=&quot;crispedges&quot; is added to avoid antialiasing seams between modules; custom shapes keep antialiasing for smooth curves. qrcodeimagebuilderbase is ignored, svg is a vector format, not an skencodedimageformat . size options ( qrcodeimagebuilderbase , qrcodeimagebuilderbase , or the symbology's default canvas) define the svg viewport in units. the stream is left open after writing.">
-              <h4><span class="kind">method</span> <span class="name">SaveToSvg</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/QRCodeImageBuilderBase.cs#L290" title="View source on GitHub" target="_blank" rel="noopener noreferrer">SaveToSvg</a></h4>
               <pre class="sig"><code>public void SaveToSvg(Stream output);</code></pre>
               <p class="doc">Generate the symbol and save as SVG document to stream.</p>
               <details class="notes" data-text="the symbol is drawn as vector shapes via sksvgcanvas , so the output scales without quality loss. all builder options apply. the root element carries a viewbox, so the document scales its content when embedded at a different size (img element, css). for plain rectangular modules, shape-rendering=&quot;crispedges&quot; is added to avoid antialiasing seams between modules; custom shapes keep antialiasing for smooth curves. qrcodeimagebuilderbase is ignored, svg is a vector format, not an skencodedimageformat . size options ( qrcodeimagebuilderbase , qrcodeimagebuilderbase , or the symbology's default canvas) define the svg viewport in units. the stream is left open after writing.">
@@ -2783,7 +2786,7 @@
           </div>
         </article>
         <article class="type" id="SkiaSharp.QrCode.Image.RectangleFinderPatternShape" data-name="skiasharp.qrcode.image.rectanglefinderpatternshape" data-text="skiasharp.qrcode.image.rectanglefinderpatternshape public sealed class rectanglefinderpatternshape : finderpatternshape standard qr code finder pattern (three nested squares, 7x7, 5x5, 3x3).  field public static readonly rectanglefinderpatternshape default; gets the default instance.  property public bool requiresantialiasing { get; } antialiasing disabled; straight-edged rectangles render cleanly without it.  method public override void draw(skcanvas canvas, skrect rect, skpaint paint);  method public override void draw(skcanvas canvas, skrect rect, skpaint paint, skcolor backgroundcolor);  method public override void draw(skcanvas canvas, skrect rect, skpaint paint, skpaint backgroundpaint); ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.RectangleFinderPatternShape" aria-label="Link to SkiaSharp.QrCode.Image.RectangleFinderPatternShape">#</a><span class="kind">class</span> <span class="name">RectangleFinderPatternShape</span></h3>
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.RectangleFinderPatternShape" aria-label="Link to SkiaSharp.QrCode.Image.RectangleFinderPatternShape">#</a><span class="kind">class</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/FinderPatternShape.cs" title="View source file on GitHub" target="_blank" rel="noopener noreferrer">RectangleFinderPatternShape</a></h3>
           <pre class="sig"><code>public sealed class RectangleFinderPatternShape : FinderPatternShape</code></pre>
           <p class="doc">Standard QR code finder pattern (three nested squares, 7x7, 5x5, 3x3).</p>
           <div class="members">
@@ -2793,26 +2796,26 @@
               <p class="doc">Gets the default instance.</p>
             </div>
             <div class="member" data-text="property public bool requiresantialiasing { get; } antialiasing disabled; straight-edged rectangles render cleanly without it. ">
-              <h4><span class="kind">property</span> <span class="name">RequiresAntialiasing</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/FinderPatternShape.cs#L80" title="View source on GitHub" target="_blank" rel="noopener noreferrer">RequiresAntialiasing</a></h4>
               <pre class="sig"><code>public bool RequiresAntialiasing { get; }</code></pre>
               <p class="doc">Antialiasing disabled; straight-edged rectangles render cleanly without it.</p>
             </div>
             <div class="member" data-text="method public override void draw(skcanvas canvas, skrect rect, skpaint paint); ">
-              <h4><span class="kind">method</span> <span class="name">Draw</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/FinderPatternShape.cs#L84" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Draw</a></h4>
               <pre class="sig"><code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint);</code></pre>
             </div>
             <div class="member" data-text="method public override void draw(skcanvas canvas, skrect rect, skpaint paint, skcolor backgroundcolor); ">
-              <h4><span class="kind">method</span> <span class="name">Draw</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/FinderPatternShape.cs#L90" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Draw</a></h4>
               <pre class="sig"><code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint, SKColor backgroundColor);</code></pre>
             </div>
             <div class="member" data-text="method public override void draw(skcanvas canvas, skrect rect, skpaint paint, skpaint backgroundpaint); ">
-              <h4><span class="kind">method</span> <span class="name">Draw</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/FinderPatternShape.cs#L97" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Draw</a></h4>
               <pre class="sig"><code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint, SKPaint backgroundPaint);</code></pre>
             </div>
           </div>
         </article>
         <article class="type" id="SkiaSharp.QrCode.Image.RectangleModuleShape" data-name="skiasharp.qrcode.image.rectanglemoduleshape" data-text="skiasharp.qrcode.image.rectanglemoduleshape public sealed class rectanglemoduleshape : moduleshape draw modules as rectangles.  field public static readonly rectanglemoduleshape default; gets the default instance.  property public bool requiresantialiasing { get; } antialiasing disabled to prevent gray borders between modules.  method public override void draw(skcanvas canvas, skrect rect, skpaint paint); ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.RectangleModuleShape" aria-label="Link to SkiaSharp.QrCode.Image.RectangleModuleShape">#</a><span class="kind">class</span> <span class="name">RectangleModuleShape</span></h3>
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.RectangleModuleShape" aria-label="Link to SkiaSharp.QrCode.Image.RectangleModuleShape">#</a><span class="kind">class</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/ModuleShape.cs" title="View source file on GitHub" target="_blank" rel="noopener noreferrer">RectangleModuleShape</a></h3>
           <pre class="sig"><code>public sealed class RectangleModuleShape : ModuleShape</code></pre>
           <p class="doc">Draw modules as rectangles.</p>
           <div class="members">
@@ -2822,18 +2825,18 @@
               <p class="doc">Gets the default instance.</p>
             </div>
             <div class="member" data-text="property public bool requiresantialiasing { get; } antialiasing disabled to prevent gray borders between modules. ">
-              <h4><span class="kind">property</span> <span class="name">RequiresAntialiasing</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/ModuleShape.cs#L35" title="View source on GitHub" target="_blank" rel="noopener noreferrer">RequiresAntialiasing</a></h4>
               <pre class="sig"><code>public bool RequiresAntialiasing { get; }</code></pre>
               <p class="doc">Antialiasing disabled to prevent gray borders between modules.</p>
             </div>
             <div class="member" data-text="method public override void draw(skcanvas canvas, skrect rect, skpaint paint); ">
-              <h4><span class="kind">method</span> <span class="name">Draw</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/ModuleShape.cs#L42" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Draw</a></h4>
               <pre class="sig"><code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint);</code></pre>
             </div>
           </div>
         </article>
         <article class="type" id="SkiaSharp.QrCode.Image.RmQRCodeImageBuilder" data-name="skiasharp.qrcode.image.rmqrcodeimagebuilder" data-text="skiasharp.qrcode.image.rmqrcodeimagebuilder public class rmqrcodeimagebuilder : qrcodeimagebuilderbase&lt;rmqrcodeimagebuilder&gt; high-level builder for creating rmqr code images with fluent configuration and static methods. this builder mirrors qrcodeimagebuilder / microqrcodeimagebuilder for the rmqr symbology (iso/iec 23941, r7x43-r17x139). version, error correction and fit use the rmqr-typed rmqrversion / rmqrecclevel / rmqrfitstrategy / rmqrheight , and the default quiet zone is the 2 modules the specification requires. rmqr symbols are rectangular. with qrcodeimagebuilderbase the image is exactly the matrix at that scale; with qrcodeimagebuilderbase the symbol is fitted into the canvas with a uniform module scale and centered (letterbox, never stretched); with withwidth (the static helpers' size, and the 512-pixel default when nothing is configured) the image is that wide, the height follows the symbol aspect ratio rounded to whole pixels, the background covers the whole image and the symbol is drawn at a uniform module scale inside it (the height rounding can leave a few pixels of background at the sides on the widest versions; there is no clear-colour pad, so an opaque background gives an opaque image). rmqr has a single finder pattern and no error-correction headroom for overlays, so the standard qr styling options that depend on those (icon overlays and custom finder pattern shapes) are intentionally not offered. constructor public rmqrcodeimagebuilder(rmqrcodedata rmqrcodedata); starts a builder that draws an rmqr code you have already generated. the symbol is used exactly as given, so only the appearance options apply. every encoding option throws invalidoperationexception on a builder created this way.  constructor public rmqrcodeimagebuilder(string content); starts a builder that will encode content when you ask for an image. error correction, version and fit keep their defaults until you set them.  method public rmqrcodeimagebuilder withecimode(ecimode ecimode); configure the eci character encoding declaration.  method public rmqrcodeimagebuilder witherrorcorrection(rmqrecclevel ecclevel); configure the error correction level (m or h).  method public rmqrcodeimagebuilder withfitstrategy(rmqrfitstrategy fitstrategy); configure how the version is chosen among those that hold the content (default minimizearea , fewest modules; note it may prefer a taller, narrower symbol, use minimizeheight or withheight for the flattest fit).  method public rmqrcodeimagebuilder withheight(rmqrheight height); restrict automatic version selection to one symbol height (fixed height, automatic width). must agree with withversion when both are used.  method public rmqrcodeimagebuilder withsegmentation(rmqrsegmentation segmentation); split the content into mixed-mode segments when that lowers the module count (see rmqrsegmentation ). defaults to single . fewer modules is not the same as a smaller image: a flatter, wider symbol can render onto a larger grid.  method public rmqrcodeimagebuilder withversion(rmqrversion version); configure the exact rmqr version to generate.  method public rmqrcodeimagebuilder withwidth(int width); configure the image width in pixels; the height follows the symbol aspect ratio (rounded to whole pixels), the background covers the whole image and the symbol is drawn at a uniform module scale inside it. this is the static helpers' sizing rule and the default (512) when no size is configured. qrcodeimagebuilderbase (letterbox into an exact canvas) or qrcodeimagebuilderbase (exact matrix) take precedence when also called.  method public static byte[] getimagebytes(rmqrcodedata rmqrcodedata, skencodedimageformat format, int size = 512, int quality = 100); generate an rmqr code as image byte array with specified format.  method public static byte[] getimagebytes(string content, skencodedimageformat format, rmqrecclevel ecclevel = 0, int size = 512, int quality = 100); generate an rmqr code as image byte array with specified format.  method public static byte[] getpngbytes(rmqrcodedata rmqrcodedata, int size = 512); generate an rmqr code as png byte array with default settings.  method public static byte[] getpngbytes(string content, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code as png byte array with default settings.  method public static byte[] getsvgbytes(rmqrcodedata rmqrcodedata, int size = 512); generate an rmqr code as svg byte array.  method public static byte[] getsvgbytes(string content, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code as svg byte array.  method public static string getsvgstring(rmqrcodedata rmqrcodedata, int size = 512); generate an rmqr code as svg string.  method public static string getsvgstring(string content, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code as svg string.  method public static void savepng(rmqrcodedata rmqrcodedata, stream output, int size = 512); generate an rmqr code and save as png to stream.  method public static void savepng(string content, stream output, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code and save as png to stream.  method public static void savesvg(rmqrcodedata rmqrcodedata, stream output, int size = 512); generate an rmqr code and save as svg to stream.  method public static void savesvg(string content, stream output, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code and save as svg to stream.  method public static void writeimage(rmqrcodedata rmqrcodedata, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, int size = 512, int quality = 100); generate an rmqr code and write encoded image bytes to a buffer writer.  method public static void writeimage(string content, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, rmqrecclevel ecclevel = 0, int size = 512, int quality = 100); generate an rmqr code and write encoded image bytes to a buffer writer.  method public static void writepng(rmqrcodedata rmqrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate an rmqr code and write png bytes to a buffer writer.  method public static void writepng(string content, ibufferwriter&lt;byte&gt; writer, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code and write png bytes to a buffer writer.  method public static void writesvg(rmqrcodedata rmqrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate an rmqr code and write the svg document to a buffer writer.  method public static void writesvg(string content, ibufferwriter&lt;byte&gt; writer, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code and write the svg document to a buffer writer. ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.RmQRCodeImageBuilder" aria-label="Link to SkiaSharp.QrCode.Image.RmQRCodeImageBuilder">#</a><span class="kind">class</span> <span class="name">RmQRCodeImageBuilder</span></h3>
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.RmQRCodeImageBuilder" aria-label="Link to SkiaSharp.QrCode.Image.RmQRCodeImageBuilder">#</a><span class="kind">class</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/RmQRCodeImageBuilder.cs" title="View source file on GitHub" target="_blank" rel="noopener noreferrer">RmQRCodeImageBuilder</a></h3>
           <pre class="sig"><code>public class RmQRCodeImageBuilder : QRCodeImageBuilderBase&lt;RmQRCodeImageBuilder&gt;</code></pre>
           <p class="doc">High-level builder for creating rMQR code images with fluent configuration and static methods.</p>
           <details class="notes" data-text="this builder mirrors qrcodeimagebuilder / microqrcodeimagebuilder for the rmqr symbology (iso/iec 23941, r7x43-r17x139). version, error correction and fit use the rmqr-typed rmqrversion / rmqrecclevel / rmqrfitstrategy / rmqrheight , and the default quiet zone is the 2 modules the specification requires. rmqr symbols are rectangular. with qrcodeimagebuilderbase the image is exactly the matrix at that scale; with qrcodeimagebuilderbase the symbol is fitted into the canvas with a uniform module scale and centered (letterbox, never stretched); with withwidth (the static helpers' size, and the 512-pixel default when nothing is configured) the image is that wide, the height follows the symbol aspect ratio rounded to whole pixels, the background covers the whole image and the symbol is drawn at a uniform module scale inside it (the height rounding can leave a few pixels of background at the sides on the widest versions; there is no clear-colour pad, so an opaque background gives an opaque image). rmqr has a single finder pattern and no error-correction headroom for overlays, so the standard qr styling options that depend on those (icon overlays and custom finder pattern shapes) are intentionally not offered.">
@@ -2842,144 +2845,144 @@
           </details>
           <div class="members">
             <div class="member" data-text="constructor public rmqrcodeimagebuilder(rmqrcodedata rmqrcodedata); starts a builder that draws an rmqr code you have already generated. the symbol is used exactly as given, so only the appearance options apply. every encoding option throws invalidoperationexception on a builder created this way. ">
-              <h4><span class="kind">constructor</span> <span class="name">RmQRCodeImageBuilder</span></h4>
+              <h4><span class="kind">constructor</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/RmQRCodeImageBuilder.cs#L43" title="View source on GitHub" target="_blank" rel="noopener noreferrer">RmQRCodeImageBuilder</a></h4>
               <pre class="sig"><code>public RmQRCodeImageBuilder(RmQRCodeData rmQrCodeData);</code></pre>
               <p class="doc">Starts a builder that draws an rMQR code you have already generated. The symbol is used exactly as given, so only the appearance options apply. Every encoding option throws InvalidOperationException on a builder created this way.</p>
             </div>
             <div class="member" data-text="constructor public rmqrcodeimagebuilder(string content); starts a builder that will encode content when you ask for an image. error correction, version and fit keep their defaults until you set them. ">
-              <h4><span class="kind">constructor</span> <span class="name">RmQRCodeImageBuilder</span></h4>
+              <h4><span class="kind">constructor</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/RmQRCodeImageBuilder.cs#L43" title="View source on GitHub" target="_blank" rel="noopener noreferrer">RmQRCodeImageBuilder</a></h4>
               <pre class="sig"><code>public RmQRCodeImageBuilder(string content);</code></pre>
               <p class="doc">Starts a builder that will encode content when you ask for an image. Error correction, version and fit keep their defaults until you set them.</p>
             </div>
             <div class="member" data-text="method public rmqrcodeimagebuilder withecimode(ecimode ecimode); configure the eci character encoding declaration. ">
-              <h4><span class="kind">method</span> <span class="name">WithEciMode</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/RmQRCodeImageBuilder.cs#L361" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WithEciMode</a></h4>
               <pre class="sig"><code>public RmQRCodeImageBuilder WithEciMode(EciMode eciMode);</code></pre>
               <p class="doc">Configure the ECI character encoding declaration.</p>
             </div>
             <div class="member" data-text="method public rmqrcodeimagebuilder witherrorcorrection(rmqrecclevel ecclevel); configure the error correction level (m or h). ">
-              <h4><span class="kind">method</span> <span class="name">WithErrorCorrection</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/RmQRCodeImageBuilder.cs#L349" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WithErrorCorrection</a></h4>
               <pre class="sig"><code>public RmQRCodeImageBuilder WithErrorCorrection(RmQREccLevel eccLevel);</code></pre>
               <p class="doc">Configure the error correction level (M or H).</p>
             </div>
             <div class="member" data-text="method public rmqrcodeimagebuilder withfitstrategy(rmqrfitstrategy fitstrategy); configure how the version is chosen among those that hold the content (default minimizearea , fewest modules; note it may prefer a taller, narrower symbol, use minimizeheight or withheight for the flattest fit). ">
-              <h4><span class="kind">method</span> <span class="name">WithFitStrategy</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/RmQRCodeImageBuilder.cs#L398" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WithFitStrategy</a></h4>
               <pre class="sig"><code>public RmQRCodeImageBuilder WithFitStrategy(RmQRFitStrategy fitStrategy);</code></pre>
               <p class="doc">Configure how the version is chosen among those that hold the content (default MinimizeArea , fewest modules; note it may prefer a taller, narrower symbol, use MinimizeHeight or WithHeight for the flattest fit).</p>
             </div>
             <div class="member" data-text="method public rmqrcodeimagebuilder withheight(rmqrheight height); restrict automatic version selection to one symbol height (fixed height, automatic width). must agree with withversion when both are used. ">
-              <h4><span class="kind">method</span> <span class="name">WithHeight</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/RmQRCodeImageBuilder.cs#L417" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WithHeight</a></h4>
               <pre class="sig"><code>public RmQRCodeImageBuilder WithHeight(RmQRHeight height);</code></pre>
               <p class="doc">Restrict automatic version selection to one symbol height (fixed height, automatic width). Must agree with WithVersion when both are used.</p>
             </div>
             <div class="member" data-text="method public rmqrcodeimagebuilder withsegmentation(rmqrsegmentation segmentation); split the content into mixed-mode segments when that lowers the module count (see rmqrsegmentation ). defaults to single . fewer modules is not the same as a smaller image: a flatter, wider symbol can render onto a larger grid. ">
-              <h4><span class="kind">method</span> <span class="name">WithSegmentation</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/RmQRCodeImageBuilder.cs#L438" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WithSegmentation</a></h4>
               <pre class="sig"><code>public RmQRCodeImageBuilder WithSegmentation(RmQRSegmentation segmentation);</code></pre>
               <p class="doc">Split the content into mixed-mode segments when that lowers the module count (see RmQRSegmentation ). Defaults to Single . Fewer modules is not the same as a smaller image: a flatter, wider symbol can render onto a larger grid.</p>
             </div>
             <div class="member" data-text="method public rmqrcodeimagebuilder withversion(rmqrversion version); configure the exact rmqr version to generate. ">
-              <h4><span class="kind">method</span> <span class="name">WithVersion</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/RmQRCodeImageBuilder.cs#L377" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WithVersion</a></h4>
               <pre class="sig"><code>public RmQRCodeImageBuilder WithVersion(RmQRVersion version);</code></pre>
               <p class="doc">Configure the exact rMQR version to generate.</p>
             </div>
             <div class="member" data-text="method public rmqrcodeimagebuilder withwidth(int width); configure the image width in pixels; the height follows the symbol aspect ratio (rounded to whole pixels), the background covers the whole image and the symbol is drawn at a uniform module scale inside it. this is the static helpers' sizing rule and the default (512) when no size is configured. qrcodeimagebuilderbase (letterbox into an exact canvas) or qrcodeimagebuilderbase (exact matrix) take precedence when also called. ">
-              <h4><span class="kind">method</span> <span class="name">WithWidth</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/RmQRCodeImageBuilder.cs#L461" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WithWidth</a></h4>
               <pre class="sig"><code>public RmQRCodeImageBuilder WithWidth(int width);</code></pre>
               <p class="doc">Configure the image width in pixels; the height follows the symbol aspect ratio (rounded to whole pixels), the background covers the whole image and the symbol is drawn at a uniform module scale inside it. This is the static helpers' sizing rule and the default (512) when no size is configured. QRCodeImageBuilderBase (letterbox into an exact canvas) or QRCodeImageBuilderBase (exact matrix) take precedence when also called.</p>
             </div>
             <div class="member" data-text="method public static byte[] getimagebytes(rmqrcodedata rmqrcodedata, skencodedimageformat format, int size = 512, int quality = 100); generate an rmqr code as image byte array with specified format. ">
-              <h4><span class="kind">method</span> <span class="name">GetImageBytes</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/RmQRCodeImageBuilder.cs#L132" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetImageBytes</a></h4>
               <pre class="sig"><code>public static byte[] GetImageBytes(RmQRCodeData rmQrCodeData, SKEncodedImageFormat format, int size = 512, int quality = 100);</code></pre>
               <p class="doc">Generate an rMQR code as image byte array with specified format.</p>
             </div>
             <div class="member" data-text="method public static byte[] getimagebytes(string content, skencodedimageformat format, rmqrecclevel ecclevel = 0, int size = 512, int quality = 100); generate an rmqr code as image byte array with specified format. ">
-              <h4><span class="kind">method</span> <span class="name">GetImageBytes</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/RmQRCodeImageBuilder.cs#L115" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetImageBytes</a></h4>
               <pre class="sig"><code>public static byte[] GetImageBytes(string content, SKEncodedImageFormat format, RmQREccLevel eccLevel = 0, int size = 512, int quality = 100);</code></pre>
               <p class="doc">Generate an rMQR code as image byte array with specified format.</p>
             </div>
             <div class="member" data-text="method public static byte[] getpngbytes(rmqrcodedata rmqrcodedata, int size = 512); generate an rmqr code as png byte array with default settings. ">
-              <h4><span class="kind">method</span> <span class="name">GetPngBytes</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/RmQRCodeImageBuilder.cs#L101" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetPngBytes</a></h4>
               <pre class="sig"><code>public static byte[] GetPngBytes(RmQRCodeData rmQrCodeData, int size = 512);</code></pre>
               <p class="doc">Generate an rMQR code as PNG byte array with default settings.</p>
             </div>
             <div class="member" data-text="method public static byte[] getpngbytes(string content, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code as png byte array with default settings. ">
-              <h4><span class="kind">method</span> <span class="name">GetPngBytes</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/RmQRCodeImageBuilder.cs#L90" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetPngBytes</a></h4>
               <pre class="sig"><code>public static byte[] GetPngBytes(string content, RmQREccLevel eccLevel = 0, int size = 512);</code></pre>
               <p class="doc">Generate an rMQR code as PNG byte array with default settings.</p>
             </div>
             <div class="member" data-text="method public static byte[] getsvgbytes(rmqrcodedata rmqrcodedata, int size = 512); generate an rmqr code as svg byte array. ">
-              <h4><span class="kind">method</span> <span class="name">GetSvgBytes</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/RmQRCodeImageBuilder.cs#L191" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetSvgBytes</a></h4>
               <pre class="sig"><code>public static byte[] GetSvgBytes(RmQRCodeData rmQrCodeData, int size = 512);</code></pre>
               <p class="doc">Generate an rMQR code as SVG byte array.</p>
             </div>
             <div class="member" data-text="method public static byte[] getsvgbytes(string content, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code as svg byte array. ">
-              <h4><span class="kind">method</span> <span class="name">GetSvgBytes</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/RmQRCodeImageBuilder.cs#L175" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetSvgBytes</a></h4>
               <pre class="sig"><code>public static byte[] GetSvgBytes(string content, RmQREccLevel eccLevel = 0, int size = 512);</code></pre>
               <p class="doc">Generate an rMQR code as SVG byte array.</p>
             </div>
             <div class="member" data-text="method public static string getsvgstring(rmqrcodedata rmqrcodedata, int size = 512); generate an rmqr code as svg string. ">
-              <h4><span class="kind">method</span> <span class="name">GetSvgString</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/RmQRCodeImageBuilder.cs#L249" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetSvgString</a></h4>
               <pre class="sig"><code>public static string GetSvgString(RmQRCodeData rmQrCodeData, int size = 512);</code></pre>
               <p class="doc">Generate an rMQR code as SVG string.</p>
             </div>
             <div class="member" data-text="method public static string getsvgstring(string content, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code as svg string. ">
-              <h4><span class="kind">method</span> <span class="name">GetSvgString</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/RmQRCodeImageBuilder.cs#L235" title="View source on GitHub" target="_blank" rel="noopener noreferrer">GetSvgString</a></h4>
               <pre class="sig"><code>public static string GetSvgString(string content, RmQREccLevel eccLevel = 0, int size = 512);</code></pre>
               <p class="doc">Generate an rMQR code as SVG string.</p>
             </div>
             <div class="member" data-text="method public static void savepng(rmqrcodedata rmqrcodedata, stream output, int size = 512); generate an rmqr code and save as png to stream. ">
-              <h4><span class="kind">method</span> <span class="name">SavePng</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/RmQRCodeImageBuilder.cs#L161" title="View source on GitHub" target="_blank" rel="noopener noreferrer">SavePng</a></h4>
               <pre class="sig"><code>public static void SavePng(RmQRCodeData rmQrCodeData, Stream output, int size = 512);</code></pre>
               <p class="doc">Generate an rMQR code and save as PNG to stream.</p>
             </div>
             <div class="member" data-text="method public static void savepng(string content, stream output, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code and save as png to stream. ">
-              <h4><span class="kind">method</span> <span class="name">SavePng</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/RmQRCodeImageBuilder.cs#L147" title="View source on GitHub" target="_blank" rel="noopener noreferrer">SavePng</a></h4>
               <pre class="sig"><code>public static void SavePng(string content, Stream output, RmQREccLevel eccLevel = 0, int size = 512);</code></pre>
               <p class="doc">Generate an rMQR code and save as PNG to stream.</p>
             </div>
             <div class="member" data-text="method public static void savesvg(rmqrcodedata rmqrcodedata, stream output, int size = 512); generate an rmqr code and save as svg to stream. ">
-              <h4><span class="kind">method</span> <span class="name">SaveSvg</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/RmQRCodeImageBuilder.cs#L221" title="View source on GitHub" target="_blank" rel="noopener noreferrer">SaveSvg</a></h4>
               <pre class="sig"><code>public static void SaveSvg(RmQRCodeData rmQrCodeData, Stream output, int size = 512);</code></pre>
               <p class="doc">Generate an rMQR code and save as SVG to stream.</p>
             </div>
             <div class="member" data-text="method public static void savesvg(string content, stream output, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code and save as svg to stream. ">
-              <h4><span class="kind">method</span> <span class="name">SaveSvg</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/RmQRCodeImageBuilder.cs#L207" title="View source on GitHub" target="_blank" rel="noopener noreferrer">SaveSvg</a></h4>
               <pre class="sig"><code>public static void SaveSvg(string content, Stream output, RmQREccLevel eccLevel = 0, int size = 512);</code></pre>
               <p class="doc">Generate an rMQR code and save as SVG to stream.</p>
             </div>
             <div class="member" data-text="method public static void writeimage(rmqrcodedata rmqrcodedata, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, int size = 512, int quality = 100); generate an rmqr code and write encoded image bytes to a buffer writer. ">
-              <h4><span class="kind">method</span> <span class="name">WriteImage</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/RmQRCodeImageBuilder.cs#L333" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WriteImage</a></h4>
               <pre class="sig"><code>public static void WriteImage(RmQRCodeData rmQrCodeData, IBufferWriter&lt;byte&gt; writer, SKEncodedImageFormat format, int size = 512, int quality = 100);</code></pre>
               <p class="doc">Generate an rMQR code and write encoded image bytes to a buffer writer.</p>
             </div>
             <div class="member" data-text="method public static void writeimage(string content, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, rmqrecclevel ecclevel = 0, int size = 512, int quality = 100); generate an rmqr code and write encoded image bytes to a buffer writer. ">
-              <h4><span class="kind">method</span> <span class="name">WriteImage</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/RmQRCodeImageBuilder.cs#L316" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WriteImage</a></h4>
               <pre class="sig"><code>public static void WriteImage(string content, IBufferWriter&lt;byte&gt; writer, SKEncodedImageFormat format, RmQREccLevel eccLevel = 0, int size = 512, int quality = 100);</code></pre>
               <p class="doc">Generate an rMQR code and write encoded image bytes to a buffer writer.</p>
             </div>
             <div class="member" data-text="method public static void writepng(rmqrcodedata rmqrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate an rmqr code and write png bytes to a buffer writer. ">
-              <h4><span class="kind">method</span> <span class="name">WritePng</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/RmQRCodeImageBuilder.cs#L302" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WritePng</a></h4>
               <pre class="sig"><code>public static void WritePng(RmQRCodeData rmQrCodeData, IBufferWriter&lt;byte&gt; writer, int size = 512);</code></pre>
               <p class="doc">Generate an rMQR code and write PNG bytes to a buffer writer.</p>
             </div>
             <div class="member" data-text="method public static void writepng(string content, ibufferwriter&lt;byte&gt; writer, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code and write png bytes to a buffer writer. ">
-              <h4><span class="kind">method</span> <span class="name">WritePng</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/RmQRCodeImageBuilder.cs#L291" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WritePng</a></h4>
               <pre class="sig"><code>public static void WritePng(string content, IBufferWriter&lt;byte&gt; writer, RmQREccLevel eccLevel = 0, int size = 512);</code></pre>
               <p class="doc">Generate an rMQR code and write PNG bytes to a buffer writer.</p>
             </div>
             <div class="member" data-text="method public static void writesvg(rmqrcodedata rmqrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate an rmqr code and write the svg document to a buffer writer. ">
-              <h4><span class="kind">method</span> <span class="name">WriteSvg</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/RmQRCodeImageBuilder.cs#L277" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WriteSvg</a></h4>
               <pre class="sig"><code>public static void WriteSvg(RmQRCodeData rmQrCodeData, IBufferWriter&lt;byte&gt; writer, int size = 512);</code></pre>
               <p class="doc">Generate an rMQR code and write the SVG document to a buffer writer.</p>
             </div>
             <div class="member" data-text="method public static void writesvg(string content, ibufferwriter&lt;byte&gt; writer, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code and write the svg document to a buffer writer. ">
-              <h4><span class="kind">method</span> <span class="name">WriteSvg</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/RmQRCodeImageBuilder.cs#L263" title="View source on GitHub" target="_blank" rel="noopener noreferrer">WriteSvg</a></h4>
               <pre class="sig"><code>public static void WriteSvg(string content, IBufferWriter&lt;byte&gt; writer, RmQREccLevel eccLevel = 0, int size = 512);</code></pre>
               <p class="doc">Generate an rMQR code and write the SVG document to a buffer writer.</p>
             </div>
           </div>
         </article>
         <article class="type" id="SkiaSharp.QrCode.Image.RoundedRectangleCircleFinderPatternShape" data-name="skiasharp.qrcode.image.roundedrectanglecirclefinderpatternshape" data-text="skiasharp.qrcode.image.roundedrectanglecirclefinderpatternshape public sealed class roundedrectanglecirclefinderpatternshape : finderpatternshape rounded rectangle outer with circular center finder pattern. three nested shapes: outer rounded rectangle (7×7), middle rounded rectangle (5×5), inner circle (3×3).  field public static readonly roundedrectanglecirclefinderpatternshape default; gets the default instance.  constructor public roundedrectanglecirclefinderpatternshape(float cornerradiuspercent = 0.3); initializes a new instance with the specified corner radius.  property public bool requiresantialiasing { get; } requires antialiasing to prevent jagged edges on curves.  method public override void draw(skcanvas canvas, skrect rect, skpaint paint);  method public override void draw(skcanvas canvas, skrect rect, skpaint paint, skcolor backgroundcolor);  method public override void draw(skcanvas canvas, skrect rect, skpaint paint, skpaint backgroundpaint); ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.RoundedRectangleCircleFinderPatternShape" aria-label="Link to SkiaSharp.QrCode.Image.RoundedRectangleCircleFinderPatternShape">#</a><span class="kind">class</span> <span class="name">RoundedRectangleCircleFinderPatternShape</span></h3>
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.RoundedRectangleCircleFinderPatternShape" aria-label="Link to SkiaSharp.QrCode.Image.RoundedRectangleCircleFinderPatternShape">#</a><span class="kind">class</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/FinderPatternShape.cs" title="View source file on GitHub" target="_blank" rel="noopener noreferrer">RoundedRectangleCircleFinderPatternShape</a></h3>
           <pre class="sig"><code>public sealed class RoundedRectangleCircleFinderPatternShape : FinderPatternShape</code></pre>
           <p class="doc">Rounded rectangle outer with circular center finder pattern. Three nested shapes: outer rounded rectangle (7×7), middle rounded rectangle (5×5), inner circle (3×3).</p>
           <div class="members">
@@ -2989,31 +2992,31 @@
               <p class="doc">Gets the default instance.</p>
             </div>
             <div class="member" data-text="constructor public roundedrectanglecirclefinderpatternshape(float cornerradiuspercent = 0.3); initializes a new instance with the specified corner radius. ">
-              <h4><span class="kind">constructor</span> <span class="name">RoundedRectangleCircleFinderPatternShape</span></h4>
+              <h4><span class="kind">constructor</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/FinderPatternShape.cs#L257" title="View source on GitHub" target="_blank" rel="noopener noreferrer">RoundedRectangleCircleFinderPatternShape</a></h4>
               <pre class="sig"><code>public RoundedRectangleCircleFinderPatternShape(float cornerRadiusPercent = 0.3);</code></pre>
               <p class="doc">Initializes a new instance with the specified corner radius.</p>
             </div>
             <div class="member" data-text="property public bool requiresantialiasing { get; } requires antialiasing to prevent jagged edges on curves. ">
-              <h4><span class="kind">property</span> <span class="name">RequiresAntialiasing</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/FinderPatternShape.cs#L267" title="View source on GitHub" target="_blank" rel="noopener noreferrer">RequiresAntialiasing</a></h4>
               <pre class="sig"><code>public bool RequiresAntialiasing { get; }</code></pre>
               <p class="doc">Requires antialiasing to prevent jagged edges on curves.</p>
             </div>
             <div class="member" data-text="method public override void draw(skcanvas canvas, skrect rect, skpaint paint); ">
-              <h4><span class="kind">method</span> <span class="name">Draw</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/FinderPatternShape.cs#L271" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Draw</a></h4>
               <pre class="sig"><code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint);</code></pre>
             </div>
             <div class="member" data-text="method public override void draw(skcanvas canvas, skrect rect, skpaint paint, skcolor backgroundcolor); ">
-              <h4><span class="kind">method</span> <span class="name">Draw</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/FinderPatternShape.cs#L277" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Draw</a></h4>
               <pre class="sig"><code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint, SKColor backgroundColor);</code></pre>
             </div>
             <div class="member" data-text="method public override void draw(skcanvas canvas, skrect rect, skpaint paint, skpaint backgroundpaint); ">
-              <h4><span class="kind">method</span> <span class="name">Draw</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/FinderPatternShape.cs#L284" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Draw</a></h4>
               <pre class="sig"><code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint, SKPaint backgroundPaint);</code></pre>
             </div>
           </div>
         </article>
         <article class="type" id="SkiaSharp.QrCode.Image.RoundedRectangleFinderPatternShape" data-name="skiasharp.qrcode.image.roundedrectanglefinderpatternshape" data-text="skiasharp.qrcode.image.roundedrectanglefinderpatternshape public sealed class roundedrectanglefinderpatternshape : finderpatternshape rounded rectangle outer with circular center finder pattern. three nested shapes: outer rounded rectangle (7×7), middle rounded rectangle (5×5), inner rounded rectangle (3×3).  field public static readonly roundedrectanglefinderpatternshape default; gets the default instance.  constructor public roundedrectanglefinderpatternshape(float cornerradiuspercent = 0.2); initializes a new instance with the specified corner radius.  property public bool requiresantialiasing { get; } requires antialiasing to prevent jagged edges on curves.  method public override void draw(skcanvas canvas, skrect rect, skpaint paint);  method public override void draw(skcanvas canvas, skrect rect, skpaint paint, skcolor backgroundcolor);  method public override void draw(skcanvas canvas, skrect rect, skpaint paint, skpaint backgroundpaint); ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.RoundedRectangleFinderPatternShape" aria-label="Link to SkiaSharp.QrCode.Image.RoundedRectangleFinderPatternShape">#</a><span class="kind">class</span> <span class="name">RoundedRectangleFinderPatternShape</span></h3>
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.RoundedRectangleFinderPatternShape" aria-label="Link to SkiaSharp.QrCode.Image.RoundedRectangleFinderPatternShape">#</a><span class="kind">class</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/FinderPatternShape.cs" title="View source file on GitHub" target="_blank" rel="noopener noreferrer">RoundedRectangleFinderPatternShape</a></h3>
           <pre class="sig"><code>public sealed class RoundedRectangleFinderPatternShape : FinderPatternShape</code></pre>
           <p class="doc">Rounded rectangle outer with circular center finder pattern. Three nested shapes: outer rounded rectangle (7×7), middle rounded rectangle (5×5), inner rounded rectangle (3×3).</p>
           <div class="members">
@@ -3023,31 +3026,31 @@
               <p class="doc">Gets the default instance.</p>
             </div>
             <div class="member" data-text="constructor public roundedrectanglefinderpatternshape(float cornerradiuspercent = 0.2); initializes a new instance with the specified corner radius. ">
-              <h4><span class="kind">constructor</span> <span class="name">RoundedRectangleFinderPatternShape</span></h4>
+              <h4><span class="kind">constructor</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/FinderPatternShape.cs#L187" title="View source on GitHub" target="_blank" rel="noopener noreferrer">RoundedRectangleFinderPatternShape</a></h4>
               <pre class="sig"><code>public RoundedRectangleFinderPatternShape(float cornerRadiusPercent = 0.2);</code></pre>
               <p class="doc">Initializes a new instance with the specified corner radius.</p>
             </div>
             <div class="member" data-text="property public bool requiresantialiasing { get; } requires antialiasing to prevent jagged edges on curves. ">
-              <h4><span class="kind">property</span> <span class="name">RequiresAntialiasing</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/FinderPatternShape.cs#L197" title="View source on GitHub" target="_blank" rel="noopener noreferrer">RequiresAntialiasing</a></h4>
               <pre class="sig"><code>public bool RequiresAntialiasing { get; }</code></pre>
               <p class="doc">Requires antialiasing to prevent jagged edges on curves.</p>
             </div>
             <div class="member" data-text="method public override void draw(skcanvas canvas, skrect rect, skpaint paint); ">
-              <h4><span class="kind">method</span> <span class="name">Draw</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/FinderPatternShape.cs#L201" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Draw</a></h4>
               <pre class="sig"><code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint);</code></pre>
             </div>
             <div class="member" data-text="method public override void draw(skcanvas canvas, skrect rect, skpaint paint, skcolor backgroundcolor); ">
-              <h4><span class="kind">method</span> <span class="name">Draw</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/FinderPatternShape.cs#L207" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Draw</a></h4>
               <pre class="sig"><code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint, SKColor backgroundColor);</code></pre>
             </div>
             <div class="member" data-text="method public override void draw(skcanvas canvas, skrect rect, skpaint paint, skpaint backgroundpaint); ">
-              <h4><span class="kind">method</span> <span class="name">Draw</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/FinderPatternShape.cs#L214" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Draw</a></h4>
               <pre class="sig"><code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint, SKPaint backgroundPaint);</code></pre>
             </div>
           </div>
         </article>
         <article class="type" id="SkiaSharp.QrCode.Image.RoundedRectangleModuleShape" data-name="skiasharp.qrcode.image.roundedrectanglemoduleshape" data-text="skiasharp.qrcode.image.roundedrectanglemoduleshape public sealed class roundedrectanglemoduleshape : moduleshape draws modules as rounded rectangles.  field public static readonly roundedrectanglemoduleshape default; gets the default instance.  constructor public roundedrectanglemoduleshape(float cornerradiuspercent = 0.3); initializes a new instance with the specified corner radius.  property public bool requiresantialiasing { get; } requires antialiasing to prevent jagged edges on curves.  method public override void draw(skcanvas canvas, skrect rect, skpaint paint); ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.RoundedRectangleModuleShape" aria-label="Link to SkiaSharp.QrCode.Image.RoundedRectangleModuleShape">#</a><span class="kind">class</span> <span class="name">RoundedRectangleModuleShape</span></h3>
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.RoundedRectangleModuleShape" aria-label="Link to SkiaSharp.QrCode.Image.RoundedRectangleModuleShape">#</a><span class="kind">class</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/ModuleShape.cs" title="View source file on GitHub" target="_blank" rel="noopener noreferrer">RoundedRectangleModuleShape</a></h3>
           <pre class="sig"><code>public sealed class RoundedRectangleModuleShape : ModuleShape</code></pre>
           <p class="doc">Draws modules as rounded rectangles.</p>
           <div class="members">
@@ -3057,17 +3060,17 @@
               <p class="doc">Gets the default instance.</p>
             </div>
             <div class="member" data-text="constructor public roundedrectanglemoduleshape(float cornerradiuspercent = 0.3); initializes a new instance with the specified corner radius. ">
-              <h4><span class="kind">constructor</span> <span class="name">RoundedRectangleModuleShape</span></h4>
+              <h4><span class="kind">constructor</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/ModuleShape.cs#L98" title="View source on GitHub" target="_blank" rel="noopener noreferrer">RoundedRectangleModuleShape</a></h4>
               <pre class="sig"><code>public RoundedRectangleModuleShape(float cornerRadiusPercent = 0.3);</code></pre>
               <p class="doc">Initializes a new instance with the specified corner radius.</p>
             </div>
             <div class="member" data-text="property public bool requiresantialiasing { get; } requires antialiasing to prevent jagged edges on curves. ">
-              <h4><span class="kind">property</span> <span class="name">RequiresAntialiasing</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/ModuleShape.cs#L91" title="View source on GitHub" target="_blank" rel="noopener noreferrer">RequiresAntialiasing</a></h4>
               <pre class="sig"><code>public bool RequiresAntialiasing { get; }</code></pre>
               <p class="doc">Requires antialiasing to prevent jagged edges on curves.</p>
             </div>
             <div class="member" data-text="method public override void draw(skcanvas canvas, skrect rect, skpaint paint); ">
-              <h4><span class="kind">method</span> <span class="name">Draw</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/ModuleShape.cs#L108" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Draw</a></h4>
               <pre class="sig"><code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint);</code></pre>
             </div>
           </div>
@@ -3092,7 +3095,7 @@
           </div>
         </article>
         <article class="type" id="SkiaSharp.QrCode.Image.Vector2Slim" data-name="skiasharp.qrcode.image.vector2slim" data-text="skiasharp.qrcode.image.vector2slim public readonly struct vector2slim : iequatable&lt;vector2slim&gt; int version of vector2, slim implementation ref: https://github.com/dotnet/corefx/blob/v3.1.32/src/system.numerics.vectors/src/system/numerics/vector2_intrinsics.cs field public static readonly vector2slim one; returns the vector (1,1).  field public static readonly vector2slim unitx; returns the vector (1,0).  field public static readonly vector2slim unity; returns the vector (0,1).  field public static readonly vector2slim zero; returns the vector (0,0).  constructor public vector2slim(int value); creates a vector with both components set to the same value.  constructor public vector2slim(int x, int y); creates a vector from its two components.  property public int x { get; } the x component of the vector.  property public int y { get; } the y component of the vector.  method public void copyto(span&lt;int&gt; span); copies the vector elements to the specified span.  method public void copyto(span&lt;int&gt; span, int index); copies the vector elements to the specified span starting at the specified index.  method public void copyto(int[] array); copies the vector elements to the specified array.  method public void copyto(int[] array, int index); copies the vector elements to the specified array starting at the specified index. ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.Vector2Slim" aria-label="Link to SkiaSharp.QrCode.Image.Vector2Slim">#</a><span class="kind">struct</span> <span class="name">Vector2Slim</span></h3>
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.Vector2Slim" aria-label="Link to SkiaSharp.QrCode.Image.Vector2Slim">#</a><span class="kind">struct</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/Vector2Slim.cs" title="View source file on GitHub" target="_blank" rel="noopener noreferrer">Vector2Slim</a></h3>
           <pre class="sig"><code>public readonly struct Vector2Slim : IEquatable&lt;Vector2Slim&gt;</code></pre>
           <p class="doc">int version of Vector2, slim implementation</p>
           <details class="notes" data-text="ref: https://github.com/dotnet/corefx/blob/v3.1.32/src/system.numerics.vectors/src/system/numerics/vector2_intrinsics.cs">
@@ -3121,42 +3124,42 @@
               <p class="doc">Returns the vector (0,0).</p>
             </div>
             <div class="member" data-text="constructor public vector2slim(int value); creates a vector with both components set to the same value. ">
-              <h4><span class="kind">constructor</span> <span class="name">Vector2Slim</span></h4>
+              <h4><span class="kind">constructor</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/Vector2Slim.cs#L26" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Vector2Slim</a></h4>
               <pre class="sig"><code>public Vector2Slim(int value);</code></pre>
               <p class="doc">Creates a vector with both components set to the same value.</p>
             </div>
             <div class="member" data-text="constructor public vector2slim(int x, int y); creates a vector from its two components. ">
-              <h4><span class="kind">constructor</span> <span class="name">Vector2Slim</span></h4>
+              <h4><span class="kind">constructor</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/Vector2Slim.cs#L33" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Vector2Slim</a></h4>
               <pre class="sig"><code>public Vector2Slim(int x, int y);</code></pre>
               <p class="doc">Creates a vector from its two components.</p>
             </div>
             <div class="member" data-text="property public int x { get; } the x component of the vector. ">
-              <h4><span class="kind">property</span> <span class="name">X</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/Vector2Slim.cs#L16" title="View source on GitHub" target="_blank" rel="noopener noreferrer">X</a></h4>
               <pre class="sig"><code>public int X { get; }</code></pre>
               <p class="doc">The X component of the vector.</p>
             </div>
             <div class="member" data-text="property public int y { get; } the y component of the vector. ">
-              <h4><span class="kind">property</span> <span class="name">Y</span></h4>
+              <h4><span class="kind">property</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/Vector2Slim.cs#L20" title="View source on GitHub" target="_blank" rel="noopener noreferrer">Y</a></h4>
               <pre class="sig"><code>public int Y { get; }</code></pre>
               <p class="doc">The Y component of the vector.</p>
             </div>
             <div class="member" data-text="method public void copyto(span&lt;int&gt; span); copies the vector elements to the specified span. ">
-              <h4><span class="kind">method</span> <span class="name">CopyTo</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/Vector2Slim.cs#L56" title="View source on GitHub" target="_blank" rel="noopener noreferrer">CopyTo</a></h4>
               <pre class="sig"><code>public void CopyTo(Span&lt;int&gt; span);</code></pre>
               <p class="doc">Copies the vector elements to the specified span.</p>
             </div>
             <div class="member" data-text="method public void copyto(span&lt;int&gt; span, int index); copies the vector elements to the specified span starting at the specified index. ">
-              <h4><span class="kind">method</span> <span class="name">CopyTo</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/Vector2Slim.cs#L83" title="View source on GitHub" target="_blank" rel="noopener noreferrer">CopyTo</a></h4>
               <pre class="sig"><code>public void CopyTo(Span&lt;int&gt; span, int index);</code></pre>
               <p class="doc">Copies the vector elements to the specified span starting at the specified index.</p>
             </div>
             <div class="member" data-text="method public void copyto(int[] array); copies the vector elements to the specified array. ">
-              <h4><span class="kind">method</span> <span class="name">CopyTo</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/Vector2Slim.cs#L43" title="View source on GitHub" target="_blank" rel="noopener noreferrer">CopyTo</a></h4>
               <pre class="sig"><code>public void CopyTo(int[] array);</code></pre>
               <p class="doc">Copies the vector elements to the specified array.</p>
             </div>
             <div class="member" data-text="method public void copyto(int[] array, int index); copies the vector elements to the specified array starting at the specified index. ">
-              <h4><span class="kind">method</span> <span class="name">CopyTo</span></h4>
+              <h4><span class="kind">method</span> <a class="name" href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/bc073bcb14e241c7466252be5559aa64af52b029/src/SkiaSharp.QrCode/Image/Vector2Slim.cs#L68" title="View source on GitHub" target="_blank" rel="noopener noreferrer">CopyTo</a></h4>
               <pre class="sig"><code>public void CopyTo(int[] array, int index);</code></pre>
               <p class="doc">Copies the vector elements to the specified array starting at the specified index.</p>
             </div>

--- a/src/SkiaSharp.QrCode.Playground/wwwroot/api/index.html
+++ b/src/SkiaSharp.QrCode.Playground/wwwroot/api/index.html
@@ -178,12 +178,29 @@
     .type:last-child { border-bottom: 0; }
     .type[hidden], .member[hidden], .ns[hidden], .toc-item[hidden], .toc-ns[hidden] { display: none; }
 
-    .type > h3 {
+    .type > h3, .member > h4 {
+      margin: 0 0 0.35rem;
+      font-size: 0.95rem;
+      font-weight: 600;
+    }
+    .member > h4 { font-size: 0.88rem; }
+
+    /* The kind is the word a reader is looking for when scanning, so it leads; the name
+       carries the accent because that is what they are looking *for*. */
+    .kind { color: var(--text-muted); font-weight: 400; }
+    .name { color: var(--accent); }
+
+    /* Signatures wrap instead of scrolling: a horizontal scrollbar per signature hides
+       the end of every long one and makes the reader work for it. C# breaks cleanly at
+       the spaces after commas, and the hanging indent keeps continuations distinct. */
+    .sig {
       margin: 0;
-      font-weight: 500;
-      overflow-x: auto;
-      white-space: nowrap;
-      padding-bottom: 0.15rem;
+      padding: 0.35rem 0.6rem 0.35rem 2.4rem;
+      text-indent: -1.8rem;
+      background: var(--sig-bg);
+      border-radius: 4px;
+      white-space: pre-wrap;
+      overflow-wrap: break-word;
     }
 
     .anchor {
@@ -231,19 +248,11 @@
     .members { margin-top: 1rem; }
 
     .member {
-      padding: 0.5rem 0 0.5rem 0.9rem;
+      padding: 0.5rem 0 0.6rem 0.9rem;
       border-left: 2px solid var(--panel-border);
-      margin-bottom: 0.15rem;
+      margin-bottom: 0.35rem;
     }
     .member:hover { border-left-color: var(--accent); }
-    .member > code {
-      display: block;
-      padding: 0.28rem 0.55rem;
-      background: var(--sig-bg);
-      border-radius: 4px;
-      overflow-x: auto;
-      white-space: nowrap;
-    }
 
     .tag {
       display: inline-block;
@@ -343,72 +352,75 @@
     <main>
       <section class="ns">
         <h2>namespace SkiaSharp.QrCode</h2>
-        <article class="type" id="SkiaSharp.QrCode.Compression" data-name="skiasharp.qrcode.compression" data-text="skiasharp.qrcode.compression public enum compression : int compression mode for qr code data serialization. no api in this library accepts or returns this type. the serialization feature it described was removed before 1.0.0; the enum was left behind and shipped in 1.1.1, which is the only reason it still exists. compress the bytes from getrawdata() yourself, as shown in docs/migration.md. uncompressed = 0, no compression  deflate = 1, deflate compression (rfc 1951)  gzip = 2, gzip compression (rfc 1952) ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.Compression" aria-label="Link to SkiaSharp.QrCode.Compression">#</a><code>public enum Compression : int</code> <span class="tag">obsolete</span></h3>
+        <article class="type" id="SkiaSharp.QrCode.Compression" data-name="skiasharp.qrcode.compression" data-text="skiasharp.qrcode.compression public enum compression : int compression mode for qr code data serialization. no api in this library accepts or returns this type. the serialization feature it described was removed before 1.0.0; the enum was left behind and shipped in 1.1.1, which is the only reason it still exists. compress the bytes from getrawdata() yourself, as shown in docs/migration.md. value uncompressed = 0, no compression  value deflate = 1, deflate compression (rfc 1951)  value gzip = 2, gzip compression (rfc 1952) ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Compression" aria-label="Link to SkiaSharp.QrCode.Compression">#</a><span class="kind">enum</span> <span class="name">Compression</span> <span class="tag">obsolete</span></h3>
+          <pre class="sig"><code>public enum Compression : int</code></pre>
           <p class="doc">Compression mode for QR code data serialization.</p>
           <details class="notes" data-text="no api in this library accepts or returns this type. the serialization feature it described was removed before 1.0.0; the enum was left behind and shipped in 1.1.1, which is the only reason it still exists. compress the bytes from getrawdata() yourself, as shown in docs/migration.md.">
             <summary>Notes</summary>
             <p class="doc remarks">No API in this library accepts or returns this type. The serialization feature it described was removed before 1.0.0; the enum was left behind and shipped in 1.1.1, which is the only reason it still exists. Compress the bytes from GetRawData() yourself, as shown in docs/migration.md.</p>
           </details>
           <div class="members">
-            <div class="member" data-text="uncompressed = 0, no compression ">
-              <code>Uncompressed = 0,</code>
+            <div class="member" data-text="value uncompressed = 0, no compression ">
+              <pre class="sig"><code>Uncompressed = 0,</code></pre>
               <p class="doc">No compression</p>
             </div>
-            <div class="member" data-text="deflate = 1, deflate compression (rfc 1951) ">
-              <code>Deflate = 1,</code>
+            <div class="member" data-text="value deflate = 1, deflate compression (rfc 1951) ">
+              <pre class="sig"><code>Deflate = 1,</code></pre>
               <p class="doc">DEFLATE compression (RFC 1951)</p>
             </div>
-            <div class="member" data-text="gzip = 2, gzip compression (rfc 1952) ">
-              <code>GZip = 2,</code>
+            <div class="member" data-text="value gzip = 2, gzip compression (rfc 1952) ">
+              <pre class="sig"><code>GZip = 2,</code></pre>
               <p class="doc">GZIP compression (RFC 1952)</p>
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.ECCLevel" data-name="skiasharp.qrcode.ecclevel" data-text="skiasharp.qrcode.ecclevel public enum ecclevel : int the error correction level: how much of a symbol can be damaged, dirty or covered while the code still scans. higher levels leave less room for content, so the same text may need a larger symbol.  l = 0, 7% may be lost before recovery is not possible  m = 1, 15% may be lost before recovery is not possible  q = 2, 25% may be lost before recovery is not possible  h = 3, 30% may be lost before recovery is not possible ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.ECCLevel" aria-label="Link to SkiaSharp.QrCode.ECCLevel">#</a><code>public enum ECCLevel : int</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.ECCLevel" data-name="skiasharp.qrcode.ecclevel" data-text="skiasharp.qrcode.ecclevel public enum ecclevel : int the error correction level: how much of a symbol can be damaged, dirty or covered while the code still scans. higher levels leave less room for content, so the same text may need a larger symbol.  value l = 0, 7% may be lost before recovery is not possible  value m = 1, 15% may be lost before recovery is not possible  value q = 2, 25% may be lost before recovery is not possible  value h = 3, 30% may be lost before recovery is not possible ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.ECCLevel" aria-label="Link to SkiaSharp.QrCode.ECCLevel">#</a><span class="kind">enum</span> <span class="name">ECCLevel</span></h3>
+          <pre class="sig"><code>public enum ECCLevel : int</code></pre>
           <p class="doc">The error correction level: how much of a symbol can be damaged, dirty or covered while the code still scans. Higher levels leave less room for content, so the same text may need a larger symbol.</p>
           <div class="members">
-            <div class="member" data-text="l = 0, 7% may be lost before recovery is not possible ">
-              <code>L = 0,</code>
+            <div class="member" data-text="value l = 0, 7% may be lost before recovery is not possible ">
+              <pre class="sig"><code>L = 0,</code></pre>
               <p class="doc">7% may be lost before recovery is not possible</p>
             </div>
-            <div class="member" data-text="m = 1, 15% may be lost before recovery is not possible ">
-              <code>M = 1,</code>
+            <div class="member" data-text="value m = 1, 15% may be lost before recovery is not possible ">
+              <pre class="sig"><code>M = 1,</code></pre>
               <p class="doc">15% may be lost before recovery is not possible</p>
             </div>
-            <div class="member" data-text="q = 2, 25% may be lost before recovery is not possible ">
-              <code>Q = 2,</code>
+            <div class="member" data-text="value q = 2, 25% may be lost before recovery is not possible ">
+              <pre class="sig"><code>Q = 2,</code></pre>
               <p class="doc">25% may be lost before recovery is not possible</p>
             </div>
-            <div class="member" data-text="h = 3, 30% may be lost before recovery is not possible ">
-              <code>H = 3,</code>
+            <div class="member" data-text="value h = 3, 30% may be lost before recovery is not possible ">
+              <pre class="sig"><code>H = 3,</code></pre>
               <p class="doc">30% may be lost before recovery is not possible</p>
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.EciMode" data-name="skiasharp.qrcode.ecimode" data-text="skiasharp.qrcode.ecimode public enum ecimode : int eci (extended channel interpretation) mode for character encoding.  default = 0, auto-detect encoding and add appropriate eci header (recommended for most use cases). automatic encoding detectionascii-only (0x00-0x7f): no eci header (maximum compatibility, smallest size)iso-8859-1 compatible: auto-upgrade to iso8859_1 (eci 3 header added)unicode (emojis, cjk, etc.): auto-upgrade to utf8 (eci 26 header added)examples: &quot;hello&quot; → no eci header (ascii-only, 29 bits for &quot;he&quot;) &quot;café&quot; → eci 3 (iso-8859-1, 41 bits for &quot;ca&quot;) &quot;🎉&quot; → eci 26 (utf-8, 41 bits + utf-8 bytes) &quot;こんにちは&quot; → eci 26 (utf-8, auto-detected) iso8859_1 = 3, iso-8859-1 (latin-1) encoding - western european characters. adds an eci header: 12 bits in standard qr, 11 bits in rmqr. character support:ascii (0x00-0x7f): a-z, 0-9, basic symbolsextended latin (0x80-0xff): à, ç, ñ, é, ü, etc.use when:content is western european languages (english, french, spanish, german, etc.)you need explicit iso-8859-1 encoding declarationcompatibility with iso-8859-1 readers is requiredcannot encode:emojis (🎉, 😀, etc.)cjk characters (日本語, 中文, 한글)cyrillic beyond basic range utf8 = 26, utf-8 unicode encoding - universal character support. adds an eci header: 12 bits in standard qr, 11 bits in rmqr. character support:all unicode characters (u+0000 to u+10ffff)emojis, cjk, arabic, hebrew, cyrillic, etc.multi-byte encoding: 1-4 bytes per charactersize impact:eci header: +12 bits in standard qr, +11 bits in rmqrdata encoding: variable (1-4 bytes per character)standard qr example: &quot;🎉&quot; = 12 (header) + 4 + 9 + 32 (4-byte utf-8) = 57 bitsstandard qr example: &quot;café&quot; = 12 (header) + 4 + 9 + 40 (5 bytes: c,a,f,é=c3a9) = 65 bitsutf-8 byte examples: 'a' → 0x41 (1 byte, ascii) 'é' → 0xc3 0xa9 (2 bytes, latin extended) '中' → 0xe4 0xb8 0xad (3 bytes, cjk) '🎉' → 0xf0 0x9f 0x8e 0x89 (4 bytes, emoji) use when:content includes emojis or symbolscontent includes cjk characters (japanese, chinese, korean)content includes non-latin scripts (cyrillic, arabic, hebrew, etc.)you need universal unicode supporttrade-offs:larger data size for non-ascii characters (multi-byte encoding)eci header adds 12 bits in standard qr or 11 bits in rmqrfor western european text, iso8859_1 is more efficient">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.EciMode" aria-label="Link to SkiaSharp.QrCode.EciMode">#</a><code>public enum EciMode : int</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.EciMode" data-name="skiasharp.qrcode.ecimode" data-text="skiasharp.qrcode.ecimode public enum ecimode : int eci (extended channel interpretation) mode for character encoding.  value default = 0, auto-detect encoding and add appropriate eci header (recommended for most use cases). automatic encoding detectionascii-only (0x00-0x7f): no eci header (maximum compatibility, smallest size)iso-8859-1 compatible: auto-upgrade to iso8859_1 (eci 3 header added)unicode (emojis, cjk, etc.): auto-upgrade to utf8 (eci 26 header added)examples: &quot;hello&quot; → no eci header (ascii-only, 29 bits for &quot;he&quot;) &quot;café&quot; → eci 3 (iso-8859-1, 41 bits for &quot;ca&quot;) &quot;🎉&quot; → eci 26 (utf-8, 41 bits + utf-8 bytes) &quot;こんにちは&quot; → eci 26 (utf-8, auto-detected) value iso8859_1 = 3, iso-8859-1 (latin-1) encoding - western european characters. adds an eci header: 12 bits in standard qr, 11 bits in rmqr. character support:ascii (0x00-0x7f): a-z, 0-9, basic symbolsextended latin (0x80-0xff): à, ç, ñ, é, ü, etc.use when:content is western european languages (english, french, spanish, german, etc.)you need explicit iso-8859-1 encoding declarationcompatibility with iso-8859-1 readers is requiredcannot encode:emojis (🎉, 😀, etc.)cjk characters (日本語, 中文, 한글)cyrillic beyond basic range value utf8 = 26, utf-8 unicode encoding - universal character support. adds an eci header: 12 bits in standard qr, 11 bits in rmqr. character support:all unicode characters (u+0000 to u+10ffff)emojis, cjk, arabic, hebrew, cyrillic, etc.multi-byte encoding: 1-4 bytes per charactersize impact:eci header: +12 bits in standard qr, +11 bits in rmqrdata encoding: variable (1-4 bytes per character)standard qr example: &quot;🎉&quot; = 12 (header) + 4 + 9 + 32 (4-byte utf-8) = 57 bitsstandard qr example: &quot;café&quot; = 12 (header) + 4 + 9 + 40 (5 bytes: c,a,f,é=c3a9) = 65 bitsutf-8 byte examples: 'a' → 0x41 (1 byte, ascii) 'é' → 0xc3 0xa9 (2 bytes, latin extended) '中' → 0xe4 0xb8 0xad (3 bytes, cjk) '🎉' → 0xf0 0x9f 0x8e 0x89 (4 bytes, emoji) use when:content includes emojis or symbolscontent includes cjk characters (japanese, chinese, korean)content includes non-latin scripts (cyrillic, arabic, hebrew, etc.)you need universal unicode supporttrade-offs:larger data size for non-ascii characters (multi-byte encoding)eci header adds 12 bits in standard qr or 11 bits in rmqrfor western european text, iso8859_1 is more efficient">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.EciMode" aria-label="Link to SkiaSharp.QrCode.EciMode">#</a><span class="kind">enum</span> <span class="name">EciMode</span></h3>
+          <pre class="sig"><code>public enum EciMode : int</code></pre>
           <p class="doc">ECI (Extended Channel Interpretation) mode for character encoding.</p>
           <div class="members">
-            <div class="member" data-text="default = 0, auto-detect encoding and add appropriate eci header (recommended for most use cases). automatic encoding detectionascii-only (0x00-0x7f): no eci header (maximum compatibility, smallest size)iso-8859-1 compatible: auto-upgrade to iso8859_1 (eci 3 header added)unicode (emojis, cjk, etc.): auto-upgrade to utf8 (eci 26 header added)examples: &quot;hello&quot; → no eci header (ascii-only, 29 bits for &quot;he&quot;) &quot;café&quot; → eci 3 (iso-8859-1, 41 bits for &quot;ca&quot;) &quot;🎉&quot; → eci 26 (utf-8, 41 bits + utf-8 bytes) &quot;こんにちは&quot; → eci 26 (utf-8, auto-detected)">
-              <code>Default = 0,</code>
+            <div class="member" data-text="value default = 0, auto-detect encoding and add appropriate eci header (recommended for most use cases). automatic encoding detectionascii-only (0x00-0x7f): no eci header (maximum compatibility, smallest size)iso-8859-1 compatible: auto-upgrade to iso8859_1 (eci 3 header added)unicode (emojis, cjk, etc.): auto-upgrade to utf8 (eci 26 header added)examples: &quot;hello&quot; → no eci header (ascii-only, 29 bits for &quot;he&quot;) &quot;café&quot; → eci 3 (iso-8859-1, 41 bits for &quot;ca&quot;) &quot;🎉&quot; → eci 26 (utf-8, 41 bits + utf-8 bytes) &quot;こんにちは&quot; → eci 26 (utf-8, auto-detected)">
+              <pre class="sig"><code>Default = 0,</code></pre>
               <p class="doc">Auto-detect encoding and add appropriate ECI header (recommended for most use cases).</p>
               <details class="notes" data-text="automatic encoding detectionascii-only (0x00-0x7f): no eci header (maximum compatibility, smallest size)iso-8859-1 compatible: auto-upgrade to iso8859_1 (eci 3 header added)unicode (emojis, cjk, etc.): auto-upgrade to utf8 (eci 26 header added)examples: &quot;hello&quot; → no eci header (ascii-only, 29 bits for &quot;he&quot;) &quot;café&quot; → eci 3 (iso-8859-1, 41 bits for &quot;ca&quot;) &quot;🎉&quot; → eci 26 (utf-8, 41 bits + utf-8 bytes) &quot;こんにちは&quot; → eci 26 (utf-8, auto-detected)">
                 <summary>Notes</summary>
                 <p class="doc remarks">Automatic Encoding DetectionASCII-only (0x00-0x7F): No ECI header (maximum compatibility, smallest size)ISO-8859-1 compatible: Auto-upgrade to Iso8859_1 (ECI 3 header added)Unicode (emojis, CJK, etc.): Auto-upgrade to Utf8 (ECI 26 header added)Examples: &quot;HELLO&quot; → No ECI header (ASCII-only, 29 bits for &quot;HE&quot;) &quot;Café&quot; → ECI 3 (ISO-8859-1, 41 bits for &quot;Ca&quot;) &quot;🎉&quot; → ECI 26 (UTF-8, 41 bits + UTF-8 bytes) &quot;こんにちは&quot; → ECI 26 (UTF-8, auto-detected)</p>
               </details>
             </div>
-            <div class="member" data-text="iso8859_1 = 3, iso-8859-1 (latin-1) encoding - western european characters. adds an eci header: 12 bits in standard qr, 11 bits in rmqr. character support:ascii (0x00-0x7f): a-z, 0-9, basic symbolsextended latin (0x80-0xff): à, ç, ñ, é, ü, etc.use when:content is western european languages (english, french, spanish, german, etc.)you need explicit iso-8859-1 encoding declarationcompatibility with iso-8859-1 readers is requiredcannot encode:emojis (🎉, 😀, etc.)cjk characters (日本語, 中文, 한글)cyrillic beyond basic range">
-              <code>Iso8859_1 = 3,</code>
+            <div class="member" data-text="value iso8859_1 = 3, iso-8859-1 (latin-1) encoding - western european characters. adds an eci header: 12 bits in standard qr, 11 bits in rmqr. character support:ascii (0x00-0x7f): a-z, 0-9, basic symbolsextended latin (0x80-0xff): à, ç, ñ, é, ü, etc.use when:content is western european languages (english, french, spanish, german, etc.)you need explicit iso-8859-1 encoding declarationcompatibility with iso-8859-1 readers is requiredcannot encode:emojis (🎉, 😀, etc.)cjk characters (日本語, 中文, 한글)cyrillic beyond basic range">
+              <pre class="sig"><code>Iso8859_1 = 3,</code></pre>
               <p class="doc">ISO-8859-1 (Latin-1) encoding - Western European characters. Adds an ECI header: 12 bits in Standard QR, 11 bits in rMQR.</p>
               <details class="notes" data-text="character support:ascii (0x00-0x7f): a-z, 0-9, basic symbolsextended latin (0x80-0xff): à, ç, ñ, é, ü, etc.use when:content is western european languages (english, french, spanish, german, etc.)you need explicit iso-8859-1 encoding declarationcompatibility with iso-8859-1 readers is requiredcannot encode:emojis (🎉, 😀, etc.)cjk characters (日本語, 中文, 한글)cyrillic beyond basic range">
                 <summary>Notes</summary>
                 <p class="doc remarks">Character Support:ASCII (0x00-0x7F): A-Z, 0-9, basic symbolsExtended Latin (0x80-0xFF): À, Ç, Ñ, é, ü, etc.Use when:Content is Western European languages (English, French, Spanish, German, etc.)You need explicit ISO-8859-1 encoding declarationCompatibility with ISO-8859-1 readers is requiredCannot encode:Emojis (🎉, 😀, etc.)CJK characters (日本語, 中文, 한글)Cyrillic beyond basic range</p>
               </details>
             </div>
-            <div class="member" data-text="utf8 = 26, utf-8 unicode encoding - universal character support. adds an eci header: 12 bits in standard qr, 11 bits in rmqr. character support:all unicode characters (u+0000 to u+10ffff)emojis, cjk, arabic, hebrew, cyrillic, etc.multi-byte encoding: 1-4 bytes per charactersize impact:eci header: +12 bits in standard qr, +11 bits in rmqrdata encoding: variable (1-4 bytes per character)standard qr example: &quot;🎉&quot; = 12 (header) + 4 + 9 + 32 (4-byte utf-8) = 57 bitsstandard qr example: &quot;café&quot; = 12 (header) + 4 + 9 + 40 (5 bytes: c,a,f,é=c3a9) = 65 bitsutf-8 byte examples: 'a' → 0x41 (1 byte, ascii) 'é' → 0xc3 0xa9 (2 bytes, latin extended) '中' → 0xe4 0xb8 0xad (3 bytes, cjk) '🎉' → 0xf0 0x9f 0x8e 0x89 (4 bytes, emoji) use when:content includes emojis or symbolscontent includes cjk characters (japanese, chinese, korean)content includes non-latin scripts (cyrillic, arabic, hebrew, etc.)you need universal unicode supporttrade-offs:larger data size for non-ascii characters (multi-byte encoding)eci header adds 12 bits in standard qr or 11 bits in rmqrfor western european text, iso8859_1 is more efficient">
-              <code>Utf8 = 26,</code>
+            <div class="member" data-text="value utf8 = 26, utf-8 unicode encoding - universal character support. adds an eci header: 12 bits in standard qr, 11 bits in rmqr. character support:all unicode characters (u+0000 to u+10ffff)emojis, cjk, arabic, hebrew, cyrillic, etc.multi-byte encoding: 1-4 bytes per charactersize impact:eci header: +12 bits in standard qr, +11 bits in rmqrdata encoding: variable (1-4 bytes per character)standard qr example: &quot;🎉&quot; = 12 (header) + 4 + 9 + 32 (4-byte utf-8) = 57 bitsstandard qr example: &quot;café&quot; = 12 (header) + 4 + 9 + 40 (5 bytes: c,a,f,é=c3a9) = 65 bitsutf-8 byte examples: 'a' → 0x41 (1 byte, ascii) 'é' → 0xc3 0xa9 (2 bytes, latin extended) '中' → 0xe4 0xb8 0xad (3 bytes, cjk) '🎉' → 0xf0 0x9f 0x8e 0x89 (4 bytes, emoji) use when:content includes emojis or symbolscontent includes cjk characters (japanese, chinese, korean)content includes non-latin scripts (cyrillic, arabic, hebrew, etc.)you need universal unicode supporttrade-offs:larger data size for non-ascii characters (multi-byte encoding)eci header adds 12 bits in standard qr or 11 bits in rmqrfor western european text, iso8859_1 is more efficient">
+              <pre class="sig"><code>Utf8 = 26,</code></pre>
               <p class="doc">UTF-8 Unicode encoding - Universal character support. Adds an ECI header: 12 bits in Standard QR, 11 bits in rMQR.</p>
               <details class="notes" data-text="character support:all unicode characters (u+0000 to u+10ffff)emojis, cjk, arabic, hebrew, cyrillic, etc.multi-byte encoding: 1-4 bytes per charactersize impact:eci header: +12 bits in standard qr, +11 bits in rmqrdata encoding: variable (1-4 bytes per character)standard qr example: &quot;🎉&quot; = 12 (header) + 4 + 9 + 32 (4-byte utf-8) = 57 bitsstandard qr example: &quot;café&quot; = 12 (header) + 4 + 9 + 40 (5 bytes: c,a,f,é=c3a9) = 65 bitsutf-8 byte examples: 'a' → 0x41 (1 byte, ascii) 'é' → 0xc3 0xa9 (2 bytes, latin extended) '中' → 0xe4 0xb8 0xad (3 bytes, cjk) '🎉' → 0xf0 0x9f 0x8e 0x89 (4 bytes, emoji) use when:content includes emojis or symbolscontent includes cjk characters (japanese, chinese, korean)content includes non-latin scripts (cyrillic, arabic, hebrew, etc.)you need universal unicode supporttrade-offs:larger data size for non-ascii characters (multi-byte encoding)eci header adds 12 bits in standard qr or 11 bits in rmqrfor western european text, iso8859_1 is more efficient">
                 <summary>Notes</summary>
@@ -417,281 +429,331 @@
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.MicroQRCodeCalculatedSize" data-name="skiasharp.qrcode.microqrcodecalculatedsize" data-text="skiasharp.qrcode.microqrcodecalculatedsize public readonly struct microqrcodecalculatedsize result of trygetrequiredbuffersize : buffer size, matrix side length and selected version for a pending micro qr encode.  public microqrversion version { get; } the micro qr version that will be produced.  public int buffersize { get; } required destination buffer size in bytes (one byte per module, quiet zone included).  public int qrsize { get; } matrix side length in modules, quiet zone included. ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.MicroQRCodeCalculatedSize" aria-label="Link to SkiaSharp.QrCode.MicroQRCodeCalculatedSize">#</a><code>public readonly struct MicroQRCodeCalculatedSize</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.MicroQRCodeCalculatedSize" data-name="skiasharp.qrcode.microqrcodecalculatedsize" data-text="skiasharp.qrcode.microqrcodecalculatedsize public readonly struct microqrcodecalculatedsize result of trygetrequiredbuffersize : buffer size, matrix side length and selected version for a pending micro qr encode.  property public microqrversion version { get; } the micro qr version that will be produced.  property public int buffersize { get; } required destination buffer size in bytes (one byte per module, quiet zone included).  property public int qrsize { get; } matrix side length in modules, quiet zone included. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.MicroQRCodeCalculatedSize" aria-label="Link to SkiaSharp.QrCode.MicroQRCodeCalculatedSize">#</a><span class="kind">struct</span> <span class="name">MicroQRCodeCalculatedSize</span></h3>
+          <pre class="sig"><code>public readonly struct MicroQRCodeCalculatedSize</code></pre>
           <p class="doc">Result of TryGetRequiredBufferSize : buffer size, matrix side length and selected version for a pending Micro QR encode.</p>
           <div class="members">
-            <div class="member" data-text="public microqrversion version { get; } the micro qr version that will be produced. ">
-              <code>public MicroQRVersion Version { get; }</code>
+            <div class="member" data-text="property public microqrversion version { get; } the micro qr version that will be produced. ">
+              <h4><span class="kind">property</span> <span class="name">Version</span></h4>
+              <pre class="sig"><code>public MicroQRVersion Version { get; }</code></pre>
               <p class="doc">The Micro QR version that will be produced.</p>
             </div>
-            <div class="member" data-text="public int buffersize { get; } required destination buffer size in bytes (one byte per module, quiet zone included). ">
-              <code>public int BufferSize { get; }</code>
+            <div class="member" data-text="property public int buffersize { get; } required destination buffer size in bytes (one byte per module, quiet zone included). ">
+              <h4><span class="kind">property</span> <span class="name">BufferSize</span></h4>
+              <pre class="sig"><code>public int BufferSize { get; }</code></pre>
               <p class="doc">Required destination buffer size in bytes (one byte per module, quiet zone included).</p>
             </div>
-            <div class="member" data-text="public int qrsize { get; } matrix side length in modules, quiet zone included. ">
-              <code>public int QrSize { get; }</code>
+            <div class="member" data-text="property public int qrsize { get; } matrix side length in modules, quiet zone included. ">
+              <h4><span class="kind">property</span> <span class="name">QrSize</span></h4>
+              <pre class="sig"><code>public int QrSize { get; }</code></pre>
               <p class="doc">Matrix side length in modules, quiet zone included.</p>
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.MicroQRCodeData" data-name="skiasharp.qrcode.microqrcodedata" data-text="skiasharp.qrcode.microqrcodedata public class microqrcodedata represents micro qr code data as a 2d boolean matrix (versions m1-m4, 11×11 to 17×17 modules). storage mirrors qrcodedata : core modules only (no quiet zone), bit-packed msb-first in flat row-major order; the quiet zone is virtual and always reads light. serialization uses the &quot;qrx&quot; container: &quot;qrx&quot; + symbol type (1 byte) + width (1 byte) + height (1 byte) + packed core bits. the legacy &quot;qrr&quot; format remains exclusive to standard qr. public microqrcodedata(microqrversion version, int quietzonesize); initializes an empty matrix for the specified version.  public microqrcodedata(readonlyspan&lt;byte&gt; rawdata, int quietzonesize);  public microqrcodedata(byte[] rawdata, int quietzonesize); deserializes micro qr data previously produced by getrawdata .  public microqrversion version { get; } gets the micro qr version (m1-m4).  public bool this[int row, int col] { get; } gets the module state at the specified position (quiet zone included). quiet zone positions always read false.  public int size { get; } gets the matrix side length in modules, including the quiet zone.  public modulerect[] getmodulerectangles(); gets the dark modules as merged rectangles in module coordinates, for rendering with any graphics api without skiasharp (svg path data, draw calls, vector output). coordinates use the same space as the indexer (this[row, col]): one unit is one module, origin at the top-left including the quiet zone, x is the column and y is the row. consumers scale by the pixel size of one module; size gives the total extent in modules. three properties are contractual: rectangles never overlap, cover only dark modules, and cover every dark module. the decomposition shape and ordering are unspecified and may change between versions (currently maximal horizontal runs in row-major order, the same merge the built-in renderer draws). public bool trygetmodulerectangles(span&lt;modulerect&gt; destination, out int written); writes the dark modules as merged rectangles into a caller-provided buffer. same contract as getmodulerectangles without allocations.  public byte[] getrawdata(); serializes the core modules (quiet zone excluded) to a new byte array.  public int getmodulerectanglesmaxcount(); gets an upper bound on the number of rectangles getmodulerectangles can return, suitable for sizing a pooled buffer for trygetmodulerectangles . o(1), no matrix scan.  public int getrawdata(ibufferwriter&lt;byte&gt; writer); writes the serialized data to the specified buffer writer without intermediate allocation.  public int getrawdatasize(); gets the serialized size in bytes (&quot;qrx&quot; header + packed core bits). ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.MicroQRCodeData" aria-label="Link to SkiaSharp.QrCode.MicroQRCodeData">#</a><code>public class MicroQRCodeData</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.MicroQRCodeData" data-name="skiasharp.qrcode.microqrcodedata" data-text="skiasharp.qrcode.microqrcodedata public class microqrcodedata represents micro qr code data as a 2d boolean matrix (versions m1-m4, 11×11 to 17×17 modules). storage mirrors qrcodedata : core modules only (no quiet zone), bit-packed msb-first in flat row-major order; the quiet zone is virtual and always reads light. serialization uses the &quot;qrx&quot; container: &quot;qrx&quot; + symbol type (1 byte) + width (1 byte) + height (1 byte) + packed core bits. the legacy &quot;qrr&quot; format remains exclusive to standard qr. constructor public microqrcodedata(microqrversion version, int quietzonesize); initializes an empty matrix for the specified version.  constructor public microqrcodedata(readonlyspan&lt;byte&gt; rawdata, int quietzonesize);  constructor public microqrcodedata(byte[] rawdata, int quietzonesize); deserializes micro qr data previously produced by getrawdata .  property public microqrversion version { get; } gets the micro qr version (m1-m4).  indexer public bool this[int row, int col] { get; } gets the module state at the specified position (quiet zone included). quiet zone positions always read false.  property public int size { get; } gets the matrix side length in modules, including the quiet zone.  method public modulerect[] getmodulerectangles(); gets the dark modules as merged rectangles in module coordinates, for rendering with any graphics api without skiasharp (svg path data, draw calls, vector output). coordinates use the same space as the indexer (this[row, col]): one unit is one module, origin at the top-left including the quiet zone, x is the column and y is the row. consumers scale by the pixel size of one module; size gives the total extent in modules. three properties are contractual: rectangles never overlap, cover only dark modules, and cover every dark module. the decomposition shape and ordering are unspecified and may change between versions (currently maximal horizontal runs in row-major order, the same merge the built-in renderer draws). method public bool trygetmodulerectangles(span&lt;modulerect&gt; destination, out int written); writes the dark modules as merged rectangles into a caller-provided buffer. same contract as getmodulerectangles without allocations.  method public byte[] getrawdata(); serializes the core modules (quiet zone excluded) to a new byte array.  method public int getmodulerectanglesmaxcount(); gets an upper bound on the number of rectangles getmodulerectangles can return, suitable for sizing a pooled buffer for trygetmodulerectangles . o(1), no matrix scan.  method public int getrawdata(ibufferwriter&lt;byte&gt; writer); writes the serialized data to the specified buffer writer without intermediate allocation.  method public int getrawdatasize(); gets the serialized size in bytes (&quot;qrx&quot; header + packed core bits). ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.MicroQRCodeData" aria-label="Link to SkiaSharp.QrCode.MicroQRCodeData">#</a><span class="kind">class</span> <span class="name">MicroQRCodeData</span></h3>
+          <pre class="sig"><code>public class MicroQRCodeData</code></pre>
           <p class="doc">Represents Micro QR code data as a 2D boolean matrix (versions M1-M4, 11×11 to 17×17 modules).</p>
           <details class="notes" data-text="storage mirrors qrcodedata : core modules only (no quiet zone), bit-packed msb-first in flat row-major order; the quiet zone is virtual and always reads light. serialization uses the &quot;qrx&quot; container: &quot;qrx&quot; + symbol type (1 byte) + width (1 byte) + height (1 byte) + packed core bits. the legacy &quot;qrr&quot; format remains exclusive to standard qr.">
             <summary>Notes</summary>
             <p class="doc remarks">Storage mirrors QRCodeData : core modules only (no quiet zone), bit-packed MSB-first in flat row-major order; the quiet zone is virtual and always reads light. Serialization uses the &quot;QRX&quot; container: &quot;QRX&quot; + symbol type (1 byte) + width (1 byte) + height (1 byte) + packed core bits. The legacy &quot;QRR&quot; format remains exclusive to Standard QR.</p>
           </details>
           <div class="members">
-            <div class="member" data-text="public microqrcodedata(microqrversion version, int quietzonesize); initializes an empty matrix for the specified version. ">
-              <code>public MicroQRCodeData(MicroQRVersion version, int quietZoneSize);</code>
+            <div class="member" data-text="constructor public microqrcodedata(microqrversion version, int quietzonesize); initializes an empty matrix for the specified version. ">
+              <h4><span class="kind">constructor</span> <span class="name">MicroQRCodeData</span></h4>
+              <pre class="sig"><code>public MicroQRCodeData(MicroQRVersion version, int quietZoneSize);</code></pre>
               <p class="doc">Initializes an empty matrix for the specified version.</p>
             </div>
-            <div class="member" data-text="public microqrcodedata(readonlyspan&lt;byte&gt; rawdata, int quietzonesize); ">
-              <code>public MicroQRCodeData(ReadOnlySpan&lt;byte&gt; rawData, int quietZoneSize);</code>
+            <div class="member" data-text="constructor public microqrcodedata(readonlyspan&lt;byte&gt; rawdata, int quietzonesize); ">
+              <h4><span class="kind">constructor</span> <span class="name">MicroQRCodeData</span></h4>
+              <pre class="sig"><code>public MicroQRCodeData(ReadOnlySpan&lt;byte&gt; rawData, int quietZoneSize);</code></pre>
             </div>
-            <div class="member" data-text="public microqrcodedata(byte[] rawdata, int quietzonesize); deserializes micro qr data previously produced by getrawdata . ">
-              <code>public MicroQRCodeData(byte[] rawData, int quietZoneSize);</code>
+            <div class="member" data-text="constructor public microqrcodedata(byte[] rawdata, int quietzonesize); deserializes micro qr data previously produced by getrawdata . ">
+              <h4><span class="kind">constructor</span> <span class="name">MicroQRCodeData</span></h4>
+              <pre class="sig"><code>public MicroQRCodeData(byte[] rawData, int quietZoneSize);</code></pre>
               <p class="doc">Deserializes Micro QR data previously produced by GetRawData .</p>
             </div>
-            <div class="member" data-text="public microqrversion version { get; } gets the micro qr version (m1-m4). ">
-              <code>public MicroQRVersion Version { get; }</code>
+            <div class="member" data-text="property public microqrversion version { get; } gets the micro qr version (m1-m4). ">
+              <h4><span class="kind">property</span> <span class="name">Version</span></h4>
+              <pre class="sig"><code>public MicroQRVersion Version { get; }</code></pre>
               <p class="doc">Gets the Micro QR version (M1-M4).</p>
             </div>
-            <div class="member" data-text="public bool this[int row, int col] { get; } gets the module state at the specified position (quiet zone included). quiet zone positions always read false. ">
-              <code>public bool this[int row, int col] { get; }</code>
+            <div class="member" data-text="indexer public bool this[int row, int col] { get; } gets the module state at the specified position (quiet zone included). quiet zone positions always read false. ">
+              <h4><span class="kind">indexer</span> <span class="name">this[int row, int col]</span></h4>
+              <pre class="sig"><code>public bool this[int row, int col] { get; }</code></pre>
               <p class="doc">Gets the module state at the specified position (quiet zone included). Quiet zone positions always read false.</p>
             </div>
-            <div class="member" data-text="public int size { get; } gets the matrix side length in modules, including the quiet zone. ">
-              <code>public int Size { get; }</code>
+            <div class="member" data-text="property public int size { get; } gets the matrix side length in modules, including the quiet zone. ">
+              <h4><span class="kind">property</span> <span class="name">Size</span></h4>
+              <pre class="sig"><code>public int Size { get; }</code></pre>
               <p class="doc">Gets the matrix side length in modules, including the quiet zone.</p>
             </div>
-            <div class="member" data-text="public modulerect[] getmodulerectangles(); gets the dark modules as merged rectangles in module coordinates, for rendering with any graphics api without skiasharp (svg path data, draw calls, vector output). coordinates use the same space as the indexer (this[row, col]): one unit is one module, origin at the top-left including the quiet zone, x is the column and y is the row. consumers scale by the pixel size of one module; size gives the total extent in modules. three properties are contractual: rectangles never overlap, cover only dark modules, and cover every dark module. the decomposition shape and ordering are unspecified and may change between versions (currently maximal horizontal runs in row-major order, the same merge the built-in renderer draws).">
-              <code>public ModuleRect[] GetModuleRectangles();</code>
+            <div class="member" data-text="method public modulerect[] getmodulerectangles(); gets the dark modules as merged rectangles in module coordinates, for rendering with any graphics api without skiasharp (svg path data, draw calls, vector output). coordinates use the same space as the indexer (this[row, col]): one unit is one module, origin at the top-left including the quiet zone, x is the column and y is the row. consumers scale by the pixel size of one module; size gives the total extent in modules. three properties are contractual: rectangles never overlap, cover only dark modules, and cover every dark module. the decomposition shape and ordering are unspecified and may change between versions (currently maximal horizontal runs in row-major order, the same merge the built-in renderer draws).">
+              <h4><span class="kind">method</span> <span class="name">GetModuleRectangles</span></h4>
+              <pre class="sig"><code>public ModuleRect[] GetModuleRectangles();</code></pre>
               <p class="doc">Gets the dark modules as merged rectangles in module coordinates, for rendering with any graphics API without SkiaSharp (SVG path data, draw calls, vector output).</p>
               <details class="notes" data-text="coordinates use the same space as the indexer (this[row, col]): one unit is one module, origin at the top-left including the quiet zone, x is the column and y is the row. consumers scale by the pixel size of one module; size gives the total extent in modules. three properties are contractual: rectangles never overlap, cover only dark modules, and cover every dark module. the decomposition shape and ordering are unspecified and may change between versions (currently maximal horizontal runs in row-major order, the same merge the built-in renderer draws).">
                 <summary>Notes</summary>
                 <p class="doc remarks">Coordinates use the same space as the indexer (this[row, col]): one unit is one module, origin at the top-left including the quiet zone, X is the column and Y is the row. Consumers scale by the pixel size of one module; Size gives the total extent in modules. Three properties are contractual: rectangles never overlap, cover only dark modules, and cover every dark module. The decomposition shape and ordering are unspecified and may change between versions (currently maximal horizontal runs in row-major order, the same merge the built-in renderer draws).</p>
               </details>
             </div>
-            <div class="member" data-text="public bool trygetmodulerectangles(span&lt;modulerect&gt; destination, out int written); writes the dark modules as merged rectangles into a caller-provided buffer. same contract as getmodulerectangles without allocations. ">
-              <code>public bool TryGetModuleRectangles(Span&lt;ModuleRect&gt; destination, out int written);</code>
+            <div class="member" data-text="method public bool trygetmodulerectangles(span&lt;modulerect&gt; destination, out int written); writes the dark modules as merged rectangles into a caller-provided buffer. same contract as getmodulerectangles without allocations. ">
+              <h4><span class="kind">method</span> <span class="name">TryGetModuleRectangles</span></h4>
+              <pre class="sig"><code>public bool TryGetModuleRectangles(Span&lt;ModuleRect&gt; destination, out int written);</code></pre>
               <p class="doc">Writes the dark modules as merged rectangles into a caller-provided buffer. Same contract as GetModuleRectangles without allocations.</p>
             </div>
-            <div class="member" data-text="public byte[] getrawdata(); serializes the core modules (quiet zone excluded) to a new byte array. ">
-              <code>public byte[] GetRawData();</code>
+            <div class="member" data-text="method public byte[] getrawdata(); serializes the core modules (quiet zone excluded) to a new byte array. ">
+              <h4><span class="kind">method</span> <span class="name">GetRawData</span></h4>
+              <pre class="sig"><code>public byte[] GetRawData();</code></pre>
               <p class="doc">Serializes the core modules (quiet zone excluded) to a new byte array.</p>
             </div>
-            <div class="member" data-text="public int getmodulerectanglesmaxcount(); gets an upper bound on the number of rectangles getmodulerectangles can return, suitable for sizing a pooled buffer for trygetmodulerectangles . o(1), no matrix scan. ">
-              <code>public int GetModuleRectanglesMaxCount();</code>
+            <div class="member" data-text="method public int getmodulerectanglesmaxcount(); gets an upper bound on the number of rectangles getmodulerectangles can return, suitable for sizing a pooled buffer for trygetmodulerectangles . o(1), no matrix scan. ">
+              <h4><span class="kind">method</span> <span class="name">GetModuleRectanglesMaxCount</span></h4>
+              <pre class="sig"><code>public int GetModuleRectanglesMaxCount();</code></pre>
               <p class="doc">Gets an upper bound on the number of rectangles GetModuleRectangles can return, suitable for sizing a pooled buffer for TryGetModuleRectangles . O(1), no matrix scan.</p>
             </div>
-            <div class="member" data-text="public int getrawdata(ibufferwriter&lt;byte&gt; writer); writes the serialized data to the specified buffer writer without intermediate allocation. ">
-              <code>public int GetRawData(IBufferWriter&lt;byte&gt; writer);</code>
+            <div class="member" data-text="method public int getrawdata(ibufferwriter&lt;byte&gt; writer); writes the serialized data to the specified buffer writer without intermediate allocation. ">
+              <h4><span class="kind">method</span> <span class="name">GetRawData</span></h4>
+              <pre class="sig"><code>public int GetRawData(IBufferWriter&lt;byte&gt; writer);</code></pre>
               <p class="doc">Writes the serialized data to the specified buffer writer without intermediate allocation.</p>
             </div>
-            <div class="member" data-text="public int getrawdatasize(); gets the serialized size in bytes (&quot;qrx&quot; header + packed core bits). ">
-              <code>public int GetRawDataSize();</code>
+            <div class="member" data-text="method public int getrawdatasize(); gets the serialized size in bytes (&quot;qrx&quot; header + packed core bits). ">
+              <h4><span class="kind">method</span> <span class="name">GetRawDataSize</span></h4>
+              <pre class="sig"><code>public int GetRawDataSize();</code></pre>
               <p class="doc">Gets the serialized size in bytes (&quot;QRX&quot; header + packed core bits).</p>
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.MicroQRCodeDecodeInfo" data-name="skiasharp.qrcode.microqrcodedecodeinfo" data-text="skiasharp.qrcode.microqrcodedecodeinfo public readonly struct microqrcodedecodeinfo diagnostic information produced by a micro qr code decode attempt. statuses are shared with the standard qr decoder ( qrcodedecodestatus ); version, ecc level and mask pattern use the micro qr domains. public microqrecclevel ecclevel { get; } error correction level read from the format information.  public microqrversion version { get; } micro qr version (m1-m4), or default (0) when the matrix was invalid.  public qrcodedecodestatus status { get; } decode result status. success when decoding succeeded.  public int errorscorrected { get; } number of codeword errors corrected by reed-solomon decoding.  public int maskpattern { get; } mask pattern (0-3) read from the format information, or -1 when unknown. ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.MicroQRCodeDecodeInfo" aria-label="Link to SkiaSharp.QrCode.MicroQRCodeDecodeInfo">#</a><code>public readonly struct MicroQRCodeDecodeInfo</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.MicroQRCodeDecodeInfo" data-name="skiasharp.qrcode.microqrcodedecodeinfo" data-text="skiasharp.qrcode.microqrcodedecodeinfo public readonly struct microqrcodedecodeinfo diagnostic information produced by a micro qr code decode attempt. statuses are shared with the standard qr decoder ( qrcodedecodestatus ); version, ecc level and mask pattern use the micro qr domains. property public microqrecclevel ecclevel { get; } error correction level read from the format information.  property public microqrversion version { get; } micro qr version (m1-m4), or default (0) when the matrix was invalid.  property public qrcodedecodestatus status { get; } decode result status. success when decoding succeeded.  property public int errorscorrected { get; } number of codeword errors corrected by reed-solomon decoding.  property public int maskpattern { get; } mask pattern (0-3) read from the format information, or -1 when unknown. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.MicroQRCodeDecodeInfo" aria-label="Link to SkiaSharp.QrCode.MicroQRCodeDecodeInfo">#</a><span class="kind">struct</span> <span class="name">MicroQRCodeDecodeInfo</span></h3>
+          <pre class="sig"><code>public readonly struct MicroQRCodeDecodeInfo</code></pre>
           <p class="doc">Diagnostic information produced by a Micro QR code decode attempt.</p>
           <details class="notes" data-text="statuses are shared with the standard qr decoder ( qrcodedecodestatus ); version, ecc level and mask pattern use the micro qr domains.">
             <summary>Notes</summary>
             <p class="doc remarks">Statuses are shared with the Standard QR decoder ( QRCodeDecodeStatus ); version, ECC level and mask pattern use the Micro QR domains.</p>
           </details>
           <div class="members">
-            <div class="member" data-text="public microqrecclevel ecclevel { get; } error correction level read from the format information. ">
-              <code>public MicroQREccLevel EccLevel { get; }</code>
+            <div class="member" data-text="property public microqrecclevel ecclevel { get; } error correction level read from the format information. ">
+              <h4><span class="kind">property</span> <span class="name">EccLevel</span></h4>
+              <pre class="sig"><code>public MicroQREccLevel EccLevel { get; }</code></pre>
               <p class="doc">Error correction level read from the format information.</p>
             </div>
-            <div class="member" data-text="public microqrversion version { get; } micro qr version (m1-m4), or default (0) when the matrix was invalid. ">
-              <code>public MicroQRVersion Version { get; }</code>
+            <div class="member" data-text="property public microqrversion version { get; } micro qr version (m1-m4), or default (0) when the matrix was invalid. ">
+              <h4><span class="kind">property</span> <span class="name">Version</span></h4>
+              <pre class="sig"><code>public MicroQRVersion Version { get; }</code></pre>
               <p class="doc">Micro QR version (M1-M4), or default (0) when the matrix was invalid.</p>
             </div>
-            <div class="member" data-text="public qrcodedecodestatus status { get; } decode result status. success when decoding succeeded. ">
-              <code>public QRCodeDecodeStatus Status { get; }</code>
+            <div class="member" data-text="property public qrcodedecodestatus status { get; } decode result status. success when decoding succeeded. ">
+              <h4><span class="kind">property</span> <span class="name">Status</span></h4>
+              <pre class="sig"><code>public QRCodeDecodeStatus Status { get; }</code></pre>
               <p class="doc">Decode result status. Success when decoding succeeded.</p>
             </div>
-            <div class="member" data-text="public int errorscorrected { get; } number of codeword errors corrected by reed-solomon decoding. ">
-              <code>public int ErrorsCorrected { get; }</code>
+            <div class="member" data-text="property public int errorscorrected { get; } number of codeword errors corrected by reed-solomon decoding. ">
+              <h4><span class="kind">property</span> <span class="name">ErrorsCorrected</span></h4>
+              <pre class="sig"><code>public int ErrorsCorrected { get; }</code></pre>
               <p class="doc">Number of codeword errors corrected by Reed-Solomon decoding.</p>
             </div>
-            <div class="member" data-text="public int maskpattern { get; } mask pattern (0-3) read from the format information, or -1 when unknown. ">
-              <code>public int MaskPattern { get; }</code>
+            <div class="member" data-text="property public int maskpattern { get; } mask pattern (0-3) read from the format information, or -1 when unknown. ">
+              <h4><span class="kind">property</span> <span class="name">MaskPattern</span></h4>
+              <pre class="sig"><code>public int MaskPattern { get; }</code></pre>
               <p class="doc">Mask pattern (0-3) read from the format information, or -1 when unknown.</p>
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.MicroQRCodeDecoder" data-name="skiasharp.qrcode.microqrcodedecoder" data-text="skiasharp.qrcode.microqrcodedecoder public static class microqrcodedecoder micro qr code decoder based on iso/iec 18004. decodes micro qr module matrices back into text, including reed-solomon error correction. supported content: numeric, alphanumeric and byte mode segments (iso-8859-1 and utf-8), all versions m1-m4 and all legal ecc levels, plus kanji mode segments in m3 and m4 (decoded as jis x 0208; this library never emits them). a kanji cell outside the jis x 0208 repertoire fails the whole symbol with unmappedcharacter rather than substituting a replacement character. micro qr has no eci mode; byte segments use utf-8 when the payload validates as utf-8 and iso-8859-1 otherwise (matching this library's encoder). inputs are module matrices ( microqrcodedata or byte-per-module buffers as produced by microqrcodegenerator ; a uniform light quiet zone border is detected and skipped automatically) or images via the trydecode / trydecodeimage overloads. image detection targets clean, screen-rendered or scanned images: arbitrary rotation, mirroring, reflectance reversal, uniform or non-uniform scaling, translation and mild perspective distortion are supported. micro qr image scanning is a separate, explicitly-typed entry point — qrcodedecoder continues to scan standard qr only. public static bool trydecode(microqrcodedata data, out string text); decodes the text content from micro qr code data.  public static bool trydecode(microqrcodedata data, out string text, out microqrcodedecodeinfo info); decodes the text content from micro qr code data, with diagnostic information.  public static bool trydecode(readonlyspan&lt;byte&gt; modules, int size, span&lt;char&gt; destination, out int charswritten, out microqrcodedecodeinfo info); decodes the text content from a module matrix into a caller-provided buffer without per-call heap allocation.  public static bool trydecode(readonlyspan&lt;byte&gt; modules, int size, out string text, out microqrcodedecodeinfo info); decodes the text content from a module matrix.  public static bool trydecode(skbitmap bitmap, out string text); detects and decodes a micro qr code from a bitmap image. targets clean, well-lit images such as screenshots, rendered symbols and scans: arbitrary rotation, mirroring, reflectance reversal (light-on-dark), uniform or non-uniform scaling, translation and mild perspective distortion are handled. strong perspective, uneven lighting and blur are out of scope. public static bool trydecode(skbitmap bitmap, out string text, out microqrcodedecodeinfo info); detects and decodes a micro qr code from a bitmap image, with diagnostic information. see trydecode for the supported image envelope. public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, span&lt;char&gt; destination, out int charswritten, out microqrcodedecodeinfo info); detects and decodes a micro qr code from grayscale image pixels into a caller-provided buffer without per-call heap allocation.  public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, out string text, out microqrcodedecodeinfo info); detects and decodes a micro qr code from grayscale image pixels.  public static int getmaxdecodedlength(microqrversion version); calculates the maximum possible decoded character count for a micro qr version, across all ecc levels and encoding modes. use to size the destination buffer for the allocation-free trydecode overload. ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.MicroQRCodeDecoder" aria-label="Link to SkiaSharp.QrCode.MicroQRCodeDecoder">#</a><code>public static class MicroQRCodeDecoder</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.MicroQRCodeDecoder" data-name="skiasharp.qrcode.microqrcodedecoder" data-text="skiasharp.qrcode.microqrcodedecoder public static class microqrcodedecoder micro qr code decoder based on iso/iec 18004. decodes micro qr module matrices back into text, including reed-solomon error correction. supported content: numeric, alphanumeric and byte mode segments (iso-8859-1 and utf-8), all versions m1-m4 and all legal ecc levels, plus kanji mode segments in m3 and m4 (decoded as jis x 0208; this library never emits them). a kanji cell outside the jis x 0208 repertoire fails the whole symbol with unmappedcharacter rather than substituting a replacement character. micro qr has no eci mode; byte segments use utf-8 when the payload validates as utf-8 and iso-8859-1 otherwise (matching this library's encoder). inputs are module matrices ( microqrcodedata or byte-per-module buffers as produced by microqrcodegenerator ; a uniform light quiet zone border is detected and skipped automatically) or images via the trydecode / trydecodeimage overloads. image detection targets clean, screen-rendered or scanned images: arbitrary rotation, mirroring, reflectance reversal, uniform or non-uniform scaling, translation and mild perspective distortion are supported. micro qr image scanning is a separate, explicitly-typed entry point — qrcodedecoder continues to scan standard qr only. method public static bool trydecode(microqrcodedata data, out string text); decodes the text content from micro qr code data.  method public static bool trydecode(microqrcodedata data, out string text, out microqrcodedecodeinfo info); decodes the text content from micro qr code data, with diagnostic information.  method public static bool trydecode(readonlyspan&lt;byte&gt; modules, int size, span&lt;char&gt; destination, out int charswritten, out microqrcodedecodeinfo info); decodes the text content from a module matrix into a caller-provided buffer without per-call heap allocation.  method public static bool trydecode(readonlyspan&lt;byte&gt; modules, int size, out string text, out microqrcodedecodeinfo info); decodes the text content from a module matrix.  method public static bool trydecode(skbitmap bitmap, out string text); detects and decodes a micro qr code from a bitmap image. targets clean, well-lit images such as screenshots, rendered symbols and scans: arbitrary rotation, mirroring, reflectance reversal (light-on-dark), uniform or non-uniform scaling, translation and mild perspective distortion are handled. strong perspective, uneven lighting and blur are out of scope. method public static bool trydecode(skbitmap bitmap, out string text, out microqrcodedecodeinfo info); detects and decodes a micro qr code from a bitmap image, with diagnostic information. see trydecode for the supported image envelope. method public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, span&lt;char&gt; destination, out int charswritten, out microqrcodedecodeinfo info); detects and decodes a micro qr code from grayscale image pixels into a caller-provided buffer without per-call heap allocation.  method public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, out string text, out microqrcodedecodeinfo info); detects and decodes a micro qr code from grayscale image pixels.  method public static int getmaxdecodedlength(microqrversion version); calculates the maximum possible decoded character count for a micro qr version, across all ecc levels and encoding modes. use to size the destination buffer for the allocation-free trydecode overload. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.MicroQRCodeDecoder" aria-label="Link to SkiaSharp.QrCode.MicroQRCodeDecoder">#</a><span class="kind">class</span> <span class="name">MicroQRCodeDecoder</span></h3>
+          <pre class="sig"><code>public static class MicroQRCodeDecoder</code></pre>
           <p class="doc">Micro QR code decoder based on ISO/IEC 18004. Decodes Micro QR module matrices back into text, including Reed-Solomon error correction.</p>
           <details class="notes" data-text="supported content: numeric, alphanumeric and byte mode segments (iso-8859-1 and utf-8), all versions m1-m4 and all legal ecc levels, plus kanji mode segments in m3 and m4 (decoded as jis x 0208; this library never emits them). a kanji cell outside the jis x 0208 repertoire fails the whole symbol with unmappedcharacter rather than substituting a replacement character. micro qr has no eci mode; byte segments use utf-8 when the payload validates as utf-8 and iso-8859-1 otherwise (matching this library's encoder). inputs are module matrices ( microqrcodedata or byte-per-module buffers as produced by microqrcodegenerator ; a uniform light quiet zone border is detected and skipped automatically) or images via the trydecode / trydecodeimage overloads. image detection targets clean, screen-rendered or scanned images: arbitrary rotation, mirroring, reflectance reversal, uniform or non-uniform scaling, translation and mild perspective distortion are supported. micro qr image scanning is a separate, explicitly-typed entry point — qrcodedecoder continues to scan standard qr only.">
             <summary>Notes</summary>
             <p class="doc remarks">Supported content: Numeric, Alphanumeric and Byte mode segments (ISO-8859-1 and UTF-8), all versions M1-M4 and all legal ECC levels, plus Kanji mode segments in M3 and M4 (decoded as JIS X 0208; this library never emits them). A Kanji cell outside the JIS X 0208 repertoire fails the whole symbol with UnmappedCharacter rather than substituting a replacement character. Micro QR has no ECI mode; byte segments use UTF-8 when the payload validates as UTF-8 and ISO-8859-1 otherwise (matching this library's encoder). Inputs are module matrices ( MicroQRCodeData or byte-per-module buffers as produced by MicroQRCodeGenerator ; a uniform light quiet zone border is detected and skipped automatically) or images via the TryDecode / TryDecodeImage overloads. Image detection targets clean, screen-rendered or scanned images: arbitrary rotation, mirroring, reflectance reversal, uniform or non-uniform scaling, translation and mild perspective distortion are supported. Micro QR image scanning is a separate, explicitly-typed entry point — QRCodeDecoder continues to scan Standard QR only.</p>
           </details>
           <div class="members">
-            <div class="member" data-text="public static bool trydecode(microqrcodedata data, out string text); decodes the text content from micro qr code data. ">
-              <code>public static bool TryDecode(MicroQRCodeData data, out string text);</code>
+            <div class="member" data-text="method public static bool trydecode(microqrcodedata data, out string text); decodes the text content from micro qr code data. ">
+              <h4><span class="kind">method</span> <span class="name">TryDecode</span></h4>
+              <pre class="sig"><code>public static bool TryDecode(MicroQRCodeData data, out string text);</code></pre>
               <p class="doc">Decodes the text content from Micro QR code data.</p>
             </div>
-            <div class="member" data-text="public static bool trydecode(microqrcodedata data, out string text, out microqrcodedecodeinfo info); decodes the text content from micro qr code data, with diagnostic information. ">
-              <code>public static bool TryDecode(MicroQRCodeData data, out string text, out MicroQRCodeDecodeInfo info);</code>
+            <div class="member" data-text="method public static bool trydecode(microqrcodedata data, out string text, out microqrcodedecodeinfo info); decodes the text content from micro qr code data, with diagnostic information. ">
+              <h4><span class="kind">method</span> <span class="name">TryDecode</span></h4>
+              <pre class="sig"><code>public static bool TryDecode(MicroQRCodeData data, out string text, out MicroQRCodeDecodeInfo info);</code></pre>
               <p class="doc">Decodes the text content from Micro QR code data, with diagnostic information.</p>
             </div>
-            <div class="member" data-text="public static bool trydecode(readonlyspan&lt;byte&gt; modules, int size, span&lt;char&gt; destination, out int charswritten, out microqrcodedecodeinfo info); decodes the text content from a module matrix into a caller-provided buffer without per-call heap allocation. ">
-              <code>public static bool TryDecode(ReadOnlySpan&lt;byte&gt; modules, int size, Span&lt;char&gt; destination, out int charsWritten, out MicroQRCodeDecodeInfo info);</code>
+            <div class="member" data-text="method public static bool trydecode(readonlyspan&lt;byte&gt; modules, int size, span&lt;char&gt; destination, out int charswritten, out microqrcodedecodeinfo info); decodes the text content from a module matrix into a caller-provided buffer without per-call heap allocation. ">
+              <h4><span class="kind">method</span> <span class="name">TryDecode</span></h4>
+              <pre class="sig"><code>public static bool TryDecode(ReadOnlySpan&lt;byte&gt; modules, int size, Span&lt;char&gt; destination, out int charsWritten, out MicroQRCodeDecodeInfo info);</code></pre>
               <p class="doc">Decodes the text content from a module matrix into a caller-provided buffer without per-call heap allocation.</p>
             </div>
-            <div class="member" data-text="public static bool trydecode(readonlyspan&lt;byte&gt; modules, int size, out string text, out microqrcodedecodeinfo info); decodes the text content from a module matrix. ">
-              <code>public static bool TryDecode(ReadOnlySpan&lt;byte&gt; modules, int size, out string text, out MicroQRCodeDecodeInfo info);</code>
+            <div class="member" data-text="method public static bool trydecode(readonlyspan&lt;byte&gt; modules, int size, out string text, out microqrcodedecodeinfo info); decodes the text content from a module matrix. ">
+              <h4><span class="kind">method</span> <span class="name">TryDecode</span></h4>
+              <pre class="sig"><code>public static bool TryDecode(ReadOnlySpan&lt;byte&gt; modules, int size, out string text, out MicroQRCodeDecodeInfo info);</code></pre>
               <p class="doc">Decodes the text content from a module matrix.</p>
             </div>
-            <div class="member" data-text="public static bool trydecode(skbitmap bitmap, out string text); detects and decodes a micro qr code from a bitmap image. targets clean, well-lit images such as screenshots, rendered symbols and scans: arbitrary rotation, mirroring, reflectance reversal (light-on-dark), uniform or non-uniform scaling, translation and mild perspective distortion are handled. strong perspective, uneven lighting and blur are out of scope.">
-              <code>public static bool TryDecode(SKBitmap bitmap, out string text);</code>
+            <div class="member" data-text="method public static bool trydecode(skbitmap bitmap, out string text); detects and decodes a micro qr code from a bitmap image. targets clean, well-lit images such as screenshots, rendered symbols and scans: arbitrary rotation, mirroring, reflectance reversal (light-on-dark), uniform or non-uniform scaling, translation and mild perspective distortion are handled. strong perspective, uneven lighting and blur are out of scope.">
+              <h4><span class="kind">method</span> <span class="name">TryDecode</span></h4>
+              <pre class="sig"><code>public static bool TryDecode(SKBitmap bitmap, out string text);</code></pre>
               <p class="doc">Detects and decodes a Micro QR code from a bitmap image.</p>
               <details class="notes" data-text="targets clean, well-lit images such as screenshots, rendered symbols and scans: arbitrary rotation, mirroring, reflectance reversal (light-on-dark), uniform or non-uniform scaling, translation and mild perspective distortion are handled. strong perspective, uneven lighting and blur are out of scope.">
                 <summary>Notes</summary>
                 <p class="doc remarks">Targets clean, well-lit images such as screenshots, rendered symbols and scans: arbitrary rotation, mirroring, reflectance reversal (light-on-dark), uniform or non-uniform scaling, translation and mild perspective distortion are handled. Strong perspective, uneven lighting and blur are out of scope.</p>
               </details>
             </div>
-            <div class="member" data-text="public static bool trydecode(skbitmap bitmap, out string text, out microqrcodedecodeinfo info); detects and decodes a micro qr code from a bitmap image, with diagnostic information. see trydecode for the supported image envelope.">
-              <code>public static bool TryDecode(SKBitmap bitmap, out string text, out MicroQRCodeDecodeInfo info);</code>
+            <div class="member" data-text="method public static bool trydecode(skbitmap bitmap, out string text, out microqrcodedecodeinfo info); detects and decodes a micro qr code from a bitmap image, with diagnostic information. see trydecode for the supported image envelope.">
+              <h4><span class="kind">method</span> <span class="name">TryDecode</span></h4>
+              <pre class="sig"><code>public static bool TryDecode(SKBitmap bitmap, out string text, out MicroQRCodeDecodeInfo info);</code></pre>
               <p class="doc">Detects and decodes a Micro QR code from a bitmap image, with diagnostic information.</p>
               <details class="notes" data-text="see trydecode for the supported image envelope.">
                 <summary>Notes</summary>
                 <p class="doc remarks">See TryDecode for the supported image envelope.</p>
               </details>
             </div>
-            <div class="member" data-text="public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, span&lt;char&gt; destination, out int charswritten, out microqrcodedecodeinfo info); detects and decodes a micro qr code from grayscale image pixels into a caller-provided buffer without per-call heap allocation. ">
-              <code>public static bool TryDecodeImage(ReadOnlySpan&lt;byte&gt; luminance, int width, int height, Span&lt;char&gt; destination, out int charsWritten, out MicroQRCodeDecodeInfo info);</code>
+            <div class="member" data-text="method public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, span&lt;char&gt; destination, out int charswritten, out microqrcodedecodeinfo info); detects and decodes a micro qr code from grayscale image pixels into a caller-provided buffer without per-call heap allocation. ">
+              <h4><span class="kind">method</span> <span class="name">TryDecodeImage</span></h4>
+              <pre class="sig"><code>public static bool TryDecodeImage(ReadOnlySpan&lt;byte&gt; luminance, int width, int height, Span&lt;char&gt; destination, out int charsWritten, out MicroQRCodeDecodeInfo info);</code></pre>
               <p class="doc">Detects and decodes a Micro QR code from grayscale image pixels into a caller-provided buffer without per-call heap allocation.</p>
             </div>
-            <div class="member" data-text="public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, out string text, out microqrcodedecodeinfo info); detects and decodes a micro qr code from grayscale image pixels. ">
-              <code>public static bool TryDecodeImage(ReadOnlySpan&lt;byte&gt; luminance, int width, int height, out string text, out MicroQRCodeDecodeInfo info);</code>
+            <div class="member" data-text="method public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, out string text, out microqrcodedecodeinfo info); detects and decodes a micro qr code from grayscale image pixels. ">
+              <h4><span class="kind">method</span> <span class="name">TryDecodeImage</span></h4>
+              <pre class="sig"><code>public static bool TryDecodeImage(ReadOnlySpan&lt;byte&gt; luminance, int width, int height, out string text, out MicroQRCodeDecodeInfo info);</code></pre>
               <p class="doc">Detects and decodes a Micro QR code from grayscale image pixels.</p>
             </div>
-            <div class="member" data-text="public static int getmaxdecodedlength(microqrversion version); calculates the maximum possible decoded character count for a micro qr version, across all ecc levels and encoding modes. use to size the destination buffer for the allocation-free trydecode overload. ">
-              <code>public static int GetMaxDecodedLength(MicroQRVersion version);</code>
+            <div class="member" data-text="method public static int getmaxdecodedlength(microqrversion version); calculates the maximum possible decoded character count for a micro qr version, across all ecc levels and encoding modes. use to size the destination buffer for the allocation-free trydecode overload. ">
+              <h4><span class="kind">method</span> <span class="name">GetMaxDecodedLength</span></h4>
+              <pre class="sig"><code>public static int GetMaxDecodedLength(MicroQRVersion version);</code></pre>
               <p class="doc">Calculates the maximum possible decoded character count for a Micro QR version, across all ECC levels and encoding modes. Use to size the destination buffer for the allocation-free TryDecode overload.</p>
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.MicroQRCodeGenerator" data-name="skiasharp.qrcode.microqrcodegenerator" data-text="skiasharp.qrcode.microqrcodegenerator public static class microqrcodegenerator micro qr code generator based on iso/iec 18004 (versions m1-m4). micro qr constraints enforced by this generator (they differ per version, so invalid combinations throw instead of silently degrading): m1: numeric mode only, errordetectiononly only.m2: numeric/alphanumeric, ecc l or m.m3: numeric/alphanumeric/byte, ecc l or m.m4: numeric/alphanumeric/byte, ecc l, m or q. micro qr has no eci mode; text that is not iso-8859-1-representable is encoded as raw utf-8 bytes in byte mode. kanji mode is not written; microqrcodedecoder does read the kanji segments (m3 and m4) that other encoders produce, so the two directions are deliberately asymmetric. [obsolete] public static microqrcodecalculatedsize getrequiredbuffersize(readonlyspan&lt;char&gt; text, microqrecclevel ecclevel, microqrversion? requestedversion = null, int quietzonesize = 2); calculates the required buffer size for encoding the specified text as a micro qr code.  public static microqrcodedata createmicroqrcode(readonlyspan&lt;char&gt; textspan, microqrecclevel ecclevel, microqrversion? requestedversion = null, int quietzonesize = 2);  public static microqrcodedata createmicroqrcode(readonlyspan&lt;char&gt; textspan, microqrecclevel ecclevel, in microqrcodegeneratoroptions options);  public static microqrcodedata createmicroqrcode(string plaintext, microqrecclevel ecclevel, microqrversion? requestedversion = null, int quietzonesize = 2); creates a micro qr code from the provided plain text.  public static microqrcodedata createmicroqrcode(string plaintext, microqrecclevel ecclevel, in microqrcodegeneratoroptions options);  public static bool trygetrequiredbuffersize(readonlyspan&lt;char&gt; text, microqrecclevel ecclevel, out microqrcodecalculatedsize size, in microqrcodegeneratoroptions options = null); calculates the required buffer size, matrix size and version for encoding the specified text as a micro qr code, reporting content that does not fit as false rather than as an exception. false means the content does not fit, which here includes an encoding mode the version or ecc level does not offer, since the text is what picks the mode. argument errors throw (rationale: specs/rmqr-encoder.md), and so does a version range that offers ecclevel on no version at all, which no content could satisfy. micro qr m1 holds 5 digits, so an overflow is an ordinary answer here. pass the same options you will encode with: segmentation can select a different version, so a buffer sized for one can be too small for the other. public static int createmicroqrcode(readonlyspan&lt;char&gt; textspan, microqrecclevel ecclevel, span&lt;byte&gt; destination, microqrversion? requestedversion = null, int quietzonesize = 2); creates a micro qr code and writes the module matrix into the caller-provided buffer without per-call heap allocation. output format matches createqrcode : one byte per module (0 = light, 1 = dark), flat row-major, quiet zone included. use trygetrequiredbuffersize to size the destination. public static int createmicroqrcode(readonlyspan&lt;char&gt; textspan, microqrecclevel ecclevel, span&lt;byte&gt; destination, in microqrcodegeneratoroptions options); ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.MicroQRCodeGenerator" aria-label="Link to SkiaSharp.QrCode.MicroQRCodeGenerator">#</a><code>public static class MicroQRCodeGenerator</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.MicroQRCodeGenerator" data-name="skiasharp.qrcode.microqrcodegenerator" data-text="skiasharp.qrcode.microqrcodegenerator public static class microqrcodegenerator micro qr code generator based on iso/iec 18004 (versions m1-m4). micro qr constraints enforced by this generator (they differ per version, so invalid combinations throw instead of silently degrading): m1: numeric mode only, errordetectiononly only.m2: numeric/alphanumeric, ecc l or m.m3: numeric/alphanumeric/byte, ecc l or m.m4: numeric/alphanumeric/byte, ecc l, m or q. micro qr has no eci mode; text that is not iso-8859-1-representable is encoded as raw utf-8 bytes in byte mode. kanji mode is not written; microqrcodedecoder does read the kanji segments (m3 and m4) that other encoders produce, so the two directions are deliberately asymmetric. method [obsolete] public static microqrcodecalculatedsize getrequiredbuffersize(readonlyspan&lt;char&gt; text, microqrecclevel ecclevel, microqrversion? requestedversion = null, int quietzonesize = 2); calculates the required buffer size for encoding the specified text as a micro qr code.  method public static microqrcodedata createmicroqrcode(readonlyspan&lt;char&gt; textspan, microqrecclevel ecclevel, microqrversion? requestedversion = null, int quietzonesize = 2);  method public static microqrcodedata createmicroqrcode(readonlyspan&lt;char&gt; textspan, microqrecclevel ecclevel, in microqrcodegeneratoroptions options);  method public static microqrcodedata createmicroqrcode(string plaintext, microqrecclevel ecclevel, microqrversion? requestedversion = null, int quietzonesize = 2); creates a micro qr code from the provided plain text.  method public static microqrcodedata createmicroqrcode(string plaintext, microqrecclevel ecclevel, in microqrcodegeneratoroptions options);  method public static bool trygetrequiredbuffersize(readonlyspan&lt;char&gt; text, microqrecclevel ecclevel, out microqrcodecalculatedsize size, in microqrcodegeneratoroptions options = null); calculates the required buffer size, matrix size and version for encoding the specified text as a micro qr code, reporting content that does not fit as false rather than as an exception. false means the content does not fit, which here includes an encoding mode the version or ecc level does not offer, since the text is what picks the mode. argument errors throw (rationale: specs/rmqr-encoder.md), and so does a version range that offers ecclevel on no version at all, which no content could satisfy. micro qr m1 holds 5 digits, so an overflow is an ordinary answer here. pass the same options you will encode with: segmentation can select a different version, so a buffer sized for one can be too small for the other. method public static int createmicroqrcode(readonlyspan&lt;char&gt; textspan, microqrecclevel ecclevel, span&lt;byte&gt; destination, microqrversion? requestedversion = null, int quietzonesize = 2); creates a micro qr code and writes the module matrix into the caller-provided buffer without per-call heap allocation. output format matches createqrcode : one byte per module (0 = light, 1 = dark), flat row-major, quiet zone included. use trygetrequiredbuffersize to size the destination. method public static int createmicroqrcode(readonlyspan&lt;char&gt; textspan, microqrecclevel ecclevel, span&lt;byte&gt; destination, in microqrcodegeneratoroptions options); ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.MicroQRCodeGenerator" aria-label="Link to SkiaSharp.QrCode.MicroQRCodeGenerator">#</a><span class="kind">class</span> <span class="name">MicroQRCodeGenerator</span></h3>
+          <pre class="sig"><code>public static class MicroQRCodeGenerator</code></pre>
           <p class="doc">Micro QR code generator based on ISO/IEC 18004 (versions M1-M4).</p>
           <details class="notes" data-text="micro qr constraints enforced by this generator (they differ per version, so invalid combinations throw instead of silently degrading): m1: numeric mode only, errordetectiononly only.m2: numeric/alphanumeric, ecc l or m.m3: numeric/alphanumeric/byte, ecc l or m.m4: numeric/alphanumeric/byte, ecc l, m or q. micro qr has no eci mode; text that is not iso-8859-1-representable is encoded as raw utf-8 bytes in byte mode. kanji mode is not written; microqrcodedecoder does read the kanji segments (m3 and m4) that other encoders produce, so the two directions are deliberately asymmetric.">
             <summary>Notes</summary>
             <p class="doc remarks">Micro QR constraints enforced by this generator (they differ per version, so invalid combinations throw instead of silently degrading): M1: Numeric mode only, ErrorDetectionOnly only.M2: Numeric/Alphanumeric, ECC L or M.M3: Numeric/Alphanumeric/Byte, ECC L or M.M4: Numeric/Alphanumeric/Byte, ECC L, M or Q. Micro QR has no ECI mode; text that is not ISO-8859-1-representable is encoded as raw UTF-8 bytes in Byte mode. Kanji mode is not written; MicroQRCodeDecoder does read the Kanji segments (M3 and M4) that other encoders produce, so the two directions are deliberately asymmetric.</p>
           </details>
           <div class="members">
-            <div class="member" data-text="public static microqrcodecalculatedsize getrequiredbuffersize(readonlyspan&lt;char&gt; text, microqrecclevel ecclevel, microqrversion? requestedversion = null, int quietzonesize = 2); calculates the required buffer size for encoding the specified text as a micro qr code. ">
-              <code>public static MicroQRCodeCalculatedSize GetRequiredBufferSize(ReadOnlySpan&lt;char&gt; text, MicroQREccLevel eccLevel, MicroQRVersion? requestedVersion = null, int quietZoneSize = 2);</code> <span class="tag">obsolete</span>
+            <div class="member" data-text="method public static microqrcodecalculatedsize getrequiredbuffersize(readonlyspan&lt;char&gt; text, microqrecclevel ecclevel, microqrversion? requestedversion = null, int quietzonesize = 2); calculates the required buffer size for encoding the specified text as a micro qr code. ">
+              <h4><span class="kind">method</span> <span class="name">GetRequiredBufferSize</span> <span class="tag">obsolete</span></h4>
+              <pre class="sig"><code>public static MicroQRCodeCalculatedSize GetRequiredBufferSize(ReadOnlySpan&lt;char&gt; text, MicroQREccLevel eccLevel, MicroQRVersion? requestedVersion = null, int quietZoneSize = 2);</code></pre>
               <p class="doc">Calculates the required buffer size for encoding the specified text as a Micro QR code.</p>
             </div>
-            <div class="member" data-text="public static microqrcodedata createmicroqrcode(readonlyspan&lt;char&gt; textspan, microqrecclevel ecclevel, microqrversion? requestedversion = null, int quietzonesize = 2); ">
-              <code>public static MicroQRCodeData CreateMicroQRCode(ReadOnlySpan&lt;char&gt; textSpan, MicroQREccLevel eccLevel, MicroQRVersion? requestedVersion = null, int quietZoneSize = 2);</code>
+            <div class="member" data-text="method public static microqrcodedata createmicroqrcode(readonlyspan&lt;char&gt; textspan, microqrecclevel ecclevel, microqrversion? requestedversion = null, int quietzonesize = 2); ">
+              <h4><span class="kind">method</span> <span class="name">CreateMicroQRCode</span></h4>
+              <pre class="sig"><code>public static MicroQRCodeData CreateMicroQRCode(ReadOnlySpan&lt;char&gt; textSpan, MicroQREccLevel eccLevel, MicroQRVersion? requestedVersion = null, int quietZoneSize = 2);</code></pre>
             </div>
-            <div class="member" data-text="public static microqrcodedata createmicroqrcode(readonlyspan&lt;char&gt; textspan, microqrecclevel ecclevel, in microqrcodegeneratoroptions options); ">
-              <code>public static MicroQRCodeData CreateMicroQRCode(ReadOnlySpan&lt;char&gt; textSpan, MicroQREccLevel eccLevel, in MicroQRCodeGeneratorOptions options);</code>
+            <div class="member" data-text="method public static microqrcodedata createmicroqrcode(readonlyspan&lt;char&gt; textspan, microqrecclevel ecclevel, in microqrcodegeneratoroptions options); ">
+              <h4><span class="kind">method</span> <span class="name">CreateMicroQRCode</span></h4>
+              <pre class="sig"><code>public static MicroQRCodeData CreateMicroQRCode(ReadOnlySpan&lt;char&gt; textSpan, MicroQREccLevel eccLevel, in MicroQRCodeGeneratorOptions options);</code></pre>
             </div>
-            <div class="member" data-text="public static microqrcodedata createmicroqrcode(string plaintext, microqrecclevel ecclevel, microqrversion? requestedversion = null, int quietzonesize = 2); creates a micro qr code from the provided plain text. ">
-              <code>public static MicroQRCodeData CreateMicroQRCode(string plainText, MicroQREccLevel eccLevel, MicroQRVersion? requestedVersion = null, int quietZoneSize = 2);</code>
+            <div class="member" data-text="method public static microqrcodedata createmicroqrcode(string plaintext, microqrecclevel ecclevel, microqrversion? requestedversion = null, int quietzonesize = 2); creates a micro qr code from the provided plain text. ">
+              <h4><span class="kind">method</span> <span class="name">CreateMicroQRCode</span></h4>
+              <pre class="sig"><code>public static MicroQRCodeData CreateMicroQRCode(string plainText, MicroQREccLevel eccLevel, MicroQRVersion? requestedVersion = null, int quietZoneSize = 2);</code></pre>
               <p class="doc">Creates a Micro QR code from the provided plain text.</p>
             </div>
-            <div class="member" data-text="public static microqrcodedata createmicroqrcode(string plaintext, microqrecclevel ecclevel, in microqrcodegeneratoroptions options); ">
-              <code>public static MicroQRCodeData CreateMicroQRCode(string plainText, MicroQREccLevel eccLevel, in MicroQRCodeGeneratorOptions options);</code>
+            <div class="member" data-text="method public static microqrcodedata createmicroqrcode(string plaintext, microqrecclevel ecclevel, in microqrcodegeneratoroptions options); ">
+              <h4><span class="kind">method</span> <span class="name">CreateMicroQRCode</span></h4>
+              <pre class="sig"><code>public static MicroQRCodeData CreateMicroQRCode(string plainText, MicroQREccLevel eccLevel, in MicroQRCodeGeneratorOptions options);</code></pre>
             </div>
-            <div class="member" data-text="public static bool trygetrequiredbuffersize(readonlyspan&lt;char&gt; text, microqrecclevel ecclevel, out microqrcodecalculatedsize size, in microqrcodegeneratoroptions options = null); calculates the required buffer size, matrix size and version for encoding the specified text as a micro qr code, reporting content that does not fit as false rather than as an exception. false means the content does not fit, which here includes an encoding mode the version or ecc level does not offer, since the text is what picks the mode. argument errors throw (rationale: specs/rmqr-encoder.md), and so does a version range that offers ecclevel on no version at all, which no content could satisfy. micro qr m1 holds 5 digits, so an overflow is an ordinary answer here. pass the same options you will encode with: segmentation can select a different version, so a buffer sized for one can be too small for the other.">
-              <code>public static bool TryGetRequiredBufferSize(ReadOnlySpan&lt;char&gt; text, MicroQREccLevel eccLevel, out MicroQRCodeCalculatedSize size, in MicroQRCodeGeneratorOptions options = null);</code>
+            <div class="member" data-text="method public static bool trygetrequiredbuffersize(readonlyspan&lt;char&gt; text, microqrecclevel ecclevel, out microqrcodecalculatedsize size, in microqrcodegeneratoroptions options = null); calculates the required buffer size, matrix size and version for encoding the specified text as a micro qr code, reporting content that does not fit as false rather than as an exception. false means the content does not fit, which here includes an encoding mode the version or ecc level does not offer, since the text is what picks the mode. argument errors throw (rationale: specs/rmqr-encoder.md), and so does a version range that offers ecclevel on no version at all, which no content could satisfy. micro qr m1 holds 5 digits, so an overflow is an ordinary answer here. pass the same options you will encode with: segmentation can select a different version, so a buffer sized for one can be too small for the other.">
+              <h4><span class="kind">method</span> <span class="name">TryGetRequiredBufferSize</span></h4>
+              <pre class="sig"><code>public static bool TryGetRequiredBufferSize(ReadOnlySpan&lt;char&gt; text, MicroQREccLevel eccLevel, out MicroQRCodeCalculatedSize size, in MicroQRCodeGeneratorOptions options = null);</code></pre>
               <p class="doc">Calculates the required buffer size, matrix size and version for encoding the specified text as a Micro QR code, reporting content that does not fit as false rather than as an exception.</p>
               <details class="notes" data-text="false means the content does not fit, which here includes an encoding mode the version or ecc level does not offer, since the text is what picks the mode. argument errors throw (rationale: specs/rmqr-encoder.md), and so does a version range that offers ecclevel on no version at all, which no content could satisfy. micro qr m1 holds 5 digits, so an overflow is an ordinary answer here. pass the same options you will encode with: segmentation can select a different version, so a buffer sized for one can be too small for the other.">
                 <summary>Notes</summary>
                 <p class="doc remarks">false means the content does not fit, which here includes an encoding mode the version or ECC level does not offer, since the text is what picks the mode. Argument errors throw (rationale: specs/rmqr-encoder.md), and so does a Version range that offers eccLevel on no version at all, which no content could satisfy. Micro QR M1 holds 5 digits, so an overflow is an ordinary answer here. Pass the same options you will encode with: Segmentation can select a different version, so a buffer sized for one can be too small for the other.</p>
               </details>
             </div>
-            <div class="member" data-text="public static int createmicroqrcode(readonlyspan&lt;char&gt; textspan, microqrecclevel ecclevel, span&lt;byte&gt; destination, microqrversion? requestedversion = null, int quietzonesize = 2); creates a micro qr code and writes the module matrix into the caller-provided buffer without per-call heap allocation. output format matches createqrcode : one byte per module (0 = light, 1 = dark), flat row-major, quiet zone included. use trygetrequiredbuffersize to size the destination.">
-              <code>public static int CreateMicroQRCode(ReadOnlySpan&lt;char&gt; textSpan, MicroQREccLevel eccLevel, Span&lt;byte&gt; destination, MicroQRVersion? requestedVersion = null, int quietZoneSize = 2);</code>
+            <div class="member" data-text="method public static int createmicroqrcode(readonlyspan&lt;char&gt; textspan, microqrecclevel ecclevel, span&lt;byte&gt; destination, microqrversion? requestedversion = null, int quietzonesize = 2); creates a micro qr code and writes the module matrix into the caller-provided buffer without per-call heap allocation. output format matches createqrcode : one byte per module (0 = light, 1 = dark), flat row-major, quiet zone included. use trygetrequiredbuffersize to size the destination.">
+              <h4><span class="kind">method</span> <span class="name">CreateMicroQRCode</span></h4>
+              <pre class="sig"><code>public static int CreateMicroQRCode(ReadOnlySpan&lt;char&gt; textSpan, MicroQREccLevel eccLevel, Span&lt;byte&gt; destination, MicroQRVersion? requestedVersion = null, int quietZoneSize = 2);</code></pre>
               <p class="doc">Creates a Micro QR code and writes the module matrix into the caller-provided buffer without per-call heap allocation.</p>
               <details class="notes" data-text="output format matches createqrcode : one byte per module (0 = light, 1 = dark), flat row-major, quiet zone included. use trygetrequiredbuffersize to size the destination.">
                 <summary>Notes</summary>
                 <p class="doc remarks">Output format matches CreateQrCode : one byte per module (0 = light, 1 = dark), flat row-major, quiet zone included. Use TryGetRequiredBufferSize to size the destination.</p>
               </details>
             </div>
-            <div class="member" data-text="public static int createmicroqrcode(readonlyspan&lt;char&gt; textspan, microqrecclevel ecclevel, span&lt;byte&gt; destination, in microqrcodegeneratoroptions options); ">
-              <code>public static int CreateMicroQRCode(ReadOnlySpan&lt;char&gt; textSpan, MicroQREccLevel eccLevel, Span&lt;byte&gt; destination, in MicroQRCodeGeneratorOptions options);</code>
+            <div class="member" data-text="method public static int createmicroqrcode(readonlyspan&lt;char&gt; textspan, microqrecclevel ecclevel, span&lt;byte&gt; destination, in microqrcodegeneratoroptions options); ">
+              <h4><span class="kind">method</span> <span class="name">CreateMicroQRCode</span></h4>
+              <pre class="sig"><code>public static int CreateMicroQRCode(ReadOnlySpan&lt;char&gt; textSpan, MicroQREccLevel eccLevel, Span&lt;byte&gt; destination, in MicroQRCodeGeneratorOptions options);</code></pre>
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.MicroQRCodeGeneratorOptions" data-name="skiasharp.qrcode.microqrcodegeneratoroptions" data-text="skiasharp.qrcode.microqrcodegeneratoroptions public readonly struct microqrcodegeneratoroptions : iequatable&lt;microqrcodegeneratoroptions&gt; optional settings for microqrcodegenerator . default is the complete default configuration (automatic version, 2-module quiet zone), so set only what you need: new microqrcodegeneratoroptions { version = microqrversion.m3, quietzonesize = 0 }. the smallest option set of the three symbologies: micro qr has no eci, and no fit strategy because m1-m4 are totally ordered by capacity. public microqrsegmentation segmentation { get; init; } how the content is split into encoding-mode segments (see microqrsegmentation ). defaults to single . optimal never selects a larger version, and emits the identical bit stream when a split would not shrink the symbol. size a destination buffer with the same value you encode with.  public microqrversionrange version { get; init; } the versions the generator may choose from. defaults to any ; a microqrversion or its nullable converts implicitly, so a null means automatic.  public int quietzonesize { get; init; } quiet zone width in modules. defaults to 2, the iso/iec 18004 value for micro qr; 0 is valid.  public int? maskpattern { get; init; } pin one of the four micro qr data mask patterns (0-3, iso/iec 18004 table 10) instead of the automatic edge-score selection. null (the default) selects the highest-scoring pattern. any pattern yields a valid, decodable symbol; the automatic choice merely optimizes scan reliability. for reproducing a symbol produced elsewhere byte-for-byte (the pattern another encoder chose is reported by maskpattern ), and for exercising a decoder against all four patterns. micro qr numbers its patterns 0-3; they are not the standard qr patterns of the same index. like version , an invalid value is an argument error and is rejected here rather than when a generator reads it. public static microqrcodegeneratoroptions default { get; } the default configuration, identical to default. ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.MicroQRCodeGeneratorOptions" aria-label="Link to SkiaSharp.QrCode.MicroQRCodeGeneratorOptions">#</a><code>public readonly struct MicroQRCodeGeneratorOptions : IEquatable&lt;MicroQRCodeGeneratorOptions&gt;</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.MicroQRCodeGeneratorOptions" data-name="skiasharp.qrcode.microqrcodegeneratoroptions" data-text="skiasharp.qrcode.microqrcodegeneratoroptions public readonly struct microqrcodegeneratoroptions : iequatable&lt;microqrcodegeneratoroptions&gt; optional settings for microqrcodegenerator . default is the complete default configuration (automatic version, 2-module quiet zone), so set only what you need: new microqrcodegeneratoroptions { version = microqrversion.m3, quietzonesize = 0 }. the smallest option set of the three symbologies: micro qr has no eci, and no fit strategy because m1-m4 are totally ordered by capacity. property public microqrsegmentation segmentation { get; init; } how the content is split into encoding-mode segments (see microqrsegmentation ). defaults to single . optimal never selects a larger version, and emits the identical bit stream when a split would not shrink the symbol. size a destination buffer with the same value you encode with.  property public microqrversionrange version { get; init; } the versions the generator may choose from. defaults to any ; a microqrversion or its nullable converts implicitly, so a null means automatic.  property public int quietzonesize { get; init; } quiet zone width in modules. defaults to 2, the iso/iec 18004 value for micro qr; 0 is valid.  property public int? maskpattern { get; init; } pin one of the four micro qr data mask patterns (0-3, iso/iec 18004 table 10) instead of the automatic edge-score selection. null (the default) selects the highest-scoring pattern. any pattern yields a valid, decodable symbol; the automatic choice merely optimizes scan reliability. for reproducing a symbol produced elsewhere byte-for-byte (the pattern another encoder chose is reported by maskpattern ), and for exercising a decoder against all four patterns. micro qr numbers its patterns 0-3; they are not the standard qr patterns of the same index. like version , an invalid value is an argument error and is rejected here rather than when a generator reads it. property public static microqrcodegeneratoroptions default { get; } the default configuration, identical to default. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.MicroQRCodeGeneratorOptions" aria-label="Link to SkiaSharp.QrCode.MicroQRCodeGeneratorOptions">#</a><span class="kind">struct</span> <span class="name">MicroQRCodeGeneratorOptions</span></h3>
+          <pre class="sig"><code>public readonly struct MicroQRCodeGeneratorOptions : IEquatable&lt;MicroQRCodeGeneratorOptions&gt;</code></pre>
           <p class="doc">Optional settings for MicroQRCodeGenerator . default is the complete default configuration (automatic version, 2-module quiet zone), so set only what you need: new MicroQRCodeGeneratorOptions { Version = MicroQRVersion.M3, QuietZoneSize = 0 }.</p>
           <details class="notes" data-text="the smallest option set of the three symbologies: micro qr has no eci, and no fit strategy because m1-m4 are totally ordered by capacity.">
             <summary>Notes</summary>
             <p class="doc remarks">The smallest option set of the three symbologies: Micro QR has no ECI, and no fit strategy because M1-M4 are totally ordered by capacity.</p>
           </details>
           <div class="members">
-            <div class="member" data-text="public microqrsegmentation segmentation { get; init; } how the content is split into encoding-mode segments (see microqrsegmentation ). defaults to single . optimal never selects a larger version, and emits the identical bit stream when a split would not shrink the symbol. size a destination buffer with the same value you encode with. ">
-              <code>public MicroQRSegmentation Segmentation { get; init; }</code>
+            <div class="member" data-text="property public microqrsegmentation segmentation { get; init; } how the content is split into encoding-mode segments (see microqrsegmentation ). defaults to single . optimal never selects a larger version, and emits the identical bit stream when a split would not shrink the symbol. size a destination buffer with the same value you encode with. ">
+              <h4><span class="kind">property</span> <span class="name">Segmentation</span></h4>
+              <pre class="sig"><code>public MicroQRSegmentation Segmentation { get; init; }</code></pre>
               <p class="doc">How the content is split into encoding-mode segments (see MicroQRSegmentation ). Defaults to Single . Optimal never selects a larger version, and emits the identical bit stream when a split would not shrink the symbol. Size a destination buffer with the same value you encode with.</p>
             </div>
-            <div class="member" data-text="public microqrversionrange version { get; init; } the versions the generator may choose from. defaults to any ; a microqrversion or its nullable converts implicitly, so a null means automatic. ">
-              <code>public MicroQRVersionRange Version { get; init; }</code>
+            <div class="member" data-text="property public microqrversionrange version { get; init; } the versions the generator may choose from. defaults to any ; a microqrversion or its nullable converts implicitly, so a null means automatic. ">
+              <h4><span class="kind">property</span> <span class="name">Version</span></h4>
+              <pre class="sig"><code>public MicroQRVersionRange Version { get; init; }</code></pre>
               <p class="doc">The versions the generator may choose from. Defaults to Any ; a MicroQRVersion or its nullable converts implicitly, so a null means automatic.</p>
             </div>
-            <div class="member" data-text="public int quietzonesize { get; init; } quiet zone width in modules. defaults to 2, the iso/iec 18004 value for micro qr; 0 is valid. ">
-              <code>public int QuietZoneSize { get; init; }</code>
+            <div class="member" data-text="property public int quietzonesize { get; init; } quiet zone width in modules. defaults to 2, the iso/iec 18004 value for micro qr; 0 is valid. ">
+              <h4><span class="kind">property</span> <span class="name">QuietZoneSize</span></h4>
+              <pre class="sig"><code>public int QuietZoneSize { get; init; }</code></pre>
               <p class="doc">Quiet zone width in modules. Defaults to 2, the ISO/IEC 18004 value for Micro QR; 0 is valid.</p>
             </div>
-            <div class="member" data-text="public int? maskpattern { get; init; } pin one of the four micro qr data mask patterns (0-3, iso/iec 18004 table 10) instead of the automatic edge-score selection. null (the default) selects the highest-scoring pattern. any pattern yields a valid, decodable symbol; the automatic choice merely optimizes scan reliability. for reproducing a symbol produced elsewhere byte-for-byte (the pattern another encoder chose is reported by maskpattern ), and for exercising a decoder against all four patterns. micro qr numbers its patterns 0-3; they are not the standard qr patterns of the same index. like version , an invalid value is an argument error and is rejected here rather than when a generator reads it.">
-              <code>public int? MaskPattern { get; init; }</code>
+            <div class="member" data-text="property public int? maskpattern { get; init; } pin one of the four micro qr data mask patterns (0-3, iso/iec 18004 table 10) instead of the automatic edge-score selection. null (the default) selects the highest-scoring pattern. any pattern yields a valid, decodable symbol; the automatic choice merely optimizes scan reliability. for reproducing a symbol produced elsewhere byte-for-byte (the pattern another encoder chose is reported by maskpattern ), and for exercising a decoder against all four patterns. micro qr numbers its patterns 0-3; they are not the standard qr patterns of the same index. like version , an invalid value is an argument error and is rejected here rather than when a generator reads it.">
+              <h4><span class="kind">property</span> <span class="name">MaskPattern</span></h4>
+              <pre class="sig"><code>public int? MaskPattern { get; init; }</code></pre>
               <p class="doc">Pin one of the four Micro QR data mask patterns (0-3, ISO/IEC 18004 Table 10) instead of the automatic edge-score selection. null (the default) selects the highest-scoring pattern. Any pattern yields a valid, decodable symbol; the automatic choice merely optimizes scan reliability.</p>
               <details class="notes" data-text="for reproducing a symbol produced elsewhere byte-for-byte (the pattern another encoder chose is reported by maskpattern ), and for exercising a decoder against all four patterns. micro qr numbers its patterns 0-3; they are not the standard qr patterns of the same index. like version , an invalid value is an argument error and is rejected here rather than when a generator reads it.">
                 <summary>Notes</summary>
                 <p class="doc remarks">For reproducing a symbol produced elsewhere byte-for-byte (the pattern another encoder chose is reported by MaskPattern ), and for exercising a decoder against all four patterns. Micro QR numbers its patterns 0-3; they are not the Standard QR patterns of the same index. Like Version , an invalid value is an argument error and is rejected here rather than when a generator reads it.</p>
               </details>
             </div>
-            <div class="member" data-text="public static microqrcodegeneratoroptions default { get; } the default configuration, identical to default. ">
-              <code>public static MicroQRCodeGeneratorOptions Default { get; }</code>
+            <div class="member" data-text="property public static microqrcodegeneratoroptions default { get; } the default configuration, identical to default. ">
+              <h4><span class="kind">property</span> <span class="name">Default</span></h4>
+              <pre class="sig"><code>public static MicroQRCodeGeneratorOptions Default { get; }</code></pre>
               <p class="doc">The default configuration, identical to default.</p>
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.MicroQREccLevel" data-name="skiasharp.qrcode.microqrecclevel" data-text="skiasharp.qrcode.microqrecclevel public enum microqrecclevel : int micro qr code error correction level (iso/iec 18004). micro qr levels differ from standard qr ecclevel : version m1 supports error detection only, and level h does not exist.  errordetectiononly = 0, error detection only, no correction capacity. valid only for version m1.  l = 1, ~7% recovery capacity. valid for versions m2-m4.  m = 2, ~15% recovery capacity. valid for versions m2-m4.  q = 3, ~25% recovery capacity. valid for version m4 only. ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.MicroQREccLevel" aria-label="Link to SkiaSharp.QrCode.MicroQREccLevel">#</a><code>public enum MicroQREccLevel : int</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.MicroQREccLevel" data-name="skiasharp.qrcode.microqrecclevel" data-text="skiasharp.qrcode.microqrecclevel public enum microqrecclevel : int micro qr code error correction level (iso/iec 18004). micro qr levels differ from standard qr ecclevel : version m1 supports error detection only, and level h does not exist.  value errordetectiononly = 0, error detection only, no correction capacity. valid only for version m1.  value l = 1, ~7% recovery capacity. valid for versions m2-m4.  value m = 2, ~15% recovery capacity. valid for versions m2-m4.  value q = 3, ~25% recovery capacity. valid for version m4 only. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.MicroQREccLevel" aria-label="Link to SkiaSharp.QrCode.MicroQREccLevel">#</a><span class="kind">enum</span> <span class="name">MicroQREccLevel</span></h3>
+          <pre class="sig"><code>public enum MicroQREccLevel : int</code></pre>
           <p class="doc">Micro QR Code error correction level (ISO/IEC 18004). Micro QR levels differ from Standard QR ECCLevel : version M1 supports error detection only, and level H does not exist.</p>
           <div class="members">
-            <div class="member" data-text="errordetectiononly = 0, error detection only, no correction capacity. valid only for version m1. ">
-              <code>ErrorDetectionOnly = 0,</code>
+            <div class="member" data-text="value errordetectiononly = 0, error detection only, no correction capacity. valid only for version m1. ">
+              <pre class="sig"><code>ErrorDetectionOnly = 0,</code></pre>
               <p class="doc">Error detection only, no correction capacity. Valid only for version M1.</p>
             </div>
-            <div class="member" data-text="l = 1, ~7% recovery capacity. valid for versions m2-m4. ">
-              <code>L = 1,</code>
+            <div class="member" data-text="value l = 1, ~7% recovery capacity. valid for versions m2-m4. ">
+              <pre class="sig"><code>L = 1,</code></pre>
               <p class="doc">~7% recovery capacity. Valid for versions M2-M4.</p>
             </div>
-            <div class="member" data-text="m = 2, ~15% recovery capacity. valid for versions m2-m4. ">
-              <code>M = 2,</code>
+            <div class="member" data-text="value m = 2, ~15% recovery capacity. valid for versions m2-m4. ">
+              <pre class="sig"><code>M = 2,</code></pre>
               <p class="doc">~15% recovery capacity. Valid for versions M2-M4.</p>
             </div>
-            <div class="member" data-text="q = 3, ~25% recovery capacity. valid for version m4 only. ">
-              <code>Q = 3,</code>
+            <div class="member" data-text="value q = 3, ~25% recovery capacity. valid for version m4 only. ">
+              <pre class="sig"><code>Q = 3,</code></pre>
               <p class="doc">~25% recovery capacity. Valid for version M4 only.</p>
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.MicroQRSegmentation" data-name="skiasharp.qrcode.microqrsegmentation" data-text="skiasharp.qrcode.microqrsegmentation public enum microqrsegmentation : int how microqrcodegenerator splits the content into encoding-mode segments. micro qr capacities are tiny (5 digits at m1, 15 byte-mode characters at m4-l), so mixing modes (for example a short prefix followed by a numeric tail) can drop the symbol a version, or encode content no single mode fits at all.  single = 0, one segment in the single mode that can represent the whole content (numeric, else alphanumeric, else byte). the default, and the cheapest to encode.  optimal = 1, the mixed-mode split with the fewest total bits. never selects a larger version than single , emits the single bit stream verbatim when a split would not shrink the symbol, and additionally encodes content that overflows every version in a single mode — unless the minimal-bit plan would be misread on decode (a relocated byte order mark, or a latin-1 run the charset heuristic would read as utf-8), in which case it reports &quot;does not fit&quot; rather than emitting a stream that decodes differently. opt-in because it prices candidate versions; the search allocates nothing (micro qr content never exceeds 35 characters). the plan respects each version's mode set — m1 is numeric-only and m2 has no byte mode — so a version is never selected for a plan whose runs it cannot carry. size buffers with the same segmentation you encode with, the two can select different versions.">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.MicroQRSegmentation" aria-label="Link to SkiaSharp.QrCode.MicroQRSegmentation">#</a><code>public enum MicroQRSegmentation : int</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.MicroQRSegmentation" data-name="skiasharp.qrcode.microqrsegmentation" data-text="skiasharp.qrcode.microqrsegmentation public enum microqrsegmentation : int how microqrcodegenerator splits the content into encoding-mode segments. micro qr capacities are tiny (5 digits at m1, 15 byte-mode characters at m4-l), so mixing modes (for example a short prefix followed by a numeric tail) can drop the symbol a version, or encode content no single mode fits at all.  value single = 0, one segment in the single mode that can represent the whole content (numeric, else alphanumeric, else byte). the default, and the cheapest to encode.  value optimal = 1, the mixed-mode split with the fewest total bits. never selects a larger version than single , emits the single bit stream verbatim when a split would not shrink the symbol, and additionally encodes content that overflows every version in a single mode — unless the minimal-bit plan would be misread on decode (a relocated byte order mark, or a latin-1 run the charset heuristic would read as utf-8), in which case it reports &quot;does not fit&quot; rather than emitting a stream that decodes differently. opt-in because it prices candidate versions; the search allocates nothing (micro qr content never exceeds 35 characters). the plan respects each version's mode set — m1 is numeric-only and m2 has no byte mode — so a version is never selected for a plan whose runs it cannot carry. size buffers with the same segmentation you encode with, the two can select different versions.">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.MicroQRSegmentation" aria-label="Link to SkiaSharp.QrCode.MicroQRSegmentation">#</a><span class="kind">enum</span> <span class="name">MicroQRSegmentation</span></h3>
+          <pre class="sig"><code>public enum MicroQRSegmentation : int</code></pre>
           <p class="doc">How MicroQRCodeGenerator splits the content into encoding-mode segments. Micro QR capacities are tiny (5 digits at M1, 15 Byte-mode characters at M4-L), so mixing modes (for example a short prefix followed by a numeric tail) can drop the symbol a version, or encode content no single mode fits at all.</p>
           <div class="members">
-            <div class="member" data-text="single = 0, one segment in the single mode that can represent the whole content (numeric, else alphanumeric, else byte). the default, and the cheapest to encode. ">
-              <code>Single = 0,</code>
+            <div class="member" data-text="value single = 0, one segment in the single mode that can represent the whole content (numeric, else alphanumeric, else byte). the default, and the cheapest to encode. ">
+              <pre class="sig"><code>Single = 0,</code></pre>
               <p class="doc">One segment in the single mode that can represent the whole content (Numeric, else Alphanumeric, else Byte). The default, and the cheapest to encode.</p>
             </div>
-            <div class="member" data-text="optimal = 1, the mixed-mode split with the fewest total bits. never selects a larger version than single , emits the single bit stream verbatim when a split would not shrink the symbol, and additionally encodes content that overflows every version in a single mode — unless the minimal-bit plan would be misread on decode (a relocated byte order mark, or a latin-1 run the charset heuristic would read as utf-8), in which case it reports &quot;does not fit&quot; rather than emitting a stream that decodes differently. opt-in because it prices candidate versions; the search allocates nothing (micro qr content never exceeds 35 characters). the plan respects each version's mode set — m1 is numeric-only and m2 has no byte mode — so a version is never selected for a plan whose runs it cannot carry. size buffers with the same segmentation you encode with, the two can select different versions.">
-              <code>Optimal = 1,</code>
+            <div class="member" data-text="value optimal = 1, the mixed-mode split with the fewest total bits. never selects a larger version than single , emits the single bit stream verbatim when a split would not shrink the symbol, and additionally encodes content that overflows every version in a single mode — unless the minimal-bit plan would be misread on decode (a relocated byte order mark, or a latin-1 run the charset heuristic would read as utf-8), in which case it reports &quot;does not fit&quot; rather than emitting a stream that decodes differently. opt-in because it prices candidate versions; the search allocates nothing (micro qr content never exceeds 35 characters). the plan respects each version's mode set — m1 is numeric-only and m2 has no byte mode — so a version is never selected for a plan whose runs it cannot carry. size buffers with the same segmentation you encode with, the two can select different versions.">
+              <pre class="sig"><code>Optimal = 1,</code></pre>
               <p class="doc">The mixed-mode split with the fewest total bits. Never selects a larger version than Single , emits the Single bit stream verbatim when a split would not shrink the symbol, and additionally encodes content that overflows every version in a single mode — unless the minimal-bit plan would be misread on decode (a relocated byte order mark, or a Latin-1 run the charset heuristic would read as UTF-8), in which case it reports &quot;does not fit&quot; rather than emitting a stream that decodes differently.</p>
               <details class="notes" data-text="opt-in because it prices candidate versions; the search allocates nothing (micro qr content never exceeds 35 characters). the plan respects each version's mode set — m1 is numeric-only and m2 has no byte mode — so a version is never selected for a plan whose runs it cannot carry. size buffers with the same segmentation you encode with, the two can select different versions.">
                 <summary>Notes</summary>
@@ -700,315 +762,367 @@
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.MicroQRVersion" data-name="skiasharp.qrcode.microqrversion" data-text="skiasharp.qrcode.microqrversion public enum microqrversion : int micro qr code symbol version (iso/iec 18004). determines symbol size: m1 = 11×11, m2 = 13×13, m3 = 15×15, m4 = 17×17 modules.  m1 = 1, 11×11 modules. numeric mode only, error detection only.  m2 = 2, 13×13 modules. numeric and alphanumeric modes, ecc l/m.  m3 = 3, 15×15 modules. numeric, alphanumeric and byte modes, ecc l/m.  m4 = 4, 17×17 modules. numeric, alphanumeric and byte modes, ecc l/m/q. ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.MicroQRVersion" aria-label="Link to SkiaSharp.QrCode.MicroQRVersion">#</a><code>public enum MicroQRVersion : int</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.MicroQRVersion" data-name="skiasharp.qrcode.microqrversion" data-text="skiasharp.qrcode.microqrversion public enum microqrversion : int micro qr code symbol version (iso/iec 18004). determines symbol size: m1 = 11×11, m2 = 13×13, m3 = 15×15, m4 = 17×17 modules.  value m1 = 1, 11×11 modules. numeric mode only, error detection only.  value m2 = 2, 13×13 modules. numeric and alphanumeric modes, ecc l/m.  value m3 = 3, 15×15 modules. numeric, alphanumeric and byte modes, ecc l/m.  value m4 = 4, 17×17 modules. numeric, alphanumeric and byte modes, ecc l/m/q. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.MicroQRVersion" aria-label="Link to SkiaSharp.QrCode.MicroQRVersion">#</a><span class="kind">enum</span> <span class="name">MicroQRVersion</span></h3>
+          <pre class="sig"><code>public enum MicroQRVersion : int</code></pre>
           <p class="doc">Micro QR Code symbol version (ISO/IEC 18004). Determines symbol size: M1 = 11×11, M2 = 13×13, M3 = 15×15, M4 = 17×17 modules.</p>
           <div class="members">
-            <div class="member" data-text="m1 = 1, 11×11 modules. numeric mode only, error detection only. ">
-              <code>M1 = 1,</code>
+            <div class="member" data-text="value m1 = 1, 11×11 modules. numeric mode only, error detection only. ">
+              <pre class="sig"><code>M1 = 1,</code></pre>
               <p class="doc">11×11 modules. Numeric mode only, error detection only.</p>
             </div>
-            <div class="member" data-text="m2 = 2, 13×13 modules. numeric and alphanumeric modes, ecc l/m. ">
-              <code>M2 = 2,</code>
+            <div class="member" data-text="value m2 = 2, 13×13 modules. numeric and alphanumeric modes, ecc l/m. ">
+              <pre class="sig"><code>M2 = 2,</code></pre>
               <p class="doc">13×13 modules. Numeric and Alphanumeric modes, ECC L/M.</p>
             </div>
-            <div class="member" data-text="m3 = 3, 15×15 modules. numeric, alphanumeric and byte modes, ecc l/m. ">
-              <code>M3 = 3,</code>
+            <div class="member" data-text="value m3 = 3, 15×15 modules. numeric, alphanumeric and byte modes, ecc l/m. ">
+              <pre class="sig"><code>M3 = 3,</code></pre>
               <p class="doc">15×15 modules. Numeric, Alphanumeric and Byte modes, ECC L/M.</p>
             </div>
-            <div class="member" data-text="m4 = 4, 17×17 modules. numeric, alphanumeric and byte modes, ecc l/m/q. ">
-              <code>M4 = 4,</code>
+            <div class="member" data-text="value m4 = 4, 17×17 modules. numeric, alphanumeric and byte modes, ecc l/m/q. ">
+              <pre class="sig"><code>M4 = 4,</code></pre>
               <p class="doc">17×17 modules. Numeric, Alphanumeric and Byte modes, ECC L/M/Q.</p>
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.MicroQRVersionRange" data-name="skiasharp.qrcode.microqrversionrange" data-text="skiasharp.qrcode.microqrversionrange public readonly struct microqrversionrange : iequatable&lt;microqrversionrange&gt; the micro qr versions a generator may choose from: the smallest one in the range that holds the content is used. the micro qr counterpart of qrcodeversionrange . m1-m4 differ in the modes and ecc levels they offer, not only in capacity, so a range can leave nothing usable for two reasons. no version offering the requested ecc level is a contradiction and throws; none carrying the mode the text needs is a poor fit and returns false, since the text is what picks the mode. public const microqrversion maxversion; the highest micro qr version, m4.  public const microqrversion minversion; the lowest micro qr version, m1.  public microqrversionrange(microqrversion min, microqrversion max); an inclusive range from min to max .  public microqrversion max { get; } the highest permitted version (m4 when unbounded above).  public microqrversion min { get; } the lowest permitted version (m1 when unbounded below).  public bool isany { get; } whether this range constrains nothing (the default).  public bool isexact { get; } whether this range pins a single version.  public static microqrversionrange any { get; } every version, m1 to m4. identical to default.  public bool contains(microqrversion version); whether version falls inside this range.  public override string tostring();  public static microqrversionrange atleast(microqrversion version); version or larger.  public static microqrversionrange atmost(microqrversion version); version or smaller.  public static microqrversionrange between(microqrversion min, microqrversion max); an inclusive range from min to max .  public static microqrversionrange exactly(microqrversion version); exactly version , with no automatic selection.  public static microqrversionrange op_implicit(microqrversion version); a single version, as exactly .  public static microqrversionrange op_implicit(microqrversion? version); a single version, or any when there is none, so an optional version needs no branch. ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.MicroQRVersionRange" aria-label="Link to SkiaSharp.QrCode.MicroQRVersionRange">#</a><code>public readonly struct MicroQRVersionRange : IEquatable&lt;MicroQRVersionRange&gt;</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.MicroQRVersionRange" data-name="skiasharp.qrcode.microqrversionrange" data-text="skiasharp.qrcode.microqrversionrange public readonly struct microqrversionrange : iequatable&lt;microqrversionrange&gt; the micro qr versions a generator may choose from: the smallest one in the range that holds the content is used. the micro qr counterpart of qrcodeversionrange . m1-m4 differ in the modes and ecc levels they offer, not only in capacity, so a range can leave nothing usable for two reasons. no version offering the requested ecc level is a contradiction and throws; none carrying the mode the text needs is a poor fit and returns false, since the text is what picks the mode. constant public const microqrversion maxversion; the highest micro qr version, m4.  constant public const microqrversion minversion; the lowest micro qr version, m1.  constructor public microqrversionrange(microqrversion min, microqrversion max); an inclusive range from min to max .  property public microqrversion max { get; } the highest permitted version (m4 when unbounded above).  property public microqrversion min { get; } the lowest permitted version (m1 when unbounded below).  property public bool isany { get; } whether this range constrains nothing (the default).  property public bool isexact { get; } whether this range pins a single version.  property public static microqrversionrange any { get; } every version, m1 to m4. identical to default.  method public bool contains(microqrversion version); whether version falls inside this range.  method public override string tostring();  method public static microqrversionrange atleast(microqrversion version); version or larger.  method public static microqrversionrange atmost(microqrversion version); version or smaller.  method public static microqrversionrange between(microqrversion min, microqrversion max); an inclusive range from min to max .  method public static microqrversionrange exactly(microqrversion version); exactly version , with no automatic selection.  operator public static microqrversionrange op_implicit(microqrversion version); a single version, as exactly .  operator public static microqrversionrange op_implicit(microqrversion? version); a single version, or any when there is none, so an optional version needs no branch. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.MicroQRVersionRange" aria-label="Link to SkiaSharp.QrCode.MicroQRVersionRange">#</a><span class="kind">struct</span> <span class="name">MicroQRVersionRange</span></h3>
+          <pre class="sig"><code>public readonly struct MicroQRVersionRange : IEquatable&lt;MicroQRVersionRange&gt;</code></pre>
           <p class="doc">The Micro QR versions a generator may choose from: the smallest one in the range that holds the content is used. The Micro QR counterpart of QRCodeVersionRange .</p>
           <details class="notes" data-text="m1-m4 differ in the modes and ecc levels they offer, not only in capacity, so a range can leave nothing usable for two reasons. no version offering the requested ecc level is a contradiction and throws; none carrying the mode the text needs is a poor fit and returns false, since the text is what picks the mode.">
             <summary>Notes</summary>
             <p class="doc remarks">M1-M4 differ in the modes and ECC levels they offer, not only in capacity, so a range can leave nothing usable for two reasons. No version offering the requested ECC level is a contradiction and throws; none carrying the mode the text needs is a poor fit and returns false, since the text is what picks the mode.</p>
           </details>
           <div class="members">
-            <div class="member" data-text="public const microqrversion maxversion; the highest micro qr version, m4. ">
-              <code>public const MicroQRVersion MaxVersion;</code>
+            <div class="member" data-text="constant public const microqrversion maxversion; the highest micro qr version, m4. ">
+              <h4><span class="kind">constant</span> <span class="name">MaxVersion</span></h4>
+              <pre class="sig"><code>public const MicroQRVersion MaxVersion;</code></pre>
               <p class="doc">The highest Micro QR version, M4.</p>
             </div>
-            <div class="member" data-text="public const microqrversion minversion; the lowest micro qr version, m1. ">
-              <code>public const MicroQRVersion MinVersion;</code>
+            <div class="member" data-text="constant public const microqrversion minversion; the lowest micro qr version, m1. ">
+              <h4><span class="kind">constant</span> <span class="name">MinVersion</span></h4>
+              <pre class="sig"><code>public const MicroQRVersion MinVersion;</code></pre>
               <p class="doc">The lowest Micro QR version, M1.</p>
             </div>
-            <div class="member" data-text="public microqrversionrange(microqrversion min, microqrversion max); an inclusive range from min to max . ">
-              <code>public MicroQRVersionRange(MicroQRVersion min, MicroQRVersion max);</code>
+            <div class="member" data-text="constructor public microqrversionrange(microqrversion min, microqrversion max); an inclusive range from min to max . ">
+              <h4><span class="kind">constructor</span> <span class="name">MicroQRVersionRange</span></h4>
+              <pre class="sig"><code>public MicroQRVersionRange(MicroQRVersion min, MicroQRVersion max);</code></pre>
               <p class="doc">An inclusive range from min to max .</p>
             </div>
-            <div class="member" data-text="public microqrversion max { get; } the highest permitted version (m4 when unbounded above). ">
-              <code>public MicroQRVersion Max { get; }</code>
+            <div class="member" data-text="property public microqrversion max { get; } the highest permitted version (m4 when unbounded above). ">
+              <h4><span class="kind">property</span> <span class="name">Max</span></h4>
+              <pre class="sig"><code>public MicroQRVersion Max { get; }</code></pre>
               <p class="doc">The highest permitted version (M4 when unbounded above).</p>
             </div>
-            <div class="member" data-text="public microqrversion min { get; } the lowest permitted version (m1 when unbounded below). ">
-              <code>public MicroQRVersion Min { get; }</code>
+            <div class="member" data-text="property public microqrversion min { get; } the lowest permitted version (m1 when unbounded below). ">
+              <h4><span class="kind">property</span> <span class="name">Min</span></h4>
+              <pre class="sig"><code>public MicroQRVersion Min { get; }</code></pre>
               <p class="doc">The lowest permitted version (M1 when unbounded below).</p>
             </div>
-            <div class="member" data-text="public bool isany { get; } whether this range constrains nothing (the default). ">
-              <code>public bool IsAny { get; }</code>
+            <div class="member" data-text="property public bool isany { get; } whether this range constrains nothing (the default). ">
+              <h4><span class="kind">property</span> <span class="name">IsAny</span></h4>
+              <pre class="sig"><code>public bool IsAny { get; }</code></pre>
               <p class="doc">Whether this range constrains nothing (the default).</p>
             </div>
-            <div class="member" data-text="public bool isexact { get; } whether this range pins a single version. ">
-              <code>public bool IsExact { get; }</code>
+            <div class="member" data-text="property public bool isexact { get; } whether this range pins a single version. ">
+              <h4><span class="kind">property</span> <span class="name">IsExact</span></h4>
+              <pre class="sig"><code>public bool IsExact { get; }</code></pre>
               <p class="doc">Whether this range pins a single version.</p>
             </div>
-            <div class="member" data-text="public static microqrversionrange any { get; } every version, m1 to m4. identical to default. ">
-              <code>public static MicroQRVersionRange Any { get; }</code>
+            <div class="member" data-text="property public static microqrversionrange any { get; } every version, m1 to m4. identical to default. ">
+              <h4><span class="kind">property</span> <span class="name">Any</span></h4>
+              <pre class="sig"><code>public static MicroQRVersionRange Any { get; }</code></pre>
               <p class="doc">Every version, M1 to M4. Identical to default.</p>
             </div>
-            <div class="member" data-text="public bool contains(microqrversion version); whether version falls inside this range. ">
-              <code>public bool Contains(MicroQRVersion version);</code>
+            <div class="member" data-text="method public bool contains(microqrversion version); whether version falls inside this range. ">
+              <h4><span class="kind">method</span> <span class="name">Contains</span></h4>
+              <pre class="sig"><code>public bool Contains(MicroQRVersion version);</code></pre>
               <p class="doc">Whether version falls inside this range.</p>
             </div>
-            <div class="member" data-text="public override string tostring(); ">
-              <code>public override string ToString();</code>
+            <div class="member" data-text="method public override string tostring(); ">
+              <h4><span class="kind">method</span> <span class="name">ToString</span></h4>
+              <pre class="sig"><code>public override string ToString();</code></pre>
             </div>
-            <div class="member" data-text="public static microqrversionrange atleast(microqrversion version); version or larger. ">
-              <code>public static MicroQRVersionRange AtLeast(MicroQRVersion version);</code>
+            <div class="member" data-text="method public static microqrversionrange atleast(microqrversion version); version or larger. ">
+              <h4><span class="kind">method</span> <span class="name">AtLeast</span></h4>
+              <pre class="sig"><code>public static MicroQRVersionRange AtLeast(MicroQRVersion version);</code></pre>
               <p class="doc">version or larger.</p>
             </div>
-            <div class="member" data-text="public static microqrversionrange atmost(microqrversion version); version or smaller. ">
-              <code>public static MicroQRVersionRange AtMost(MicroQRVersion version);</code>
+            <div class="member" data-text="method public static microqrversionrange atmost(microqrversion version); version or smaller. ">
+              <h4><span class="kind">method</span> <span class="name">AtMost</span></h4>
+              <pre class="sig"><code>public static MicroQRVersionRange AtMost(MicroQRVersion version);</code></pre>
               <p class="doc">version or smaller.</p>
             </div>
-            <div class="member" data-text="public static microqrversionrange between(microqrversion min, microqrversion max); an inclusive range from min to max . ">
-              <code>public static MicroQRVersionRange Between(MicroQRVersion min, MicroQRVersion max);</code>
+            <div class="member" data-text="method public static microqrversionrange between(microqrversion min, microqrversion max); an inclusive range from min to max . ">
+              <h4><span class="kind">method</span> <span class="name">Between</span></h4>
+              <pre class="sig"><code>public static MicroQRVersionRange Between(MicroQRVersion min, MicroQRVersion max);</code></pre>
               <p class="doc">An inclusive range from min to max .</p>
             </div>
-            <div class="member" data-text="public static microqrversionrange exactly(microqrversion version); exactly version , with no automatic selection. ">
-              <code>public static MicroQRVersionRange Exactly(MicroQRVersion version);</code>
+            <div class="member" data-text="method public static microqrversionrange exactly(microqrversion version); exactly version , with no automatic selection. ">
+              <h4><span class="kind">method</span> <span class="name">Exactly</span></h4>
+              <pre class="sig"><code>public static MicroQRVersionRange Exactly(MicroQRVersion version);</code></pre>
               <p class="doc">Exactly version , with no automatic selection.</p>
             </div>
-            <div class="member" data-text="public static microqrversionrange op_implicit(microqrversion version); a single version, as exactly . ">
-              <code>public static MicroQRVersionRange op_Implicit(MicroQRVersion version);</code>
+            <div class="member" data-text="operator public static microqrversionrange op_implicit(microqrversion version); a single version, as exactly . ">
+              <h4><span class="kind">operator</span> <span class="name">op_Implicit</span></h4>
+              <pre class="sig"><code>public static MicroQRVersionRange op_Implicit(MicroQRVersion version);</code></pre>
               <p class="doc">A single version, as Exactly .</p>
             </div>
-            <div class="member" data-text="public static microqrversionrange op_implicit(microqrversion? version); a single version, or any when there is none, so an optional version needs no branch. ">
-              <code>public static MicroQRVersionRange op_Implicit(MicroQRVersion? version);</code>
+            <div class="member" data-text="operator public static microqrversionrange op_implicit(microqrversion? version); a single version, or any when there is none, so an optional version needs no branch. ">
+              <h4><span class="kind">operator</span> <span class="name">op_Implicit</span></h4>
+              <pre class="sig"><code>public static MicroQRVersionRange op_Implicit(MicroQRVersion? version);</code></pre>
               <p class="doc">A single version, or Any when there is none, so an optional version needs no branch.</p>
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.ModuleRect" data-name="skiasharp.qrcode.modulerect" data-text="skiasharp.qrcode.modulerect public readonly struct modulerect : iequatable&lt;modulerect&gt; an axis-aligned rectangle of dark modules, in module coordinates. produced by the getmodulerectangles family on qrcodedata , microqrcodedata , and rmqrcodedata . coordinates use the same space as the matrix indexer: one unit is one module, origin at the top-left corner of the symbol including its quiet zone, x growing right and y growing down. the module at column c, row r read via data[r, c] corresponds to the unit rectangle at x = c, y = r. renderers map to pixels by multiplying all four values by the pixel size of one module. no scale or pixel size is baked in, so the same value works for svg path data (viewbox in module units), draw calls, and any other coordinate transform the consumer applies. public modulerect(int x, int y, int width, int height); an axis-aligned rectangle of dark modules, in module coordinates. produced by the getmodulerectangles family on qrcodedata , microqrcodedata , and rmqrcodedata . coordinates use the same space as the matrix indexer: one unit is one module, origin at the top-left corner of the symbol including its quiet zone, x growing right and y growing down. the module at column c, row r read via data[r, c] corresponds to the unit rectangle at x = c, y = r. renderers map to pixels by multiplying all four values by the pixel size of one module. no scale or pixel size is baked in, so the same value works for svg path data (viewbox in module units), draw calls, and any other coordinate transform the consumer applies. public int height { get; init; } height in modules (always positive).  public int width { get; init; } width in modules (always positive).  public int x { get; init; } column of the left edge (0-based, including the quiet zone if present).  public int y { get; init; } row of the top edge (0-based, including the quiet zone if present). ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.ModuleRect" aria-label="Link to SkiaSharp.QrCode.ModuleRect">#</a><code>public readonly struct ModuleRect : IEquatable&lt;ModuleRect&gt;</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.ModuleRect" data-name="skiasharp.qrcode.modulerect" data-text="skiasharp.qrcode.modulerect public readonly struct modulerect : iequatable&lt;modulerect&gt; an axis-aligned rectangle of dark modules, in module coordinates. produced by the getmodulerectangles family on qrcodedata , microqrcodedata , and rmqrcodedata . coordinates use the same space as the matrix indexer: one unit is one module, origin at the top-left corner of the symbol including its quiet zone, x growing right and y growing down. the module at column c, row r read via data[r, c] corresponds to the unit rectangle at x = c, y = r. renderers map to pixels by multiplying all four values by the pixel size of one module. no scale or pixel size is baked in, so the same value works for svg path data (viewbox in module units), draw calls, and any other coordinate transform the consumer applies. constructor public modulerect(int x, int y, int width, int height); an axis-aligned rectangle of dark modules, in module coordinates. produced by the getmodulerectangles family on qrcodedata , microqrcodedata , and rmqrcodedata . coordinates use the same space as the matrix indexer: one unit is one module, origin at the top-left corner of the symbol including its quiet zone, x growing right and y growing down. the module at column c, row r read via data[r, c] corresponds to the unit rectangle at x = c, y = r. renderers map to pixels by multiplying all four values by the pixel size of one module. no scale or pixel size is baked in, so the same value works for svg path data (viewbox in module units), draw calls, and any other coordinate transform the consumer applies. property public int height { get; init; } height in modules (always positive).  property public int width { get; init; } width in modules (always positive).  property public int x { get; init; } column of the left edge (0-based, including the quiet zone if present).  property public int y { get; init; } row of the top edge (0-based, including the quiet zone if present). ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.ModuleRect" aria-label="Link to SkiaSharp.QrCode.ModuleRect">#</a><span class="kind">struct</span> <span class="name">ModuleRect</span></h3>
+          <pre class="sig"><code>public readonly struct ModuleRect : IEquatable&lt;ModuleRect&gt;</code></pre>
           <p class="doc">An axis-aligned rectangle of dark modules, in module coordinates. Produced by the GetModuleRectangles family on QRCodeData , MicroQRCodeData , and RmQRCodeData .</p>
           <details class="notes" data-text="coordinates use the same space as the matrix indexer: one unit is one module, origin at the top-left corner of the symbol including its quiet zone, x growing right and y growing down. the module at column c, row r read via data[r, c] corresponds to the unit rectangle at x = c, y = r. renderers map to pixels by multiplying all four values by the pixel size of one module. no scale or pixel size is baked in, so the same value works for svg path data (viewbox in module units), draw calls, and any other coordinate transform the consumer applies.">
             <summary>Notes</summary>
             <p class="doc remarks">Coordinates use the same space as the matrix indexer: one unit is one module, origin at the top-left corner of the symbol including its quiet zone, X growing right and Y growing down. The module at column c, row r read via data[r, c] corresponds to the unit rectangle at X = c, Y = r. Renderers map to pixels by multiplying all four values by the pixel size of one module. No scale or pixel size is baked in, so the same value works for SVG path data (viewBox in module units), draw calls, and any other coordinate transform the consumer applies.</p>
           </details>
           <div class="members">
-            <div class="member" data-text="public modulerect(int x, int y, int width, int height); an axis-aligned rectangle of dark modules, in module coordinates. produced by the getmodulerectangles family on qrcodedata , microqrcodedata , and rmqrcodedata . coordinates use the same space as the matrix indexer: one unit is one module, origin at the top-left corner of the symbol including its quiet zone, x growing right and y growing down. the module at column c, row r read via data[r, c] corresponds to the unit rectangle at x = c, y = r. renderers map to pixels by multiplying all four values by the pixel size of one module. no scale or pixel size is baked in, so the same value works for svg path data (viewbox in module units), draw calls, and any other coordinate transform the consumer applies.">
-              <code>public ModuleRect(int X, int Y, int Width, int Height);</code>
+            <div class="member" data-text="constructor public modulerect(int x, int y, int width, int height); an axis-aligned rectangle of dark modules, in module coordinates. produced by the getmodulerectangles family on qrcodedata , microqrcodedata , and rmqrcodedata . coordinates use the same space as the matrix indexer: one unit is one module, origin at the top-left corner of the symbol including its quiet zone, x growing right and y growing down. the module at column c, row r read via data[r, c] corresponds to the unit rectangle at x = c, y = r. renderers map to pixels by multiplying all four values by the pixel size of one module. no scale or pixel size is baked in, so the same value works for svg path data (viewbox in module units), draw calls, and any other coordinate transform the consumer applies.">
+              <h4><span class="kind">constructor</span> <span class="name">ModuleRect</span></h4>
+              <pre class="sig"><code>public ModuleRect(int X, int Y, int Width, int Height);</code></pre>
               <p class="doc">An axis-aligned rectangle of dark modules, in module coordinates. Produced by the GetModuleRectangles family on QRCodeData , MicroQRCodeData , and RmQRCodeData .</p>
               <details class="notes" data-text="coordinates use the same space as the matrix indexer: one unit is one module, origin at the top-left corner of the symbol including its quiet zone, x growing right and y growing down. the module at column c, row r read via data[r, c] corresponds to the unit rectangle at x = c, y = r. renderers map to pixels by multiplying all four values by the pixel size of one module. no scale or pixel size is baked in, so the same value works for svg path data (viewbox in module units), draw calls, and any other coordinate transform the consumer applies.">
                 <summary>Notes</summary>
                 <p class="doc remarks">Coordinates use the same space as the matrix indexer: one unit is one module, origin at the top-left corner of the symbol including its quiet zone, X growing right and Y growing down. The module at column c, row r read via data[r, c] corresponds to the unit rectangle at X = c, Y = r. Renderers map to pixels by multiplying all four values by the pixel size of one module. No scale or pixel size is baked in, so the same value works for SVG path data (viewBox in module units), draw calls, and any other coordinate transform the consumer applies.</p>
               </details>
             </div>
-            <div class="member" data-text="public int height { get; init; } height in modules (always positive). ">
-              <code>public int Height { get; init; }</code>
+            <div class="member" data-text="property public int height { get; init; } height in modules (always positive). ">
+              <h4><span class="kind">property</span> <span class="name">Height</span></h4>
+              <pre class="sig"><code>public int Height { get; init; }</code></pre>
               <p class="doc">Height in modules (always positive).</p>
             </div>
-            <div class="member" data-text="public int width { get; init; } width in modules (always positive). ">
-              <code>public int Width { get; init; }</code>
+            <div class="member" data-text="property public int width { get; init; } width in modules (always positive). ">
+              <h4><span class="kind">property</span> <span class="name">Width</span></h4>
+              <pre class="sig"><code>public int Width { get; init; }</code></pre>
               <p class="doc">Width in modules (always positive).</p>
             </div>
-            <div class="member" data-text="public int x { get; init; } column of the left edge (0-based, including the quiet zone if present). ">
-              <code>public int X { get; init; }</code>
+            <div class="member" data-text="property public int x { get; init; } column of the left edge (0-based, including the quiet zone if present). ">
+              <h4><span class="kind">property</span> <span class="name">X</span></h4>
+              <pre class="sig"><code>public int X { get; init; }</code></pre>
               <p class="doc">Column of the left edge (0-based, including the quiet zone if present).</p>
             </div>
-            <div class="member" data-text="public int y { get; init; } row of the top edge (0-based, including the quiet zone if present). ">
-              <code>public int Y { get; init; }</code>
+            <div class="member" data-text="property public int y { get; init; } row of the top edge (0-based, including the quiet zone if present). ">
+              <h4><span class="kind">property</span> <span class="name">Y</span></h4>
+              <pre class="sig"><code>public int Y { get; init; }</code></pre>
               <p class="doc">Row of the top edge (0-based, including the quiet zone if present).</p>
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.QRCodeCalculatedSize" data-name="skiasharp.qrcode.qrcodecalculatedsize" data-text="skiasharp.qrcode.qrcodecalculatedsize public readonly struct qrcodecalculatedsize : iequatable&lt;qrcodecalculatedsize&gt; calculated qr code size information.  public qrcodecalculatedsize(int buffersize, int qrsize, int version); calculated qr code size information.  public bool isvalid { get; } validates that the calculated size values are within acceptable ranges.  public int buffersize { get; init; } required buffer size for the qr code matrix data (in bytes). calculated as qrsize × qrsize.  public int qrsize { get; init; } qr code size in modules per side (including quiet zone if specified)  public int version { get; init; } qr code version (1-40) determined by data capacity requirements ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeCalculatedSize" aria-label="Link to SkiaSharp.QrCode.QRCodeCalculatedSize">#</a><code>public readonly struct QRCodeCalculatedSize : IEquatable&lt;QRCodeCalculatedSize&gt;</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.QRCodeCalculatedSize" data-name="skiasharp.qrcode.qrcodecalculatedsize" data-text="skiasharp.qrcode.qrcodecalculatedsize public readonly struct qrcodecalculatedsize : iequatable&lt;qrcodecalculatedsize&gt; calculated qr code size information.  constructor public qrcodecalculatedsize(int buffersize, int qrsize, int version); calculated qr code size information.  property public bool isvalid { get; } validates that the calculated size values are within acceptable ranges.  property public int buffersize { get; init; } required buffer size for the qr code matrix data (in bytes). calculated as qrsize × qrsize.  property public int qrsize { get; init; } qr code size in modules per side (including quiet zone if specified)  property public int version { get; init; } qr code version (1-40) determined by data capacity requirements ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeCalculatedSize" aria-label="Link to SkiaSharp.QrCode.QRCodeCalculatedSize">#</a><span class="kind">struct</span> <span class="name">QRCodeCalculatedSize</span></h3>
+          <pre class="sig"><code>public readonly struct QRCodeCalculatedSize : IEquatable&lt;QRCodeCalculatedSize&gt;</code></pre>
           <p class="doc">Calculated QR code size information.</p>
           <div class="members">
-            <div class="member" data-text="public qrcodecalculatedsize(int buffersize, int qrsize, int version); calculated qr code size information. ">
-              <code>public QRCodeCalculatedSize(int BufferSize, int QrSize, int Version);</code>
+            <div class="member" data-text="constructor public qrcodecalculatedsize(int buffersize, int qrsize, int version); calculated qr code size information. ">
+              <h4><span class="kind">constructor</span> <span class="name">QRCodeCalculatedSize</span></h4>
+              <pre class="sig"><code>public QRCodeCalculatedSize(int BufferSize, int QrSize, int Version);</code></pre>
               <p class="doc">Calculated QR code size information.</p>
             </div>
-            <div class="member" data-text="public bool isvalid { get; } validates that the calculated size values are within acceptable ranges. ">
-              <code>public bool IsValid { get; }</code>
+            <div class="member" data-text="property public bool isvalid { get; } validates that the calculated size values are within acceptable ranges. ">
+              <h4><span class="kind">property</span> <span class="name">IsValid</span></h4>
+              <pre class="sig"><code>public bool IsValid { get; }</code></pre>
               <p class="doc">Validates that the calculated size values are within acceptable ranges.</p>
             </div>
-            <div class="member" data-text="public int buffersize { get; init; } required buffer size for the qr code matrix data (in bytes). calculated as qrsize × qrsize. ">
-              <code>public int BufferSize { get; init; }</code>
+            <div class="member" data-text="property public int buffersize { get; init; } required buffer size for the qr code matrix data (in bytes). calculated as qrsize × qrsize. ">
+              <h4><span class="kind">property</span> <span class="name">BufferSize</span></h4>
+              <pre class="sig"><code>public int BufferSize { get; init; }</code></pre>
               <p class="doc">Required buffer size for the QR code matrix data (in bytes). Calculated as QrSize × QrSize.</p>
             </div>
-            <div class="member" data-text="public int qrsize { get; init; } qr code size in modules per side (including quiet zone if specified) ">
-              <code>public int QrSize { get; init; }</code>
+            <div class="member" data-text="property public int qrsize { get; init; } qr code size in modules per side (including quiet zone if specified) ">
+              <h4><span class="kind">property</span> <span class="name">QrSize</span></h4>
+              <pre class="sig"><code>public int QrSize { get; init; }</code></pre>
               <p class="doc">QR code size in modules per side (including quiet zone if specified)</p>
             </div>
-            <div class="member" data-text="public int version { get; init; } qr code version (1-40) determined by data capacity requirements ">
-              <code>public int Version { get; init; }</code>
+            <div class="member" data-text="property public int version { get; init; } qr code version (1-40) determined by data capacity requirements ">
+              <h4><span class="kind">property</span> <span class="name">Version</span></h4>
+              <pre class="sig"><code>public int Version { get; init; }</code></pre>
               <p class="doc">QR code version (1-40) determined by data capacity requirements</p>
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.QRCodeData" data-name="skiasharp.qrcode.qrcodedata" data-text="skiasharp.qrcode.qrcodedata public class qrcodedata represents qr code data as a 2d boolean matrix. qr code structure: - version: 1-40 (determines size: 21×21 to 177×177) - module matrix: 2d array of boolean values (dark/light) - serialization format: &quot;qrr&quot; header + size + bit-packed data public qrcodedata(readonlyspan&lt;byte&gt; rawdataspan, int quietzonesize); initializes a new instance of the qrcodedata class from serialized raw data. this constructor deserializes qr code data that was previously serialized using getrawdata . the raw data contains only the core qr code modules (excluding quiet zone). data format: &quot;qrr&quot; header (3 bytes) + base size (1 byte) + bit-packed module data the quiet zone (white border) can be added during deserialization by specifying the quietzonesize parameter. this overload is useful for high-performance scenarios where you want to deserialize from existing memory buffers (e.g., memory , arraysegment , or stack-allocated arrays) without allocating a new byte array. public qrcodedata(byte[] rawdata, int quietzonesize); initializes a new instance of the qrcodedata class from serialized raw data. this constructor deserializes qr code data that was previously serialized using getrawdata . the raw data contains only the core qr code modules (excluding quiet zone). data format: &quot;qrr&quot; header (3 bytes) + base size (1 byte) + bit-packed module data the quiet zone (white border) can be added during deserialization by specifying the quietzonesize parameter. public qrcodedata(int version, int quietzonesize); initializes with the specified version.  public bool this[int row, int col] { get; } gets or sets the module state at the specified position. quiet zone positions always read false (the quiet zone is light by definition and is not stored). the internal setter only accepts core positions, quiet zone modules cannot be modified. public int size { get; } gets the size of the qr code matrix (modules per side).  public int version { get; } get the qr code version (1-40)  public modulerect[] getmodulerectangles(); gets the dark modules as merged rectangles in module coordinates, for rendering with any graphics api without skiasharp (svg path data, draw calls, vector output). coordinates use the same space as the indexer (this[row, col]): one unit is one module, origin at the top-left including the quiet zone, x is the column and y is the row. consumers scale by the pixel size of one module; size gives the total extent in modules. three properties are contractual: rectangles never overlap, cover only dark modules, and cover every dark module. the decomposition shape and ordering are unspecified and may change between versions (currently maximal horizontal runs in row-major order, the same merge the built-in renderer draws). public bool isfinderpattern(int row, int col); checks if the specified module position (excluding quiet zone) is part of a finder pattern.  public bool trygetmodulerectangles(span&lt;modulerect&gt; destination, out int written); writes the dark modules as merged rectangles into a caller-provided buffer. same contract as getmodulerectangles without allocations.  public byte[] getrawdata(); serializes the qr code data to a byte array. the serialized data contains only the core qr code modules (excluding quiet zone). the quiet zone can be added when deserializing via the #ctor constructor. format: &quot;qrr&quot; header (3 bytes) + base size (1 byte) + bit-packed module data public int getfinderpatternindex(int row, int col); gets the finder pattern index for the specified module position (excluding quiet zone).  public int getmodulerectanglesmaxcount(); gets an upper bound on the number of rectangles getmodulerectangles can return, suitable for sizing a pooled buffer for trygetmodulerectangles . o(1), no matrix scan.  public int getrawdata(ibufferwriter&lt;byte&gt; writer); writes the serialized qr code data to the specified buffer writer. this method writes only the core qr mode modules (excluding quiet zone). the quiet zone can be added when deserializing via the #ctor constructor. format: &quot;qrr&quot; header (3 bytes) + base size (1 byte) + bit-packed module data this overload is useful for high-performance scenarios where memory allocations need to be minimized, such as response writing or streaming. public int getrawdatasize(); calculates the required buffer size for serialization. ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeData" aria-label="Link to SkiaSharp.QrCode.QRCodeData">#</a><code>public class QRCodeData</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.QRCodeData" data-name="skiasharp.qrcode.qrcodedata" data-text="skiasharp.qrcode.qrcodedata public class qrcodedata represents qr code data as a 2d boolean matrix. qr code structure: - version: 1-40 (determines size: 21×21 to 177×177) - module matrix: 2d array of boolean values (dark/light) - serialization format: &quot;qrr&quot; header + size + bit-packed data constructor public qrcodedata(readonlyspan&lt;byte&gt; rawdataspan, int quietzonesize); initializes a new instance of the qrcodedata class from serialized raw data. this constructor deserializes qr code data that was previously serialized using getrawdata . the raw data contains only the core qr code modules (excluding quiet zone). data format: &quot;qrr&quot; header (3 bytes) + base size (1 byte) + bit-packed module data the quiet zone (white border) can be added during deserialization by specifying the quietzonesize parameter. this overload is useful for high-performance scenarios where you want to deserialize from existing memory buffers (e.g., memory , arraysegment , or stack-allocated arrays) without allocating a new byte array. constructor public qrcodedata(byte[] rawdata, int quietzonesize); initializes a new instance of the qrcodedata class from serialized raw data. this constructor deserializes qr code data that was previously serialized using getrawdata . the raw data contains only the core qr code modules (excluding quiet zone). data format: &quot;qrr&quot; header (3 bytes) + base size (1 byte) + bit-packed module data the quiet zone (white border) can be added during deserialization by specifying the quietzonesize parameter. constructor public qrcodedata(int version, int quietzonesize); initializes with the specified version.  indexer public bool this[int row, int col] { get; } gets or sets the module state at the specified position. quiet zone positions always read false (the quiet zone is light by definition and is not stored). the internal setter only accepts core positions, quiet zone modules cannot be modified. property public int size { get; } gets the size of the qr code matrix (modules per side).  property public int version { get; } get the qr code version (1-40)  method public modulerect[] getmodulerectangles(); gets the dark modules as merged rectangles in module coordinates, for rendering with any graphics api without skiasharp (svg path data, draw calls, vector output). coordinates use the same space as the indexer (this[row, col]): one unit is one module, origin at the top-left including the quiet zone, x is the column and y is the row. consumers scale by the pixel size of one module; size gives the total extent in modules. three properties are contractual: rectangles never overlap, cover only dark modules, and cover every dark module. the decomposition shape and ordering are unspecified and may change between versions (currently maximal horizontal runs in row-major order, the same merge the built-in renderer draws). method public bool isfinderpattern(int row, int col); checks if the specified module position (excluding quiet zone) is part of a finder pattern.  method public bool trygetmodulerectangles(span&lt;modulerect&gt; destination, out int written); writes the dark modules as merged rectangles into a caller-provided buffer. same contract as getmodulerectangles without allocations.  method public byte[] getrawdata(); serializes the qr code data to a byte array. the serialized data contains only the core qr code modules (excluding quiet zone). the quiet zone can be added when deserializing via the #ctor constructor. format: &quot;qrr&quot; header (3 bytes) + base size (1 byte) + bit-packed module data method public int getfinderpatternindex(int row, int col); gets the finder pattern index for the specified module position (excluding quiet zone).  method public int getmodulerectanglesmaxcount(); gets an upper bound on the number of rectangles getmodulerectangles can return, suitable for sizing a pooled buffer for trygetmodulerectangles . o(1), no matrix scan.  method public int getrawdata(ibufferwriter&lt;byte&gt; writer); writes the serialized qr code data to the specified buffer writer. this method writes only the core qr mode modules (excluding quiet zone). the quiet zone can be added when deserializing via the #ctor constructor. format: &quot;qrr&quot; header (3 bytes) + base size (1 byte) + bit-packed module data this overload is useful for high-performance scenarios where memory allocations need to be minimized, such as response writing or streaming. method public int getrawdatasize(); calculates the required buffer size for serialization. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeData" aria-label="Link to SkiaSharp.QrCode.QRCodeData">#</a><span class="kind">class</span> <span class="name">QRCodeData</span></h3>
+          <pre class="sig"><code>public class QRCodeData</code></pre>
           <p class="doc">Represents QR code data as a 2D boolean matrix.</p>
           <details class="notes" data-text="qr code structure: - version: 1-40 (determines size: 21×21 to 177×177) - module matrix: 2d array of boolean values (dark/light) - serialization format: &quot;qrr&quot; header + size + bit-packed data">
             <summary>Notes</summary>
             <p class="doc remarks">QR code structure: - Version: 1-40 (determines size: 21×21 to 177×177) - Module matrix: 2D array of boolean values (dark/light) - Serialization format: &quot;QRR&quot; header + size + bit-packed data</p>
           </details>
           <div class="members">
-            <div class="member" data-text="public qrcodedata(readonlyspan&lt;byte&gt; rawdataspan, int quietzonesize); initializes a new instance of the qrcodedata class from serialized raw data. this constructor deserializes qr code data that was previously serialized using getrawdata . the raw data contains only the core qr code modules (excluding quiet zone). data format: &quot;qrr&quot; header (3 bytes) + base size (1 byte) + bit-packed module data the quiet zone (white border) can be added during deserialization by specifying the quietzonesize parameter. this overload is useful for high-performance scenarios where you want to deserialize from existing memory buffers (e.g., memory , arraysegment , or stack-allocated arrays) without allocating a new byte array.">
-              <code>public QRCodeData(ReadOnlySpan&lt;byte&gt; rawDataSpan, int quietZoneSize);</code>
+            <div class="member" data-text="constructor public qrcodedata(readonlyspan&lt;byte&gt; rawdataspan, int quietzonesize); initializes a new instance of the qrcodedata class from serialized raw data. this constructor deserializes qr code data that was previously serialized using getrawdata . the raw data contains only the core qr code modules (excluding quiet zone). data format: &quot;qrr&quot; header (3 bytes) + base size (1 byte) + bit-packed module data the quiet zone (white border) can be added during deserialization by specifying the quietzonesize parameter. this overload is useful for high-performance scenarios where you want to deserialize from existing memory buffers (e.g., memory , arraysegment , or stack-allocated arrays) without allocating a new byte array.">
+              <h4><span class="kind">constructor</span> <span class="name">QRCodeData</span></h4>
+              <pre class="sig"><code>public QRCodeData(ReadOnlySpan&lt;byte&gt; rawDataSpan, int quietZoneSize);</code></pre>
               <p class="doc">Initializes a new instance of the QRCodeData class from serialized raw data.</p>
               <details class="notes" data-text="this constructor deserializes qr code data that was previously serialized using getrawdata . the raw data contains only the core qr code modules (excluding quiet zone). data format: &quot;qrr&quot; header (3 bytes) + base size (1 byte) + bit-packed module data the quiet zone (white border) can be added during deserialization by specifying the quietzonesize parameter. this overload is useful for high-performance scenarios where you want to deserialize from existing memory buffers (e.g., memory , arraysegment , or stack-allocated arrays) without allocating a new byte array.">
                 <summary>Notes</summary>
                 <p class="doc remarks">This constructor deserializes QR code data that was previously serialized using GetRawData . The raw data contains only the core QR code modules (excluding quiet zone). Data format: &quot;QRR&quot; header (3 bytes) + base size (1 byte) + bit-packed module data The quiet zone (white border) can be added during deserialization by specifying the quietZoneSize parameter. This overload is useful for high-performance scenarios where you want to deserialize from existing memory buffers (e.g., Memory , ArraySegment , or stack-allocated arrays) without allocating a new byte array.</p>
               </details>
             </div>
-            <div class="member" data-text="public qrcodedata(byte[] rawdata, int quietzonesize); initializes a new instance of the qrcodedata class from serialized raw data. this constructor deserializes qr code data that was previously serialized using getrawdata . the raw data contains only the core qr code modules (excluding quiet zone). data format: &quot;qrr&quot; header (3 bytes) + base size (1 byte) + bit-packed module data the quiet zone (white border) can be added during deserialization by specifying the quietzonesize parameter.">
-              <code>public QRCodeData(byte[] rawData, int quietZoneSize);</code>
+            <div class="member" data-text="constructor public qrcodedata(byte[] rawdata, int quietzonesize); initializes a new instance of the qrcodedata class from serialized raw data. this constructor deserializes qr code data that was previously serialized using getrawdata . the raw data contains only the core qr code modules (excluding quiet zone). data format: &quot;qrr&quot; header (3 bytes) + base size (1 byte) + bit-packed module data the quiet zone (white border) can be added during deserialization by specifying the quietzonesize parameter.">
+              <h4><span class="kind">constructor</span> <span class="name">QRCodeData</span></h4>
+              <pre class="sig"><code>public QRCodeData(byte[] rawData, int quietZoneSize);</code></pre>
               <p class="doc">Initializes a new instance of the QRCodeData class from serialized raw data.</p>
               <details class="notes" data-text="this constructor deserializes qr code data that was previously serialized using getrawdata . the raw data contains only the core qr code modules (excluding quiet zone). data format: &quot;qrr&quot; header (3 bytes) + base size (1 byte) + bit-packed module data the quiet zone (white border) can be added during deserialization by specifying the quietzonesize parameter.">
                 <summary>Notes</summary>
                 <p class="doc remarks">This constructor deserializes QR code data that was previously serialized using GetRawData . The raw data contains only the core QR code modules (excluding quiet zone). Data format: &quot;QRR&quot; header (3 bytes) + base size (1 byte) + bit-packed module data The quiet zone (white border) can be added during deserialization by specifying the quietZoneSize parameter.</p>
               </details>
             </div>
-            <div class="member" data-text="public qrcodedata(int version, int quietzonesize); initializes with the specified version. ">
-              <code>public QRCodeData(int version, int quietZoneSize);</code>
+            <div class="member" data-text="constructor public qrcodedata(int version, int quietzonesize); initializes with the specified version. ">
+              <h4><span class="kind">constructor</span> <span class="name">QRCodeData</span></h4>
+              <pre class="sig"><code>public QRCodeData(int version, int quietZoneSize);</code></pre>
               <p class="doc">Initializes with the specified version.</p>
             </div>
-            <div class="member" data-text="public bool this[int row, int col] { get; } gets or sets the module state at the specified position. quiet zone positions always read false (the quiet zone is light by definition and is not stored). the internal setter only accepts core positions, quiet zone modules cannot be modified.">
-              <code>public bool this[int row, int col] { get; }</code>
+            <div class="member" data-text="indexer public bool this[int row, int col] { get; } gets or sets the module state at the specified position. quiet zone positions always read false (the quiet zone is light by definition and is not stored). the internal setter only accepts core positions, quiet zone modules cannot be modified.">
+              <h4><span class="kind">indexer</span> <span class="name">this[int row, int col]</span></h4>
+              <pre class="sig"><code>public bool this[int row, int col] { get; }</code></pre>
               <p class="doc">Gets or sets the module state at the specified position.</p>
               <details class="notes" data-text="quiet zone positions always read false (the quiet zone is light by definition and is not stored). the internal setter only accepts core positions, quiet zone modules cannot be modified.">
                 <summary>Notes</summary>
                 <p class="doc remarks">Quiet zone positions always read false (the quiet zone is light by definition and is not stored). The internal setter only accepts core positions, quiet zone modules cannot be modified.</p>
               </details>
             </div>
-            <div class="member" data-text="public int size { get; } gets the size of the qr code matrix (modules per side). ">
-              <code>public int Size { get; }</code>
+            <div class="member" data-text="property public int size { get; } gets the size of the qr code matrix (modules per side). ">
+              <h4><span class="kind">property</span> <span class="name">Size</span></h4>
+              <pre class="sig"><code>public int Size { get; }</code></pre>
               <p class="doc">Gets the size of the QR code matrix (modules per side).</p>
             </div>
-            <div class="member" data-text="public int version { get; } get the qr code version (1-40) ">
-              <code>public int Version { get; }</code>
+            <div class="member" data-text="property public int version { get; } get the qr code version (1-40) ">
+              <h4><span class="kind">property</span> <span class="name">Version</span></h4>
+              <pre class="sig"><code>public int Version { get; }</code></pre>
               <p class="doc">Get the QR code version (1-40)</p>
             </div>
-            <div class="member" data-text="public modulerect[] getmodulerectangles(); gets the dark modules as merged rectangles in module coordinates, for rendering with any graphics api without skiasharp (svg path data, draw calls, vector output). coordinates use the same space as the indexer (this[row, col]): one unit is one module, origin at the top-left including the quiet zone, x is the column and y is the row. consumers scale by the pixel size of one module; size gives the total extent in modules. three properties are contractual: rectangles never overlap, cover only dark modules, and cover every dark module. the decomposition shape and ordering are unspecified and may change between versions (currently maximal horizontal runs in row-major order, the same merge the built-in renderer draws).">
-              <code>public ModuleRect[] GetModuleRectangles();</code>
+            <div class="member" data-text="method public modulerect[] getmodulerectangles(); gets the dark modules as merged rectangles in module coordinates, for rendering with any graphics api without skiasharp (svg path data, draw calls, vector output). coordinates use the same space as the indexer (this[row, col]): one unit is one module, origin at the top-left including the quiet zone, x is the column and y is the row. consumers scale by the pixel size of one module; size gives the total extent in modules. three properties are contractual: rectangles never overlap, cover only dark modules, and cover every dark module. the decomposition shape and ordering are unspecified and may change between versions (currently maximal horizontal runs in row-major order, the same merge the built-in renderer draws).">
+              <h4><span class="kind">method</span> <span class="name">GetModuleRectangles</span></h4>
+              <pre class="sig"><code>public ModuleRect[] GetModuleRectangles();</code></pre>
               <p class="doc">Gets the dark modules as merged rectangles in module coordinates, for rendering with any graphics API without SkiaSharp (SVG path data, draw calls, vector output).</p>
               <details class="notes" data-text="coordinates use the same space as the indexer (this[row, col]): one unit is one module, origin at the top-left including the quiet zone, x is the column and y is the row. consumers scale by the pixel size of one module; size gives the total extent in modules. three properties are contractual: rectangles never overlap, cover only dark modules, and cover every dark module. the decomposition shape and ordering are unspecified and may change between versions (currently maximal horizontal runs in row-major order, the same merge the built-in renderer draws).">
                 <summary>Notes</summary>
                 <p class="doc remarks">Coordinates use the same space as the indexer (this[row, col]): one unit is one module, origin at the top-left including the quiet zone, X is the column and Y is the row. Consumers scale by the pixel size of one module; Size gives the total extent in modules. Three properties are contractual: rectangles never overlap, cover only dark modules, and cover every dark module. The decomposition shape and ordering are unspecified and may change between versions (currently maximal horizontal runs in row-major order, the same merge the built-in renderer draws).</p>
               </details>
             </div>
-            <div class="member" data-text="public bool isfinderpattern(int row, int col); checks if the specified module position (excluding quiet zone) is part of a finder pattern. ">
-              <code>public bool IsFinderPattern(int row, int col);</code>
+            <div class="member" data-text="method public bool isfinderpattern(int row, int col); checks if the specified module position (excluding quiet zone) is part of a finder pattern. ">
+              <h4><span class="kind">method</span> <span class="name">IsFinderPattern</span></h4>
+              <pre class="sig"><code>public bool IsFinderPattern(int row, int col);</code></pre>
               <p class="doc">Checks if the specified module position (excluding quiet zone) is part of a finder pattern.</p>
             </div>
-            <div class="member" data-text="public bool trygetmodulerectangles(span&lt;modulerect&gt; destination, out int written); writes the dark modules as merged rectangles into a caller-provided buffer. same contract as getmodulerectangles without allocations. ">
-              <code>public bool TryGetModuleRectangles(Span&lt;ModuleRect&gt; destination, out int written);</code>
+            <div class="member" data-text="method public bool trygetmodulerectangles(span&lt;modulerect&gt; destination, out int written); writes the dark modules as merged rectangles into a caller-provided buffer. same contract as getmodulerectangles without allocations. ">
+              <h4><span class="kind">method</span> <span class="name">TryGetModuleRectangles</span></h4>
+              <pre class="sig"><code>public bool TryGetModuleRectangles(Span&lt;ModuleRect&gt; destination, out int written);</code></pre>
               <p class="doc">Writes the dark modules as merged rectangles into a caller-provided buffer. Same contract as GetModuleRectangles without allocations.</p>
             </div>
-            <div class="member" data-text="public byte[] getrawdata(); serializes the qr code data to a byte array. the serialized data contains only the core qr code modules (excluding quiet zone). the quiet zone can be added when deserializing via the #ctor constructor. format: &quot;qrr&quot; header (3 bytes) + base size (1 byte) + bit-packed module data">
-              <code>public byte[] GetRawData();</code>
+            <div class="member" data-text="method public byte[] getrawdata(); serializes the qr code data to a byte array. the serialized data contains only the core qr code modules (excluding quiet zone). the quiet zone can be added when deserializing via the #ctor constructor. format: &quot;qrr&quot; header (3 bytes) + base size (1 byte) + bit-packed module data">
+              <h4><span class="kind">method</span> <span class="name">GetRawData</span></h4>
+              <pre class="sig"><code>public byte[] GetRawData();</code></pre>
               <p class="doc">Serializes the QR code data to a byte array.</p>
               <details class="notes" data-text="the serialized data contains only the core qr code modules (excluding quiet zone). the quiet zone can be added when deserializing via the #ctor constructor. format: &quot;qrr&quot; header (3 bytes) + base size (1 byte) + bit-packed module data">
                 <summary>Notes</summary>
                 <p class="doc remarks">The serialized data contains only the core QR code modules (excluding quiet zone). The quiet zone can be added when deserializing via the #ctor constructor. Format: &quot;QRR&quot; header (3 bytes) + base size (1 byte) + bit-packed module data</p>
               </details>
             </div>
-            <div class="member" data-text="public int getfinderpatternindex(int row, int col); gets the finder pattern index for the specified module position (excluding quiet zone). ">
-              <code>public int GetFinderPatternIndex(int row, int col);</code>
+            <div class="member" data-text="method public int getfinderpatternindex(int row, int col); gets the finder pattern index for the specified module position (excluding quiet zone). ">
+              <h4><span class="kind">method</span> <span class="name">GetFinderPatternIndex</span></h4>
+              <pre class="sig"><code>public int GetFinderPatternIndex(int row, int col);</code></pre>
               <p class="doc">Gets the finder pattern index for the specified module position (excluding quiet zone).</p>
             </div>
-            <div class="member" data-text="public int getmodulerectanglesmaxcount(); gets an upper bound on the number of rectangles getmodulerectangles can return, suitable for sizing a pooled buffer for trygetmodulerectangles . o(1), no matrix scan. ">
-              <code>public int GetModuleRectanglesMaxCount();</code>
+            <div class="member" data-text="method public int getmodulerectanglesmaxcount(); gets an upper bound on the number of rectangles getmodulerectangles can return, suitable for sizing a pooled buffer for trygetmodulerectangles . o(1), no matrix scan. ">
+              <h4><span class="kind">method</span> <span class="name">GetModuleRectanglesMaxCount</span></h4>
+              <pre class="sig"><code>public int GetModuleRectanglesMaxCount();</code></pre>
               <p class="doc">Gets an upper bound on the number of rectangles GetModuleRectangles can return, suitable for sizing a pooled buffer for TryGetModuleRectangles . O(1), no matrix scan.</p>
             </div>
-            <div class="member" data-text="public int getrawdata(ibufferwriter&lt;byte&gt; writer); writes the serialized qr code data to the specified buffer writer. this method writes only the core qr mode modules (excluding quiet zone). the quiet zone can be added when deserializing via the #ctor constructor. format: &quot;qrr&quot; header (3 bytes) + base size (1 byte) + bit-packed module data this overload is useful for high-performance scenarios where memory allocations need to be minimized, such as response writing or streaming.">
-              <code>public int GetRawData(IBufferWriter&lt;byte&gt; writer);</code>
+            <div class="member" data-text="method public int getrawdata(ibufferwriter&lt;byte&gt; writer); writes the serialized qr code data to the specified buffer writer. this method writes only the core qr mode modules (excluding quiet zone). the quiet zone can be added when deserializing via the #ctor constructor. format: &quot;qrr&quot; header (3 bytes) + base size (1 byte) + bit-packed module data this overload is useful for high-performance scenarios where memory allocations need to be minimized, such as response writing or streaming.">
+              <h4><span class="kind">method</span> <span class="name">GetRawData</span></h4>
+              <pre class="sig"><code>public int GetRawData(IBufferWriter&lt;byte&gt; writer);</code></pre>
               <p class="doc">Writes the serialized QR code data to the specified buffer writer.</p>
               <details class="notes" data-text="this method writes only the core qr mode modules (excluding quiet zone). the quiet zone can be added when deserializing via the #ctor constructor. format: &quot;qrr&quot; header (3 bytes) + base size (1 byte) + bit-packed module data this overload is useful for high-performance scenarios where memory allocations need to be minimized, such as response writing or streaming.">
                 <summary>Notes</summary>
                 <p class="doc remarks">This method writes only the core QR mode modules (excluding quiet zone). The quiet zone can be added when deserializing via the #ctor constructor. Format: &quot;QRR&quot; header (3 bytes) + base size (1 byte) + bit-packed module data This overload is useful for high-performance scenarios where memory allocations need to be minimized, such as response writing or streaming.</p>
               </details>
             </div>
-            <div class="member" data-text="public int getrawdatasize(); calculates the required buffer size for serialization. ">
-              <code>public int GetRawDataSize();</code>
+            <div class="member" data-text="method public int getrawdatasize(); calculates the required buffer size for serialization. ">
+              <h4><span class="kind">method</span> <span class="name">GetRawDataSize</span></h4>
+              <pre class="sig"><code>public int GetRawDataSize();</code></pre>
               <p class="doc">Calculates the required buffer size for serialization.</p>
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.QRCodeDecodeInfo" data-name="skiasharp.qrcode.qrcodedecodeinfo" data-text="skiasharp.qrcode.qrcodedecodeinfo public readonly struct qrcodedecodeinfo diagnostic information produced by a qr code decode attempt.  public ecclevel ecclevel { get; } error correction level read from the format information.  public qrcodedecodestatus status { get; } decode result status. success when decoding succeeded.  public int errorscorrected { get; } total number of codeword errors corrected by reed-solomon decoding.  public int maskpattern { get; } mask pattern (0-7) read from the format information, or -1 when unknown.  public int version { get; } qr code version (1-40), or 0 when the matrix was invalid. ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeDecodeInfo" aria-label="Link to SkiaSharp.QrCode.QRCodeDecodeInfo">#</a><code>public readonly struct QRCodeDecodeInfo</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.QRCodeDecodeInfo" data-name="skiasharp.qrcode.qrcodedecodeinfo" data-text="skiasharp.qrcode.qrcodedecodeinfo public readonly struct qrcodedecodeinfo diagnostic information produced by a qr code decode attempt.  property public ecclevel ecclevel { get; } error correction level read from the format information.  property public qrcodedecodestatus status { get; } decode result status. success when decoding succeeded.  property public int errorscorrected { get; } total number of codeword errors corrected by reed-solomon decoding.  property public int maskpattern { get; } mask pattern (0-7) read from the format information, or -1 when unknown.  property public int version { get; } qr code version (1-40), or 0 when the matrix was invalid. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeDecodeInfo" aria-label="Link to SkiaSharp.QrCode.QRCodeDecodeInfo">#</a><span class="kind">struct</span> <span class="name">QRCodeDecodeInfo</span></h3>
+          <pre class="sig"><code>public readonly struct QRCodeDecodeInfo</code></pre>
           <p class="doc">Diagnostic information produced by a QR code decode attempt.</p>
           <div class="members">
-            <div class="member" data-text="public ecclevel ecclevel { get; } error correction level read from the format information. ">
-              <code>public ECCLevel EccLevel { get; }</code>
+            <div class="member" data-text="property public ecclevel ecclevel { get; } error correction level read from the format information. ">
+              <h4><span class="kind">property</span> <span class="name">EccLevel</span></h4>
+              <pre class="sig"><code>public ECCLevel EccLevel { get; }</code></pre>
               <p class="doc">Error correction level read from the format information.</p>
             </div>
-            <div class="member" data-text="public qrcodedecodestatus status { get; } decode result status. success when decoding succeeded. ">
-              <code>public QRCodeDecodeStatus Status { get; }</code>
+            <div class="member" data-text="property public qrcodedecodestatus status { get; } decode result status. success when decoding succeeded. ">
+              <h4><span class="kind">property</span> <span class="name">Status</span></h4>
+              <pre class="sig"><code>public QRCodeDecodeStatus Status { get; }</code></pre>
               <p class="doc">Decode result status. Success when decoding succeeded.</p>
             </div>
-            <div class="member" data-text="public int errorscorrected { get; } total number of codeword errors corrected by reed-solomon decoding. ">
-              <code>public int ErrorsCorrected { get; }</code>
+            <div class="member" data-text="property public int errorscorrected { get; } total number of codeword errors corrected by reed-solomon decoding. ">
+              <h4><span class="kind">property</span> <span class="name">ErrorsCorrected</span></h4>
+              <pre class="sig"><code>public int ErrorsCorrected { get; }</code></pre>
               <p class="doc">Total number of codeword errors corrected by Reed-Solomon decoding.</p>
             </div>
-            <div class="member" data-text="public int maskpattern { get; } mask pattern (0-7) read from the format information, or -1 when unknown. ">
-              <code>public int MaskPattern { get; }</code>
+            <div class="member" data-text="property public int maskpattern { get; } mask pattern (0-7) read from the format information, or -1 when unknown. ">
+              <h4><span class="kind">property</span> <span class="name">MaskPattern</span></h4>
+              <pre class="sig"><code>public int MaskPattern { get; }</code></pre>
               <p class="doc">Mask pattern (0-7) read from the format information, or -1 when unknown.</p>
             </div>
-            <div class="member" data-text="public int version { get; } qr code version (1-40), or 0 when the matrix was invalid. ">
-              <code>public int Version { get; }</code>
+            <div class="member" data-text="property public int version { get; } qr code version (1-40), or 0 when the matrix was invalid. ">
+              <h4><span class="kind">property</span> <span class="name">Version</span></h4>
+              <pre class="sig"><code>public int Version { get; }</code></pre>
               <p class="doc">QR code version (1-40), or 0 when the matrix was invalid.</p>
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.QRCodeDecodeStatus" data-name="skiasharp.qrcode.qrcodedecodestatus" data-text="skiasharp.qrcode.qrcodedecodestatus public enum qrcodedecodestatus : int result status of a qr code decode attempt.  success = 0, decoding succeeded.  invalidmatrix = 1, the input is not a valid qr module matrix (invalid size or no dark modules).  formatinformationinvalid = 2, both format information copies are corrupted beyond bch correction capacity.  datauncorrectable = 3, one or more reed-solomon blocks contain more errors than the ecc level can correct.  invalidbitstream = 4, the data bitstream is malformed (invalid segment values or truncated data).  unsupportedcontent = 5, the bitstream is well-formed but uses a feature this decoder does not support (fnc1, structured append, or an unsupported eci charset). a property of the symbol's structure, not of its text; see unmappedcharacter for the per-character case.  destinationtoosmall = 6, the destination buffer is too small for the decoded text.  notdetected = 7, no qr code was detected in the image (finder patterns not found or inconsistent).  unmappedcharacter = 8, the symbol was read correctly, but one character has no mapping under the charset this decoder applies, so no text is produced. today this means a kanji mode cell outside jis x 0208 — in practice one of the 83 characters microsoft cp932 adds in nec row 13 (circled digits, roman numerals, unit ligatures). it is deliberately distinct from unsupportedcontent : that says the symbol uses a feature this library does not implement, and no reader choice changes it, whereas this says the symbol is well formed and a cp932-capable reader would read it. a caller that wants to fall back to such a reader should branch on exactly this status.">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeDecodeStatus" aria-label="Link to SkiaSharp.QrCode.QRCodeDecodeStatus">#</a><code>public enum QRCodeDecodeStatus : int</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.QRCodeDecodeStatus" data-name="skiasharp.qrcode.qrcodedecodestatus" data-text="skiasharp.qrcode.qrcodedecodestatus public enum qrcodedecodestatus : int result status of a qr code decode attempt.  value success = 0, decoding succeeded.  value invalidmatrix = 1, the input is not a valid qr module matrix (invalid size or no dark modules).  value formatinformationinvalid = 2, both format information copies are corrupted beyond bch correction capacity.  value datauncorrectable = 3, one or more reed-solomon blocks contain more errors than the ecc level can correct.  value invalidbitstream = 4, the data bitstream is malformed (invalid segment values or truncated data).  value unsupportedcontent = 5, the bitstream is well-formed but uses a feature this decoder does not support (fnc1, structured append, or an unsupported eci charset). a property of the symbol's structure, not of its text; see unmappedcharacter for the per-character case.  value destinationtoosmall = 6, the destination buffer is too small for the decoded text.  value notdetected = 7, no qr code was detected in the image (finder patterns not found or inconsistent).  value unmappedcharacter = 8, the symbol was read correctly, but one character has no mapping under the charset this decoder applies, so no text is produced. today this means a kanji mode cell outside jis x 0208 — in practice one of the 83 characters microsoft cp932 adds in nec row 13 (circled digits, roman numerals, unit ligatures). it is deliberately distinct from unsupportedcontent : that says the symbol uses a feature this library does not implement, and no reader choice changes it, whereas this says the symbol is well formed and a cp932-capable reader would read it. a caller that wants to fall back to such a reader should branch on exactly this status.">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeDecodeStatus" aria-label="Link to SkiaSharp.QrCode.QRCodeDecodeStatus">#</a><span class="kind">enum</span> <span class="name">QRCodeDecodeStatus</span></h3>
+          <pre class="sig"><code>public enum QRCodeDecodeStatus : int</code></pre>
           <p class="doc">Result status of a QR code decode attempt.</p>
           <div class="members">
-            <div class="member" data-text="success = 0, decoding succeeded. ">
-              <code>Success = 0,</code>
+            <div class="member" data-text="value success = 0, decoding succeeded. ">
+              <pre class="sig"><code>Success = 0,</code></pre>
               <p class="doc">Decoding succeeded.</p>
             </div>
-            <div class="member" data-text="invalidmatrix = 1, the input is not a valid qr module matrix (invalid size or no dark modules). ">
-              <code>InvalidMatrix = 1,</code>
+            <div class="member" data-text="value invalidmatrix = 1, the input is not a valid qr module matrix (invalid size or no dark modules). ">
+              <pre class="sig"><code>InvalidMatrix = 1,</code></pre>
               <p class="doc">The input is not a valid QR module matrix (invalid size or no dark modules).</p>
             </div>
-            <div class="member" data-text="formatinformationinvalid = 2, both format information copies are corrupted beyond bch correction capacity. ">
-              <code>FormatInformationInvalid = 2,</code>
+            <div class="member" data-text="value formatinformationinvalid = 2, both format information copies are corrupted beyond bch correction capacity. ">
+              <pre class="sig"><code>FormatInformationInvalid = 2,</code></pre>
               <p class="doc">Both format information copies are corrupted beyond BCH correction capacity.</p>
             </div>
-            <div class="member" data-text="datauncorrectable = 3, one or more reed-solomon blocks contain more errors than the ecc level can correct. ">
-              <code>DataUncorrectable = 3,</code>
+            <div class="member" data-text="value datauncorrectable = 3, one or more reed-solomon blocks contain more errors than the ecc level can correct. ">
+              <pre class="sig"><code>DataUncorrectable = 3,</code></pre>
               <p class="doc">One or more Reed-Solomon blocks contain more errors than the ECC level can correct.</p>
             </div>
-            <div class="member" data-text="invalidbitstream = 4, the data bitstream is malformed (invalid segment values or truncated data). ">
-              <code>InvalidBitstream = 4,</code>
+            <div class="member" data-text="value invalidbitstream = 4, the data bitstream is malformed (invalid segment values or truncated data). ">
+              <pre class="sig"><code>InvalidBitstream = 4,</code></pre>
               <p class="doc">The data bitstream is malformed (invalid segment values or truncated data).</p>
             </div>
-            <div class="member" data-text="unsupportedcontent = 5, the bitstream is well-formed but uses a feature this decoder does not support (fnc1, structured append, or an unsupported eci charset). a property of the symbol's structure, not of its text; see unmappedcharacter for the per-character case. ">
-              <code>UnsupportedContent = 5,</code>
+            <div class="member" data-text="value unsupportedcontent = 5, the bitstream is well-formed but uses a feature this decoder does not support (fnc1, structured append, or an unsupported eci charset). a property of the symbol's structure, not of its text; see unmappedcharacter for the per-character case. ">
+              <pre class="sig"><code>UnsupportedContent = 5,</code></pre>
               <p class="doc">The bitstream is well-formed but uses a feature this decoder does not support (FNC1, Structured Append, or an unsupported ECI charset). A property of the symbol's structure, not of its text; see UnmappedCharacter for the per-character case.</p>
             </div>
-            <div class="member" data-text="destinationtoosmall = 6, the destination buffer is too small for the decoded text. ">
-              <code>DestinationTooSmall = 6,</code>
+            <div class="member" data-text="value destinationtoosmall = 6, the destination buffer is too small for the decoded text. ">
+              <pre class="sig"><code>DestinationTooSmall = 6,</code></pre>
               <p class="doc">The destination buffer is too small for the decoded text.</p>
             </div>
-            <div class="member" data-text="notdetected = 7, no qr code was detected in the image (finder patterns not found or inconsistent). ">
-              <code>NotDetected = 7,</code>
+            <div class="member" data-text="value notdetected = 7, no qr code was detected in the image (finder patterns not found or inconsistent). ">
+              <pre class="sig"><code>NotDetected = 7,</code></pre>
               <p class="doc">No QR code was detected in the image (finder patterns not found or inconsistent).</p>
             </div>
-            <div class="member" data-text="unmappedcharacter = 8, the symbol was read correctly, but one character has no mapping under the charset this decoder applies, so no text is produced. today this means a kanji mode cell outside jis x 0208 — in practice one of the 83 characters microsoft cp932 adds in nec row 13 (circled digits, roman numerals, unit ligatures). it is deliberately distinct from unsupportedcontent : that says the symbol uses a feature this library does not implement, and no reader choice changes it, whereas this says the symbol is well formed and a cp932-capable reader would read it. a caller that wants to fall back to such a reader should branch on exactly this status.">
-              <code>UnmappedCharacter = 8,</code>
+            <div class="member" data-text="value unmappedcharacter = 8, the symbol was read correctly, but one character has no mapping under the charset this decoder applies, so no text is produced. today this means a kanji mode cell outside jis x 0208 — in practice one of the 83 characters microsoft cp932 adds in nec row 13 (circled digits, roman numerals, unit ligatures). it is deliberately distinct from unsupportedcontent : that says the symbol uses a feature this library does not implement, and no reader choice changes it, whereas this says the symbol is well formed and a cp932-capable reader would read it. a caller that wants to fall back to such a reader should branch on exactly this status.">
+              <pre class="sig"><code>UnmappedCharacter = 8,</code></pre>
               <p class="doc">The symbol was read correctly, but one character has no mapping under the charset this decoder applies, so no text is produced.</p>
               <details class="notes" data-text="today this means a kanji mode cell outside jis x 0208 — in practice one of the 83 characters microsoft cp932 adds in nec row 13 (circled digits, roman numerals, unit ligatures). it is deliberately distinct from unsupportedcontent : that says the symbol uses a feature this library does not implement, and no reader choice changes it, whereas this says the symbol is well formed and a cp932-capable reader would read it. a caller that wants to fall back to such a reader should branch on exactly this status.">
                 <summary>Notes</summary>
@@ -1017,102 +1131,119 @@
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.QRCodeDecoder" data-name="skiasharp.qrcode.qrcodedecoder" data-text="skiasharp.qrcode.qrcodedecoder public static class qrcodedecoder qr code decoder based on iso/iec 18004 standard. decodes qr module matrices back into text, including reed-solomon error correction. supported content: numeric, alphanumeric and byte mode segments (iso-8859-1 and utf-8, with or without eci headers), the full version range 1-40 and all ecc levels. kanji mode is decoded as jis x 0208; the generator never emits it, so kanji is a read-only mode here. a kanji cell outside the jis x 0208 repertoire (most visibly the nec row 13 characters cp932 adds, such as circled digits) fails the whole symbol with unmappedcharacter rather than substituting a replacement character; that status is distinct from unsupportedcontent so a caller can tell &quot;a cp932 reader would read this&quot; from &quot;this uses a feature we do not implement&quot;. fnc1 and structured append are the latter. byte segments without an eci header have no declared charset. the decoder uses utf-8 when the payload is valid utf-8 (or carries a bom) and iso-8859-1 otherwise. public static bool trydecode(qrcodedata data, out string text); decodes the text content from qr code data.  public static bool trydecode(qrcodedata data, out string text, out qrcodedecodeinfo info); decodes the text content from qr code data, with diagnostic information.  public static bool trydecode(readonlyspan&lt;byte&gt; modules, int size, span&lt;char&gt; destination, out int charswritten, out qrcodedecodeinfo info); decodes the text content from a module matrix into a caller-provided buffer without per-call heap allocation.  public static bool trydecode(readonlyspan&lt;byte&gt; modules, int size, out string text, out qrcodedecodeinfo info); decodes the text content from a module matrix.  public static bool trydecode(skbitmap bitmap, out string text); detects and decodes a qr code from a bitmap image. tier-1/2 image support: clean, well-lit images such as screenshots, rendered qr codes and scans, including arbitrary rotation, mirroring, reflectance reversal (light-on-dark) and mild perspective distortion. photos with strong perspective distortion, uneven lighting or blur are out of scope — use a computer-vision grade reader (e.g. zxing.net) for those. public static bool trydecode(skbitmap bitmap, out string text, out qrcodedecodeinfo info); detects and decodes a qr code from a bitmap image, with diagnostic information. tier-1/2 image support: clean, well-lit images such as screenshots, rendered qr codes and scans, including arbitrary rotation, mirroring, reflectance reversal (light-on-dark) and mild perspective distortion. photos with strong perspective distortion, uneven lighting or blur are out of scope — use a computer-vision grade reader (e.g. zxing.net) for those. public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, span&lt;char&gt; destination, out int charswritten, out qrcodedecodeinfo info); detects and decodes a qr code from grayscale image pixels into a caller-provided buffer without per-call heap allocation.  public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, out string text, out qrcodedecodeinfo info); detects and decodes a qr code from grayscale image pixels.  public static int getmaxdecodedlength(int version); calculates the maximum possible decoded character count for a qr code version, across all ecc levels and encoding modes. use to size the destination buffer for the allocation-free trydecode overload. ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeDecoder" aria-label="Link to SkiaSharp.QrCode.QRCodeDecoder">#</a><code>public static class QRCodeDecoder</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.QRCodeDecoder" data-name="skiasharp.qrcode.qrcodedecoder" data-text="skiasharp.qrcode.qrcodedecoder public static class qrcodedecoder qr code decoder based on iso/iec 18004 standard. decodes qr module matrices back into text, including reed-solomon error correction. supported content: numeric, alphanumeric and byte mode segments (iso-8859-1 and utf-8, with or without eci headers), the full version range 1-40 and all ecc levels. kanji mode is decoded as jis x 0208; the generator never emits it, so kanji is a read-only mode here. a kanji cell outside the jis x 0208 repertoire (most visibly the nec row 13 characters cp932 adds, such as circled digits) fails the whole symbol with unmappedcharacter rather than substituting a replacement character; that status is distinct from unsupportedcontent so a caller can tell &quot;a cp932 reader would read this&quot; from &quot;this uses a feature we do not implement&quot;. fnc1 and structured append are the latter. byte segments without an eci header have no declared charset. the decoder uses utf-8 when the payload is valid utf-8 (or carries a bom) and iso-8859-1 otherwise. method public static bool trydecode(qrcodedata data, out string text); decodes the text content from qr code data.  method public static bool trydecode(qrcodedata data, out string text, out qrcodedecodeinfo info); decodes the text content from qr code data, with diagnostic information.  method public static bool trydecode(readonlyspan&lt;byte&gt; modules, int size, span&lt;char&gt; destination, out int charswritten, out qrcodedecodeinfo info); decodes the text content from a module matrix into a caller-provided buffer without per-call heap allocation.  method public static bool trydecode(readonlyspan&lt;byte&gt; modules, int size, out string text, out qrcodedecodeinfo info); decodes the text content from a module matrix.  method public static bool trydecode(skbitmap bitmap, out string text); detects and decodes a qr code from a bitmap image. tier-1/2 image support: clean, well-lit images such as screenshots, rendered qr codes and scans, including arbitrary rotation, mirroring, reflectance reversal (light-on-dark) and mild perspective distortion. photos with strong perspective distortion, uneven lighting or blur are out of scope — use a computer-vision grade reader (e.g. zxing.net) for those. method public static bool trydecode(skbitmap bitmap, out string text, out qrcodedecodeinfo info); detects and decodes a qr code from a bitmap image, with diagnostic information. tier-1/2 image support: clean, well-lit images such as screenshots, rendered qr codes and scans, including arbitrary rotation, mirroring, reflectance reversal (light-on-dark) and mild perspective distortion. photos with strong perspective distortion, uneven lighting or blur are out of scope — use a computer-vision grade reader (e.g. zxing.net) for those. method public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, span&lt;char&gt; destination, out int charswritten, out qrcodedecodeinfo info); detects and decodes a qr code from grayscale image pixels into a caller-provided buffer without per-call heap allocation.  method public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, out string text, out qrcodedecodeinfo info); detects and decodes a qr code from grayscale image pixels.  method public static int getmaxdecodedlength(int version); calculates the maximum possible decoded character count for a qr code version, across all ecc levels and encoding modes. use to size the destination buffer for the allocation-free trydecode overload. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeDecoder" aria-label="Link to SkiaSharp.QrCode.QRCodeDecoder">#</a><span class="kind">class</span> <span class="name">QRCodeDecoder</span></h3>
+          <pre class="sig"><code>public static class QRCodeDecoder</code></pre>
           <p class="doc">QR code decoder based on ISO/IEC 18004 standard. Decodes QR module matrices back into text, including Reed-Solomon error correction.</p>
           <details class="notes" data-text="supported content: numeric, alphanumeric and byte mode segments (iso-8859-1 and utf-8, with or without eci headers), the full version range 1-40 and all ecc levels. kanji mode is decoded as jis x 0208; the generator never emits it, so kanji is a read-only mode here. a kanji cell outside the jis x 0208 repertoire (most visibly the nec row 13 characters cp932 adds, such as circled digits) fails the whole symbol with unmappedcharacter rather than substituting a replacement character; that status is distinct from unsupportedcontent so a caller can tell &quot;a cp932 reader would read this&quot; from &quot;this uses a feature we do not implement&quot;. fnc1 and structured append are the latter. byte segments without an eci header have no declared charset. the decoder uses utf-8 when the payload is valid utf-8 (or carries a bom) and iso-8859-1 otherwise.">
             <summary>Notes</summary>
             <p class="doc remarks">Supported content: Numeric, Alphanumeric and Byte mode segments (ISO-8859-1 and UTF-8, with or without ECI headers), the full version range 1-40 and all ECC levels. Kanji mode is decoded as JIS X 0208; the generator never emits it, so Kanji is a read-only mode here. A Kanji cell outside the JIS X 0208 repertoire (most visibly the NEC row 13 characters CP932 adds, such as circled digits) fails the WHOLE symbol with UnmappedCharacter rather than substituting a replacement character; that status is distinct from UnsupportedContent so a caller can tell &quot;a CP932 reader would read this&quot; from &quot;this uses a feature we do not implement&quot;. FNC1 and Structured Append are the latter. Byte segments without an ECI header have no declared charset. The decoder uses UTF-8 when the payload is valid UTF-8 (or carries a BOM) and ISO-8859-1 otherwise.</p>
           </details>
           <div class="members">
-            <div class="member" data-text="public static bool trydecode(qrcodedata data, out string text); decodes the text content from qr code data. ">
-              <code>public static bool TryDecode(QRCodeData data, out string text);</code>
+            <div class="member" data-text="method public static bool trydecode(qrcodedata data, out string text); decodes the text content from qr code data. ">
+              <h4><span class="kind">method</span> <span class="name">TryDecode</span></h4>
+              <pre class="sig"><code>public static bool TryDecode(QRCodeData data, out string text);</code></pre>
               <p class="doc">Decodes the text content from QR code data.</p>
             </div>
-            <div class="member" data-text="public static bool trydecode(qrcodedata data, out string text, out qrcodedecodeinfo info); decodes the text content from qr code data, with diagnostic information. ">
-              <code>public static bool TryDecode(QRCodeData data, out string text, out QRCodeDecodeInfo info);</code>
+            <div class="member" data-text="method public static bool trydecode(qrcodedata data, out string text, out qrcodedecodeinfo info); decodes the text content from qr code data, with diagnostic information. ">
+              <h4><span class="kind">method</span> <span class="name">TryDecode</span></h4>
+              <pre class="sig"><code>public static bool TryDecode(QRCodeData data, out string text, out QRCodeDecodeInfo info);</code></pre>
               <p class="doc">Decodes the text content from QR code data, with diagnostic information.</p>
             </div>
-            <div class="member" data-text="public static bool trydecode(readonlyspan&lt;byte&gt; modules, int size, span&lt;char&gt; destination, out int charswritten, out qrcodedecodeinfo info); decodes the text content from a module matrix into a caller-provided buffer without per-call heap allocation. ">
-              <code>public static bool TryDecode(ReadOnlySpan&lt;byte&gt; modules, int size, Span&lt;char&gt; destination, out int charsWritten, out QRCodeDecodeInfo info);</code>
+            <div class="member" data-text="method public static bool trydecode(readonlyspan&lt;byte&gt; modules, int size, span&lt;char&gt; destination, out int charswritten, out qrcodedecodeinfo info); decodes the text content from a module matrix into a caller-provided buffer without per-call heap allocation. ">
+              <h4><span class="kind">method</span> <span class="name">TryDecode</span></h4>
+              <pre class="sig"><code>public static bool TryDecode(ReadOnlySpan&lt;byte&gt; modules, int size, Span&lt;char&gt; destination, out int charsWritten, out QRCodeDecodeInfo info);</code></pre>
               <p class="doc">Decodes the text content from a module matrix into a caller-provided buffer without per-call heap allocation.</p>
             </div>
-            <div class="member" data-text="public static bool trydecode(readonlyspan&lt;byte&gt; modules, int size, out string text, out qrcodedecodeinfo info); decodes the text content from a module matrix. ">
-              <code>public static bool TryDecode(ReadOnlySpan&lt;byte&gt; modules, int size, out string text, out QRCodeDecodeInfo info);</code>
+            <div class="member" data-text="method public static bool trydecode(readonlyspan&lt;byte&gt; modules, int size, out string text, out qrcodedecodeinfo info); decodes the text content from a module matrix. ">
+              <h4><span class="kind">method</span> <span class="name">TryDecode</span></h4>
+              <pre class="sig"><code>public static bool TryDecode(ReadOnlySpan&lt;byte&gt; modules, int size, out string text, out QRCodeDecodeInfo info);</code></pre>
               <p class="doc">Decodes the text content from a module matrix.</p>
             </div>
-            <div class="member" data-text="public static bool trydecode(skbitmap bitmap, out string text); detects and decodes a qr code from a bitmap image. tier-1/2 image support: clean, well-lit images such as screenshots, rendered qr codes and scans, including arbitrary rotation, mirroring, reflectance reversal (light-on-dark) and mild perspective distortion. photos with strong perspective distortion, uneven lighting or blur are out of scope — use a computer-vision grade reader (e.g. zxing.net) for those.">
-              <code>public static bool TryDecode(SKBitmap bitmap, out string text);</code>
+            <div class="member" data-text="method public static bool trydecode(skbitmap bitmap, out string text); detects and decodes a qr code from a bitmap image. tier-1/2 image support: clean, well-lit images such as screenshots, rendered qr codes and scans, including arbitrary rotation, mirroring, reflectance reversal (light-on-dark) and mild perspective distortion. photos with strong perspective distortion, uneven lighting or blur are out of scope — use a computer-vision grade reader (e.g. zxing.net) for those.">
+              <h4><span class="kind">method</span> <span class="name">TryDecode</span></h4>
+              <pre class="sig"><code>public static bool TryDecode(SKBitmap bitmap, out string text);</code></pre>
               <p class="doc">Detects and decodes a QR code from a bitmap image.</p>
               <details class="notes" data-text="tier-1/2 image support: clean, well-lit images such as screenshots, rendered qr codes and scans, including arbitrary rotation, mirroring, reflectance reversal (light-on-dark) and mild perspective distortion. photos with strong perspective distortion, uneven lighting or blur are out of scope — use a computer-vision grade reader (e.g. zxing.net) for those.">
                 <summary>Notes</summary>
                 <p class="doc remarks">Tier-1/2 image support: clean, well-lit images such as screenshots, rendered QR codes and scans, including arbitrary rotation, mirroring, reflectance reversal (light-on-dark) and mild perspective distortion. Photos with strong perspective distortion, uneven lighting or blur are out of scope — use a computer-vision grade reader (e.g. ZXing.Net) for those.</p>
               </details>
             </div>
-            <div class="member" data-text="public static bool trydecode(skbitmap bitmap, out string text, out qrcodedecodeinfo info); detects and decodes a qr code from a bitmap image, with diagnostic information. tier-1/2 image support: clean, well-lit images such as screenshots, rendered qr codes and scans, including arbitrary rotation, mirroring, reflectance reversal (light-on-dark) and mild perspective distortion. photos with strong perspective distortion, uneven lighting or blur are out of scope — use a computer-vision grade reader (e.g. zxing.net) for those.">
-              <code>public static bool TryDecode(SKBitmap bitmap, out string text, out QRCodeDecodeInfo info);</code>
+            <div class="member" data-text="method public static bool trydecode(skbitmap bitmap, out string text, out qrcodedecodeinfo info); detects and decodes a qr code from a bitmap image, with diagnostic information. tier-1/2 image support: clean, well-lit images such as screenshots, rendered qr codes and scans, including arbitrary rotation, mirroring, reflectance reversal (light-on-dark) and mild perspective distortion. photos with strong perspective distortion, uneven lighting or blur are out of scope — use a computer-vision grade reader (e.g. zxing.net) for those.">
+              <h4><span class="kind">method</span> <span class="name">TryDecode</span></h4>
+              <pre class="sig"><code>public static bool TryDecode(SKBitmap bitmap, out string text, out QRCodeDecodeInfo info);</code></pre>
               <p class="doc">Detects and decodes a QR code from a bitmap image, with diagnostic information.</p>
               <details class="notes" data-text="tier-1/2 image support: clean, well-lit images such as screenshots, rendered qr codes and scans, including arbitrary rotation, mirroring, reflectance reversal (light-on-dark) and mild perspective distortion. photos with strong perspective distortion, uneven lighting or blur are out of scope — use a computer-vision grade reader (e.g. zxing.net) for those.">
                 <summary>Notes</summary>
                 <p class="doc remarks">Tier-1/2 image support: clean, well-lit images such as screenshots, rendered QR codes and scans, including arbitrary rotation, mirroring, reflectance reversal (light-on-dark) and mild perspective distortion. Photos with strong perspective distortion, uneven lighting or blur are out of scope — use a computer-vision grade reader (e.g. ZXing.Net) for those.</p>
               </details>
             </div>
-            <div class="member" data-text="public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, span&lt;char&gt; destination, out int charswritten, out qrcodedecodeinfo info); detects and decodes a qr code from grayscale image pixels into a caller-provided buffer without per-call heap allocation. ">
-              <code>public static bool TryDecodeImage(ReadOnlySpan&lt;byte&gt; luminance, int width, int height, Span&lt;char&gt; destination, out int charsWritten, out QRCodeDecodeInfo info);</code>
+            <div class="member" data-text="method public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, span&lt;char&gt; destination, out int charswritten, out qrcodedecodeinfo info); detects and decodes a qr code from grayscale image pixels into a caller-provided buffer without per-call heap allocation. ">
+              <h4><span class="kind">method</span> <span class="name">TryDecodeImage</span></h4>
+              <pre class="sig"><code>public static bool TryDecodeImage(ReadOnlySpan&lt;byte&gt; luminance, int width, int height, Span&lt;char&gt; destination, out int charsWritten, out QRCodeDecodeInfo info);</code></pre>
               <p class="doc">Detects and decodes a QR code from grayscale image pixels into a caller-provided buffer without per-call heap allocation.</p>
             </div>
-            <div class="member" data-text="public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, out string text, out qrcodedecodeinfo info); detects and decodes a qr code from grayscale image pixels. ">
-              <code>public static bool TryDecodeImage(ReadOnlySpan&lt;byte&gt; luminance, int width, int height, out string text, out QRCodeDecodeInfo info);</code>
+            <div class="member" data-text="method public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, out string text, out qrcodedecodeinfo info); detects and decodes a qr code from grayscale image pixels. ">
+              <h4><span class="kind">method</span> <span class="name">TryDecodeImage</span></h4>
+              <pre class="sig"><code>public static bool TryDecodeImage(ReadOnlySpan&lt;byte&gt; luminance, int width, int height, out string text, out QRCodeDecodeInfo info);</code></pre>
               <p class="doc">Detects and decodes a QR code from grayscale image pixels.</p>
             </div>
-            <div class="member" data-text="public static int getmaxdecodedlength(int version); calculates the maximum possible decoded character count for a qr code version, across all ecc levels and encoding modes. use to size the destination buffer for the allocation-free trydecode overload. ">
-              <code>public static int GetMaxDecodedLength(int version);</code>
+            <div class="member" data-text="method public static int getmaxdecodedlength(int version); calculates the maximum possible decoded character count for a qr code version, across all ecc levels and encoding modes. use to size the destination buffer for the allocation-free trydecode overload. ">
+              <h4><span class="kind">method</span> <span class="name">GetMaxDecodedLength</span></h4>
+              <pre class="sig"><code>public static int GetMaxDecodedLength(int version);</code></pre>
               <p class="doc">Calculates the maximum possible decoded character count for a QR code version, across all ECC levels and encoding modes. Use to size the destination buffer for the allocation-free TryDecode overload.</p>
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.QRCodeExtensions" data-name="skiasharp.qrcode.qrcodeextensions" data-text="skiasharp.qrcode.qrcodeextensions public static class qrcodeextensions extension methods that render a qr, micro qr or rmqr symbol onto an skcanvas you already have, instead of producing an image file. each method clears the whole canvas before drawing, so anything already on it is lost. to place a symbol inside a larger drawing, wrap the call in save and cliprect , or call qrcoderenderer directly, which draws only the symbol. public static void render(skcanvas canvas, microqrcodedata data, skrect area, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); renders a micro qr code on the canvas with custom colors. micro qr does not offer the standard qr icon overlay or custom finder pattern shape options (single finder pattern, no error-correction headroom for overlays). public static void render(skcanvas canvas, microqrcodedata data, int width, int height, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); renders a micro qr code on the canvas with default colors. micro qr does not offer the standard qr icon overlay or custom finder pattern shape options (single finder pattern, no error-correction headroom for overlays). public static void render(skcanvas canvas, qrcodedata data, skrect area, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, icondata? icondata = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null, finderpatternshape? finderpatternshape = null); renders a qr code on the canvas with custom colors.  public static void render(skcanvas canvas, qrcodedata data, int width, int height, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, icondata? icondata = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null, finderpatternshape? finderpatternshape = null); renders a qr code on the canvas with default colors.  public static void render(skcanvas canvas, rmqrcodedata data, skrect area, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); renders an rmqr code on the canvas with custom colors. the rectangular symbol (quiet zone included) is drawn with a uniform module scale and centered in the area (letterbox); the whole area receives the background color. rmqr offers no icon overlay or finder styling options. public static void render(skcanvas canvas, rmqrcodedata data, int width, int height, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); renders an rmqr code on the canvas with default colors. the rectangular symbol (quiet zone included) is drawn with a uniform module scale and centered in the area (letterbox); the whole area receives the background color. rmqr offers no icon overlay or finder styling options.">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeExtensions" aria-label="Link to SkiaSharp.QrCode.QRCodeExtensions">#</a><code>public static class QRCodeExtensions</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.QRCodeExtensions" data-name="skiasharp.qrcode.qrcodeextensions" data-text="skiasharp.qrcode.qrcodeextensions public static class qrcodeextensions extension methods that render a qr, micro qr or rmqr symbol onto an skcanvas you already have, instead of producing an image file. each method clears the whole canvas before drawing, so anything already on it is lost. to place a symbol inside a larger drawing, wrap the call in save and cliprect , or call qrcoderenderer directly, which draws only the symbol. method public static void render(skcanvas canvas, microqrcodedata data, skrect area, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); renders a micro qr code on the canvas with custom colors. micro qr does not offer the standard qr icon overlay or custom finder pattern shape options (single finder pattern, no error-correction headroom for overlays). method public static void render(skcanvas canvas, microqrcodedata data, int width, int height, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); renders a micro qr code on the canvas with default colors. micro qr does not offer the standard qr icon overlay or custom finder pattern shape options (single finder pattern, no error-correction headroom for overlays). method public static void render(skcanvas canvas, qrcodedata data, skrect area, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, icondata? icondata = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null, finderpatternshape? finderpatternshape = null); renders a qr code on the canvas with custom colors.  method public static void render(skcanvas canvas, qrcodedata data, int width, int height, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, icondata? icondata = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null, finderpatternshape? finderpatternshape = null); renders a qr code on the canvas with default colors.  method public static void render(skcanvas canvas, rmqrcodedata data, skrect area, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); renders an rmqr code on the canvas with custom colors. the rectangular symbol (quiet zone included) is drawn with a uniform module scale and centered in the area (letterbox); the whole area receives the background color. rmqr offers no icon overlay or finder styling options. method public static void render(skcanvas canvas, rmqrcodedata data, int width, int height, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); renders an rmqr code on the canvas with default colors. the rectangular symbol (quiet zone included) is drawn with a uniform module scale and centered in the area (letterbox); the whole area receives the background color. rmqr offers no icon overlay or finder styling options.">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeExtensions" aria-label="Link to SkiaSharp.QrCode.QRCodeExtensions">#</a><span class="kind">class</span> <span class="name">QRCodeExtensions</span></h3>
+          <pre class="sig"><code>public static class QRCodeExtensions</code></pre>
           <p class="doc">Extension methods that render a QR, Micro QR or rMQR symbol onto an SKCanvas you already have, instead of producing an image file.</p>
           <details class="notes" data-text="each method clears the whole canvas before drawing, so anything already on it is lost. to place a symbol inside a larger drawing, wrap the call in save and cliprect , or call qrcoderenderer directly, which draws only the symbol.">
             <summary>Notes</summary>
             <p class="doc remarks">Each method clears the whole canvas before drawing, so anything already on it is lost. To place a symbol inside a larger drawing, wrap the call in Save and ClipRect , or call QRCodeRenderer directly, which draws only the symbol.</p>
           </details>
           <div class="members">
-            <div class="member" data-text="public static void render(skcanvas canvas, microqrcodedata data, skrect area, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); renders a micro qr code on the canvas with custom colors. micro qr does not offer the standard qr icon overlay or custom finder pattern shape options (single finder pattern, no error-correction headroom for overlays).">
-              <code>public static void Render(SKCanvas canvas, MicroQRCodeData data, SKRect area, SKColor? clearColor = null, SKColor? codeColor = null, SKColor? backgroundColor = null, ModuleShape? moduleShape = null, float moduleSizePercent = 1, GradientOptions? gradientOptions = null);</code>
+            <div class="member" data-text="method public static void render(skcanvas canvas, microqrcodedata data, skrect area, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); renders a micro qr code on the canvas with custom colors. micro qr does not offer the standard qr icon overlay or custom finder pattern shape options (single finder pattern, no error-correction headroom for overlays).">
+              <h4><span class="kind">method</span> <span class="name">Render</span></h4>
+              <pre class="sig"><code>public static void Render(SKCanvas canvas, MicroQRCodeData data, SKRect area, SKColor? clearColor = null, SKColor? codeColor = null, SKColor? backgroundColor = null, ModuleShape? moduleShape = null, float moduleSizePercent = 1, GradientOptions? gradientOptions = null);</code></pre>
               <p class="doc">Renders a Micro QR code on the canvas with custom colors.</p>
               <details class="notes" data-text="micro qr does not offer the standard qr icon overlay or custom finder pattern shape options (single finder pattern, no error-correction headroom for overlays).">
                 <summary>Notes</summary>
                 <p class="doc remarks">Micro QR does not offer the Standard QR icon overlay or custom finder pattern shape options (single finder pattern, no error-correction headroom for overlays).</p>
               </details>
             </div>
-            <div class="member" data-text="public static void render(skcanvas canvas, microqrcodedata data, int width, int height, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); renders a micro qr code on the canvas with default colors. micro qr does not offer the standard qr icon overlay or custom finder pattern shape options (single finder pattern, no error-correction headroom for overlays).">
-              <code>public static void Render(SKCanvas canvas, MicroQRCodeData data, int width, int height, SKColor? clearColor = null, SKColor? codeColor = null, SKColor? backgroundColor = null, ModuleShape? moduleShape = null, float moduleSizePercent = 1, GradientOptions? gradientOptions = null);</code>
+            <div class="member" data-text="method public static void render(skcanvas canvas, microqrcodedata data, int width, int height, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); renders a micro qr code on the canvas with default colors. micro qr does not offer the standard qr icon overlay or custom finder pattern shape options (single finder pattern, no error-correction headroom for overlays).">
+              <h4><span class="kind">method</span> <span class="name">Render</span></h4>
+              <pre class="sig"><code>public static void Render(SKCanvas canvas, MicroQRCodeData data, int width, int height, SKColor? clearColor = null, SKColor? codeColor = null, SKColor? backgroundColor = null, ModuleShape? moduleShape = null, float moduleSizePercent = 1, GradientOptions? gradientOptions = null);</code></pre>
               <p class="doc">Renders a Micro QR code on the canvas with default colors.</p>
               <details class="notes" data-text="micro qr does not offer the standard qr icon overlay or custom finder pattern shape options (single finder pattern, no error-correction headroom for overlays).">
                 <summary>Notes</summary>
                 <p class="doc remarks">Micro QR does not offer the Standard QR icon overlay or custom finder pattern shape options (single finder pattern, no error-correction headroom for overlays).</p>
               </details>
             </div>
-            <div class="member" data-text="public static void render(skcanvas canvas, qrcodedata data, skrect area, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, icondata? icondata = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null, finderpatternshape? finderpatternshape = null); renders a qr code on the canvas with custom colors. ">
-              <code>public static void Render(SKCanvas canvas, QRCodeData data, SKRect area, SKColor? clearColor = null, SKColor? codeColor = null, SKColor? backgroundColor = null, IconData? iconData = null, ModuleShape? moduleShape = null, float moduleSizePercent = 1, GradientOptions? gradientOptions = null, FinderPatternShape? finderPatternShape = null);</code>
+            <div class="member" data-text="method public static void render(skcanvas canvas, qrcodedata data, skrect area, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, icondata? icondata = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null, finderpatternshape? finderpatternshape = null); renders a qr code on the canvas with custom colors. ">
+              <h4><span class="kind">method</span> <span class="name">Render</span></h4>
+              <pre class="sig"><code>public static void Render(SKCanvas canvas, QRCodeData data, SKRect area, SKColor? clearColor = null, SKColor? codeColor = null, SKColor? backgroundColor = null, IconData? iconData = null, ModuleShape? moduleShape = null, float moduleSizePercent = 1, GradientOptions? gradientOptions = null, FinderPatternShape? finderPatternShape = null);</code></pre>
               <p class="doc">Renders a QR code on the canvas with custom colors.</p>
             </div>
-            <div class="member" data-text="public static void render(skcanvas canvas, qrcodedata data, int width, int height, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, icondata? icondata = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null, finderpatternshape? finderpatternshape = null); renders a qr code on the canvas with default colors. ">
-              <code>public static void Render(SKCanvas canvas, QRCodeData data, int width, int height, SKColor? clearColor = null, SKColor? codeColor = null, SKColor? backgroundColor = null, IconData? iconData = null, ModuleShape? moduleShape = null, float moduleSizePercent = 1, GradientOptions? gradientOptions = null, FinderPatternShape? finderPatternShape = null);</code>
+            <div class="member" data-text="method public static void render(skcanvas canvas, qrcodedata data, int width, int height, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, icondata? icondata = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null, finderpatternshape? finderpatternshape = null); renders a qr code on the canvas with default colors. ">
+              <h4><span class="kind">method</span> <span class="name">Render</span></h4>
+              <pre class="sig"><code>public static void Render(SKCanvas canvas, QRCodeData data, int width, int height, SKColor? clearColor = null, SKColor? codeColor = null, SKColor? backgroundColor = null, IconData? iconData = null, ModuleShape? moduleShape = null, float moduleSizePercent = 1, GradientOptions? gradientOptions = null, FinderPatternShape? finderPatternShape = null);</code></pre>
               <p class="doc">Renders a QR code on the canvas with default colors.</p>
             </div>
-            <div class="member" data-text="public static void render(skcanvas canvas, rmqrcodedata data, skrect area, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); renders an rmqr code on the canvas with custom colors. the rectangular symbol (quiet zone included) is drawn with a uniform module scale and centered in the area (letterbox); the whole area receives the background color. rmqr offers no icon overlay or finder styling options.">
-              <code>public static void Render(SKCanvas canvas, RmQRCodeData data, SKRect area, SKColor? clearColor = null, SKColor? codeColor = null, SKColor? backgroundColor = null, ModuleShape? moduleShape = null, float moduleSizePercent = 1, GradientOptions? gradientOptions = null);</code>
+            <div class="member" data-text="method public static void render(skcanvas canvas, rmqrcodedata data, skrect area, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); renders an rmqr code on the canvas with custom colors. the rectangular symbol (quiet zone included) is drawn with a uniform module scale and centered in the area (letterbox); the whole area receives the background color. rmqr offers no icon overlay or finder styling options.">
+              <h4><span class="kind">method</span> <span class="name">Render</span></h4>
+              <pre class="sig"><code>public static void Render(SKCanvas canvas, RmQRCodeData data, SKRect area, SKColor? clearColor = null, SKColor? codeColor = null, SKColor? backgroundColor = null, ModuleShape? moduleShape = null, float moduleSizePercent = 1, GradientOptions? gradientOptions = null);</code></pre>
               <p class="doc">Renders an rMQR code on the canvas with custom colors.</p>
               <details class="notes" data-text="the rectangular symbol (quiet zone included) is drawn with a uniform module scale and centered in the area (letterbox); the whole area receives the background color. rmqr offers no icon overlay or finder styling options.">
                 <summary>Notes</summary>
                 <p class="doc remarks">The rectangular symbol (quiet zone included) is drawn with a uniform module scale and centered in the area (letterbox); the whole area receives the background color. rMQR offers no icon overlay or finder styling options.</p>
               </details>
             </div>
-            <div class="member" data-text="public static void render(skcanvas canvas, rmqrcodedata data, int width, int height, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); renders an rmqr code on the canvas with default colors. the rectangular symbol (quiet zone included) is drawn with a uniform module scale and centered in the area (letterbox); the whole area receives the background color. rmqr offers no icon overlay or finder styling options.">
-              <code>public static void Render(SKCanvas canvas, RmQRCodeData data, int width, int height, SKColor? clearColor = null, SKColor? codeColor = null, SKColor? backgroundColor = null, ModuleShape? moduleShape = null, float moduleSizePercent = 1, GradientOptions? gradientOptions = null);</code>
+            <div class="member" data-text="method public static void render(skcanvas canvas, rmqrcodedata data, int width, int height, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); renders an rmqr code on the canvas with default colors. the rectangular symbol (quiet zone included) is drawn with a uniform module scale and centered in the area (letterbox); the whole area receives the background color. rmqr offers no icon overlay or finder styling options.">
+              <h4><span class="kind">method</span> <span class="name">Render</span></h4>
+              <pre class="sig"><code>public static void Render(SKCanvas canvas, RmQRCodeData data, int width, int height, SKColor? clearColor = null, SKColor? codeColor = null, SKColor? backgroundColor = null, ModuleShape? moduleShape = null, float moduleSizePercent = 1, GradientOptions? gradientOptions = null);</code></pre>
               <p class="doc">Renders an rMQR code on the canvas with default colors.</p>
               <details class="notes" data-text="the rectangular symbol (quiet zone included) is drawn with a uniform module scale and centered in the area (letterbox); the whole area receives the background color. rmqr offers no icon overlay or finder styling options.">
                 <summary>Notes</summary>
@@ -1121,148 +1252,174 @@
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.QRCodeGenerator" data-name="skiasharp.qrcode.qrcodegenerator" data-text="skiasharp.qrcode.qrcodegenerator public static class qrcodegenerator qr code generator based on iso/iec 18004 standard. supports qr code versions 1-40 with multiple encoding modes and error correction levels. encoding modes written here are numeric, alphanumeric and byte (iso-8859-1 / utf-8, with eci). kanji mode is never written, japanese text goes out as utf-8 in byte mode; qrcodedecoder does read kanji segments other encoders produce, so the two directions are deliberately asymmetric. [obsolete] public static qrcodecalculatedsize getrequiredbuffersize(readonlyspan&lt;char&gt; text, ecclevel ecclevel, bool utf8bom = false, ecimode ecimode = 0, int quietzonesize = 4); calculates the required buffer size for encoding the specified text as a qr code.  public static qrcodedata createqrcode(readonlyspan&lt;char&gt; textspan, ecclevel ecclevel, bool utf8bom = false, ecimode ecimode = 0, int requestedversion = -1, int quietzonesize = 4); creates a qr code from the provided plain text.  public static qrcodedata createqrcode(readonlyspan&lt;char&gt; textspan, ecclevel ecclevel, in qrcodegeneratoroptions options);  public static qrcodedata createqrcode(string plaintext, ecclevel ecclevel, bool utf8bom = false, ecimode ecimode = 0, int requestedversion = -1, int quietzonesize = 4); creates a qr code from the provided plain text.  public static qrcodedata createqrcode(string plaintext, ecclevel ecclevel, in qrcodegeneratoroptions options);  public static bool trygetrequiredbuffersize(readonlyspan&lt;char&gt; text, ecclevel ecclevel, out qrcodecalculatedsize size, in qrcodegeneratoroptions options = null); calculates the required buffer size, matrix size and version for encoding the specified text as a qr code, reporting content that does not fit as false rather than as an exception. false means the content does not fit, and nothing else: argument errors throw (rationale: specs/rmqr-encoder.md). when version is narrower than any , that means no version in that range holds the content, not merely that it exceeds version 40. boostecclevel has no effect here: the boost never changes the version, and the buffer size depends only on the version. pass the same options you will encode with: segmentation and ecimode can select different versions, so a buffer sized for one can be too small for the other. public static int createqrcode(readonlyspan&lt;char&gt; textspan, ecclevel ecclevel, span&lt;byte&gt; destination, bool utf8bom = false, ecimode ecimode = 0, int requestedversion = -1, int quietzonesize = 4); creates a qr code from the provided plain text and writes the module matrix into the caller-provided buffer without per-call heap allocation. output format: one byte per module (0 = light, 1 = dark), flat row-major order, quiet zone included. module at (row, col) is destination[row * qrsize + col] where qrsize is qrsize returned by trygetrequiredbuffersize . usage flow for allocation-free generation: if (!qrcodegenerator.trygetrequiredbuffersize(text, ecclevel.m, out var calculated, qrcodegeneratoroptions.default)) return; // content does not fit version 40 at this ecc level var buffer = arraypool&lt;byte&gt;.shared.rent(calculated.buffersize); var written = qrcodegenerator.createqrcode(text, ecclevel.m, buffer); var matrix = buffer.asspan(0, written); // ... consume matrix ... arraypool&lt;byte&gt;.shared.return(buffer); only the first buffersize bytes of destination are written (every byte of that region is written, so a dirty pooled buffer is fine); any remaining bytes are left untouched. public static int createqrcode(readonlyspan&lt;char&gt; textspan, ecclevel ecclevel, span&lt;byte&gt; destination, in qrcodegeneratoroptions options);  public static int createqrcode(string plaintext, ecclevel ecclevel, span&lt;byte&gt; destination, bool utf8bom = false, ecimode ecimode = 0, int requestedversion = -1, int quietzonesize = 4); creates a qr code from the provided plain text and writes the module matrix into the caller-provided buffer without per-call heap allocation.  public static int createqrcode(string plaintext, ecclevel ecclevel, span&lt;byte&gt; destination, in qrcodegeneratoroptions options); ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeGenerator" aria-label="Link to SkiaSharp.QrCode.QRCodeGenerator">#</a><code>public static class QRCodeGenerator</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.QRCodeGenerator" data-name="skiasharp.qrcode.qrcodegenerator" data-text="skiasharp.qrcode.qrcodegenerator public static class qrcodegenerator qr code generator based on iso/iec 18004 standard. supports qr code versions 1-40 with multiple encoding modes and error correction levels. encoding modes written here are numeric, alphanumeric and byte (iso-8859-1 / utf-8, with eci). kanji mode is never written, japanese text goes out as utf-8 in byte mode; qrcodedecoder does read kanji segments other encoders produce, so the two directions are deliberately asymmetric. method [obsolete] public static qrcodecalculatedsize getrequiredbuffersize(readonlyspan&lt;char&gt; text, ecclevel ecclevel, bool utf8bom = false, ecimode ecimode = 0, int quietzonesize = 4); calculates the required buffer size for encoding the specified text as a qr code.  method public static qrcodedata createqrcode(readonlyspan&lt;char&gt; textspan, ecclevel ecclevel, bool utf8bom = false, ecimode ecimode = 0, int requestedversion = -1, int quietzonesize = 4); creates a qr code from the provided plain text.  method public static qrcodedata createqrcode(readonlyspan&lt;char&gt; textspan, ecclevel ecclevel, in qrcodegeneratoroptions options);  method public static qrcodedata createqrcode(string plaintext, ecclevel ecclevel, bool utf8bom = false, ecimode ecimode = 0, int requestedversion = -1, int quietzonesize = 4); creates a qr code from the provided plain text.  method public static qrcodedata createqrcode(string plaintext, ecclevel ecclevel, in qrcodegeneratoroptions options);  method public static bool trygetrequiredbuffersize(readonlyspan&lt;char&gt; text, ecclevel ecclevel, out qrcodecalculatedsize size, in qrcodegeneratoroptions options = null); calculates the required buffer size, matrix size and version for encoding the specified text as a qr code, reporting content that does not fit as false rather than as an exception. false means the content does not fit, and nothing else: argument errors throw (rationale: specs/rmqr-encoder.md). when version is narrower than any , that means no version in that range holds the content, not merely that it exceeds version 40. boostecclevel has no effect here: the boost never changes the version, and the buffer size depends only on the version. pass the same options you will encode with: segmentation and ecimode can select different versions, so a buffer sized for one can be too small for the other. method public static int createqrcode(readonlyspan&lt;char&gt; textspan, ecclevel ecclevel, span&lt;byte&gt; destination, bool utf8bom = false, ecimode ecimode = 0, int requestedversion = -1, int quietzonesize = 4); creates a qr code from the provided plain text and writes the module matrix into the caller-provided buffer without per-call heap allocation. output format: one byte per module (0 = light, 1 = dark), flat row-major order, quiet zone included. module at (row, col) is destination[row * qrsize + col] where qrsize is qrsize returned by trygetrequiredbuffersize . usage flow for allocation-free generation: if (!qrcodegenerator.trygetrequiredbuffersize(text, ecclevel.m, out var calculated, qrcodegeneratoroptions.default)) return; // content does not fit version 40 at this ecc level var buffer = arraypool&lt;byte&gt;.shared.rent(calculated.buffersize); var written = qrcodegenerator.createqrcode(text, ecclevel.m, buffer); var matrix = buffer.asspan(0, written); // ... consume matrix ... arraypool&lt;byte&gt;.shared.return(buffer); only the first buffersize bytes of destination are written (every byte of that region is written, so a dirty pooled buffer is fine); any remaining bytes are left untouched. method public static int createqrcode(readonlyspan&lt;char&gt; textspan, ecclevel ecclevel, span&lt;byte&gt; destination, in qrcodegeneratoroptions options);  method public static int createqrcode(string plaintext, ecclevel ecclevel, span&lt;byte&gt; destination, bool utf8bom = false, ecimode ecimode = 0, int requestedversion = -1, int quietzonesize = 4); creates a qr code from the provided plain text and writes the module matrix into the caller-provided buffer without per-call heap allocation.  method public static int createqrcode(string plaintext, ecclevel ecclevel, span&lt;byte&gt; destination, in qrcodegeneratoroptions options); ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeGenerator" aria-label="Link to SkiaSharp.QrCode.QRCodeGenerator">#</a><span class="kind">class</span> <span class="name">QRCodeGenerator</span></h3>
+          <pre class="sig"><code>public static class QRCodeGenerator</code></pre>
           <p class="doc">QR code generator based on ISO/IEC 18004 standard. Supports QR code versions 1-40 with multiple encoding modes and error correction levels.</p>
           <details class="notes" data-text="encoding modes written here are numeric, alphanumeric and byte (iso-8859-1 / utf-8, with eci). kanji mode is never written, japanese text goes out as utf-8 in byte mode; qrcodedecoder does read kanji segments other encoders produce, so the two directions are deliberately asymmetric.">
             <summary>Notes</summary>
             <p class="doc remarks">Encoding modes written here are Numeric, Alphanumeric and Byte (ISO-8859-1 / UTF-8, with ECI). Kanji mode is never written, Japanese text goes out as UTF-8 in Byte mode; QRCodeDecoder does read Kanji segments other encoders produce, so the two directions are deliberately asymmetric.</p>
           </details>
           <div class="members">
-            <div class="member" data-text="public static qrcodecalculatedsize getrequiredbuffersize(readonlyspan&lt;char&gt; text, ecclevel ecclevel, bool utf8bom = false, ecimode ecimode = 0, int quietzonesize = 4); calculates the required buffer size for encoding the specified text as a qr code. ">
-              <code>public static QRCodeCalculatedSize GetRequiredBufferSize(ReadOnlySpan&lt;char&gt; text, ECCLevel eccLevel, bool utf8BOM = false, EciMode eciMode = 0, int quietZoneSize = 4);</code> <span class="tag">obsolete</span>
+            <div class="member" data-text="method public static qrcodecalculatedsize getrequiredbuffersize(readonlyspan&lt;char&gt; text, ecclevel ecclevel, bool utf8bom = false, ecimode ecimode = 0, int quietzonesize = 4); calculates the required buffer size for encoding the specified text as a qr code. ">
+              <h4><span class="kind">method</span> <span class="name">GetRequiredBufferSize</span> <span class="tag">obsolete</span></h4>
+              <pre class="sig"><code>public static QRCodeCalculatedSize GetRequiredBufferSize(ReadOnlySpan&lt;char&gt; text, ECCLevel eccLevel, bool utf8BOM = false, EciMode eciMode = 0, int quietZoneSize = 4);</code></pre>
               <p class="doc">Calculates the required buffer size for encoding the specified text as a QR code.</p>
             </div>
-            <div class="member" data-text="public static qrcodedata createqrcode(readonlyspan&lt;char&gt; textspan, ecclevel ecclevel, bool utf8bom = false, ecimode ecimode = 0, int requestedversion = -1, int quietzonesize = 4); creates a qr code from the provided plain text. ">
-              <code>public static QRCodeData CreateQrCode(ReadOnlySpan&lt;char&gt; textSpan, ECCLevel eccLevel, bool utf8BOM = false, EciMode eciMode = 0, int requestedVersion = -1, int quietZoneSize = 4);</code>
+            <div class="member" data-text="method public static qrcodedata createqrcode(readonlyspan&lt;char&gt; textspan, ecclevel ecclevel, bool utf8bom = false, ecimode ecimode = 0, int requestedversion = -1, int quietzonesize = 4); creates a qr code from the provided plain text. ">
+              <h4><span class="kind">method</span> <span class="name">CreateQrCode</span></h4>
+              <pre class="sig"><code>public static QRCodeData CreateQrCode(ReadOnlySpan&lt;char&gt; textSpan, ECCLevel eccLevel, bool utf8BOM = false, EciMode eciMode = 0, int requestedVersion = -1, int quietZoneSize = 4);</code></pre>
               <p class="doc">Creates a QR code from the provided plain text.</p>
             </div>
-            <div class="member" data-text="public static qrcodedata createqrcode(readonlyspan&lt;char&gt; textspan, ecclevel ecclevel, in qrcodegeneratoroptions options); ">
-              <code>public static QRCodeData CreateQrCode(ReadOnlySpan&lt;char&gt; textSpan, ECCLevel eccLevel, in QRCodeGeneratorOptions options);</code>
+            <div class="member" data-text="method public static qrcodedata createqrcode(readonlyspan&lt;char&gt; textspan, ecclevel ecclevel, in qrcodegeneratoroptions options); ">
+              <h4><span class="kind">method</span> <span class="name">CreateQrCode</span></h4>
+              <pre class="sig"><code>public static QRCodeData CreateQrCode(ReadOnlySpan&lt;char&gt; textSpan, ECCLevel eccLevel, in QRCodeGeneratorOptions options);</code></pre>
             </div>
-            <div class="member" data-text="public static qrcodedata createqrcode(string plaintext, ecclevel ecclevel, bool utf8bom = false, ecimode ecimode = 0, int requestedversion = -1, int quietzonesize = 4); creates a qr code from the provided plain text. ">
-              <code>public static QRCodeData CreateQrCode(string plainText, ECCLevel eccLevel, bool utf8BOM = false, EciMode eciMode = 0, int requestedVersion = -1, int quietZoneSize = 4);</code>
+            <div class="member" data-text="method public static qrcodedata createqrcode(string plaintext, ecclevel ecclevel, bool utf8bom = false, ecimode ecimode = 0, int requestedversion = -1, int quietzonesize = 4); creates a qr code from the provided plain text. ">
+              <h4><span class="kind">method</span> <span class="name">CreateQrCode</span></h4>
+              <pre class="sig"><code>public static QRCodeData CreateQrCode(string plainText, ECCLevel eccLevel, bool utf8BOM = false, EciMode eciMode = 0, int requestedVersion = -1, int quietZoneSize = 4);</code></pre>
               <p class="doc">Creates a QR code from the provided plain text.</p>
             </div>
-            <div class="member" data-text="public static qrcodedata createqrcode(string plaintext, ecclevel ecclevel, in qrcodegeneratoroptions options); ">
-              <code>public static QRCodeData CreateQrCode(string plainText, ECCLevel eccLevel, in QRCodeGeneratorOptions options);</code>
+            <div class="member" data-text="method public static qrcodedata createqrcode(string plaintext, ecclevel ecclevel, in qrcodegeneratoroptions options); ">
+              <h4><span class="kind">method</span> <span class="name">CreateQrCode</span></h4>
+              <pre class="sig"><code>public static QRCodeData CreateQrCode(string plainText, ECCLevel eccLevel, in QRCodeGeneratorOptions options);</code></pre>
             </div>
-            <div class="member" data-text="public static bool trygetrequiredbuffersize(readonlyspan&lt;char&gt; text, ecclevel ecclevel, out qrcodecalculatedsize size, in qrcodegeneratoroptions options = null); calculates the required buffer size, matrix size and version for encoding the specified text as a qr code, reporting content that does not fit as false rather than as an exception. false means the content does not fit, and nothing else: argument errors throw (rationale: specs/rmqr-encoder.md). when version is narrower than any , that means no version in that range holds the content, not merely that it exceeds version 40. boostecclevel has no effect here: the boost never changes the version, and the buffer size depends only on the version. pass the same options you will encode with: segmentation and ecimode can select different versions, so a buffer sized for one can be too small for the other.">
-              <code>public static bool TryGetRequiredBufferSize(ReadOnlySpan&lt;char&gt; text, ECCLevel eccLevel, out QRCodeCalculatedSize size, in QRCodeGeneratorOptions options = null);</code>
+            <div class="member" data-text="method public static bool trygetrequiredbuffersize(readonlyspan&lt;char&gt; text, ecclevel ecclevel, out qrcodecalculatedsize size, in qrcodegeneratoroptions options = null); calculates the required buffer size, matrix size and version for encoding the specified text as a qr code, reporting content that does not fit as false rather than as an exception. false means the content does not fit, and nothing else: argument errors throw (rationale: specs/rmqr-encoder.md). when version is narrower than any , that means no version in that range holds the content, not merely that it exceeds version 40. boostecclevel has no effect here: the boost never changes the version, and the buffer size depends only on the version. pass the same options you will encode with: segmentation and ecimode can select different versions, so a buffer sized for one can be too small for the other.">
+              <h4><span class="kind">method</span> <span class="name">TryGetRequiredBufferSize</span></h4>
+              <pre class="sig"><code>public static bool TryGetRequiredBufferSize(ReadOnlySpan&lt;char&gt; text, ECCLevel eccLevel, out QRCodeCalculatedSize size, in QRCodeGeneratorOptions options = null);</code></pre>
               <p class="doc">Calculates the required buffer size, matrix size and version for encoding the specified text as a QR code, reporting content that does not fit as false rather than as an exception.</p>
               <details class="notes" data-text="false means the content does not fit, and nothing else: argument errors throw (rationale: specs/rmqr-encoder.md). when version is narrower than any , that means no version in that range holds the content, not merely that it exceeds version 40. boostecclevel has no effect here: the boost never changes the version, and the buffer size depends only on the version. pass the same options you will encode with: segmentation and ecimode can select different versions, so a buffer sized for one can be too small for the other.">
                 <summary>Notes</summary>
                 <p class="doc remarks">false means the content does not fit, and nothing else: argument errors throw (rationale: specs/rmqr-encoder.md). When Version is narrower than Any , that means no version in that range holds the content, not merely that it exceeds version 40. BoostEccLevel has no effect here: the boost never changes the version, and the buffer size depends only on the version. Pass the same options you will encode with: Segmentation and EciMode can select different versions, so a buffer sized for one can be too small for the other.</p>
               </details>
             </div>
-            <div class="member" data-text="public static int createqrcode(readonlyspan&lt;char&gt; textspan, ecclevel ecclevel, span&lt;byte&gt; destination, bool utf8bom = false, ecimode ecimode = 0, int requestedversion = -1, int quietzonesize = 4); creates a qr code from the provided plain text and writes the module matrix into the caller-provided buffer without per-call heap allocation. output format: one byte per module (0 = light, 1 = dark), flat row-major order, quiet zone included. module at (row, col) is destination[row * qrsize + col] where qrsize is qrsize returned by trygetrequiredbuffersize . usage flow for allocation-free generation: if (!qrcodegenerator.trygetrequiredbuffersize(text, ecclevel.m, out var calculated, qrcodegeneratoroptions.default)) return; // content does not fit version 40 at this ecc level var buffer = arraypool&lt;byte&gt;.shared.rent(calculated.buffersize); var written = qrcodegenerator.createqrcode(text, ecclevel.m, buffer); var matrix = buffer.asspan(0, written); // ... consume matrix ... arraypool&lt;byte&gt;.shared.return(buffer); only the first buffersize bytes of destination are written (every byte of that region is written, so a dirty pooled buffer is fine); any remaining bytes are left untouched.">
-              <code>public static int CreateQrCode(ReadOnlySpan&lt;char&gt; textSpan, ECCLevel eccLevel, Span&lt;byte&gt; destination, bool utf8BOM = false, EciMode eciMode = 0, int requestedVersion = -1, int quietZoneSize = 4);</code>
+            <div class="member" data-text="method public static int createqrcode(readonlyspan&lt;char&gt; textspan, ecclevel ecclevel, span&lt;byte&gt; destination, bool utf8bom = false, ecimode ecimode = 0, int requestedversion = -1, int quietzonesize = 4); creates a qr code from the provided plain text and writes the module matrix into the caller-provided buffer without per-call heap allocation. output format: one byte per module (0 = light, 1 = dark), flat row-major order, quiet zone included. module at (row, col) is destination[row * qrsize + col] where qrsize is qrsize returned by trygetrequiredbuffersize . usage flow for allocation-free generation: if (!qrcodegenerator.trygetrequiredbuffersize(text, ecclevel.m, out var calculated, qrcodegeneratoroptions.default)) return; // content does not fit version 40 at this ecc level var buffer = arraypool&lt;byte&gt;.shared.rent(calculated.buffersize); var written = qrcodegenerator.createqrcode(text, ecclevel.m, buffer); var matrix = buffer.asspan(0, written); // ... consume matrix ... arraypool&lt;byte&gt;.shared.return(buffer); only the first buffersize bytes of destination are written (every byte of that region is written, so a dirty pooled buffer is fine); any remaining bytes are left untouched.">
+              <h4><span class="kind">method</span> <span class="name">CreateQrCode</span></h4>
+              <pre class="sig"><code>public static int CreateQrCode(ReadOnlySpan&lt;char&gt; textSpan, ECCLevel eccLevel, Span&lt;byte&gt; destination, bool utf8BOM = false, EciMode eciMode = 0, int requestedVersion = -1, int quietZoneSize = 4);</code></pre>
               <p class="doc">Creates a QR code from the provided plain text and writes the module matrix into the caller-provided buffer without per-call heap allocation.</p>
               <details class="notes" data-text="output format: one byte per module (0 = light, 1 = dark), flat row-major order, quiet zone included. module at (row, col) is destination[row * qrsize + col] where qrsize is qrsize returned by trygetrequiredbuffersize . usage flow for allocation-free generation: if (!qrcodegenerator.trygetrequiredbuffersize(text, ecclevel.m, out var calculated, qrcodegeneratoroptions.default)) return; // content does not fit version 40 at this ecc level var buffer = arraypool&lt;byte&gt;.shared.rent(calculated.buffersize); var written = qrcodegenerator.createqrcode(text, ecclevel.m, buffer); var matrix = buffer.asspan(0, written); // ... consume matrix ... arraypool&lt;byte&gt;.shared.return(buffer); only the first buffersize bytes of destination are written (every byte of that region is written, so a dirty pooled buffer is fine); any remaining bytes are left untouched.">
                 <summary>Notes</summary>
                 <p class="doc remarks">Output format: one byte per module (0 = light, 1 = dark), flat row-major order, quiet zone included. Module at (row, col) is destination[row * qrSize + col] where qrSize is QrSize returned by TryGetRequiredBufferSize . Usage flow for allocation-free generation: if (!QRCodeGenerator.TryGetRequiredBufferSize(text, ECCLevel.M, out var calculated, QRCodeGeneratorOptions.Default)) return; // content does not fit version 40 at this ECC level var buffer = ArrayPool&lt;byte&gt;.Shared.Rent(calculated.BufferSize); var written = QRCodeGenerator.CreateQrCode(text, ECCLevel.M, buffer); var matrix = buffer.AsSpan(0, written); // ... consume matrix ... ArrayPool&lt;byte&gt;.Shared.Return(buffer); Only the first BufferSize bytes of destination are written (every byte of that region is written, so a dirty pooled buffer is fine); any remaining bytes are left untouched.</p>
               </details>
             </div>
-            <div class="member" data-text="public static int createqrcode(readonlyspan&lt;char&gt; textspan, ecclevel ecclevel, span&lt;byte&gt; destination, in qrcodegeneratoroptions options); ">
-              <code>public static int CreateQrCode(ReadOnlySpan&lt;char&gt; textSpan, ECCLevel eccLevel, Span&lt;byte&gt; destination, in QRCodeGeneratorOptions options);</code>
+            <div class="member" data-text="method public static int createqrcode(readonlyspan&lt;char&gt; textspan, ecclevel ecclevel, span&lt;byte&gt; destination, in qrcodegeneratoroptions options); ">
+              <h4><span class="kind">method</span> <span class="name">CreateQrCode</span></h4>
+              <pre class="sig"><code>public static int CreateQrCode(ReadOnlySpan&lt;char&gt; textSpan, ECCLevel eccLevel, Span&lt;byte&gt; destination, in QRCodeGeneratorOptions options);</code></pre>
             </div>
-            <div class="member" data-text="public static int createqrcode(string plaintext, ecclevel ecclevel, span&lt;byte&gt; destination, bool utf8bom = false, ecimode ecimode = 0, int requestedversion = -1, int quietzonesize = 4); creates a qr code from the provided plain text and writes the module matrix into the caller-provided buffer without per-call heap allocation. ">
-              <code>public static int CreateQrCode(string plainText, ECCLevel eccLevel, Span&lt;byte&gt; destination, bool utf8BOM = false, EciMode eciMode = 0, int requestedVersion = -1, int quietZoneSize = 4);</code>
+            <div class="member" data-text="method public static int createqrcode(string plaintext, ecclevel ecclevel, span&lt;byte&gt; destination, bool utf8bom = false, ecimode ecimode = 0, int requestedversion = -1, int quietzonesize = 4); creates a qr code from the provided plain text and writes the module matrix into the caller-provided buffer without per-call heap allocation. ">
+              <h4><span class="kind">method</span> <span class="name">CreateQrCode</span></h4>
+              <pre class="sig"><code>public static int CreateQrCode(string plainText, ECCLevel eccLevel, Span&lt;byte&gt; destination, bool utf8BOM = false, EciMode eciMode = 0, int requestedVersion = -1, int quietZoneSize = 4);</code></pre>
               <p class="doc">Creates a QR code from the provided plain text and writes the module matrix into the caller-provided buffer without per-call heap allocation.</p>
             </div>
-            <div class="member" data-text="public static int createqrcode(string plaintext, ecclevel ecclevel, span&lt;byte&gt; destination, in qrcodegeneratoroptions options); ">
-              <code>public static int CreateQrCode(string plainText, ECCLevel eccLevel, Span&lt;byte&gt; destination, in QRCodeGeneratorOptions options);</code>
+            <div class="member" data-text="method public static int createqrcode(string plaintext, ecclevel ecclevel, span&lt;byte&gt; destination, in qrcodegeneratoroptions options); ">
+              <h4><span class="kind">method</span> <span class="name">CreateQrCode</span></h4>
+              <pre class="sig"><code>public static int CreateQrCode(string plainText, ECCLevel eccLevel, Span&lt;byte&gt; destination, in QRCodeGeneratorOptions options);</code></pre>
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.QRCodeGeneratorOptions" data-name="skiasharp.qrcode.qrcodegeneratoroptions" data-text="skiasharp.qrcode.qrcodegeneratoroptions public readonly struct qrcodegeneratoroptions : iequatable&lt;qrcodegeneratoroptions&gt; optional settings for qrcodegenerator . default is the complete default configuration, so set only what you need: new qrcodegeneratoroptions { ecimode = ecimode.utf8, quietzonesize = 0 }. standard qr specific rather than shared: the three generators agree on almost nothing. version is a different type in each, quietzonesize has a different specified default in each, micro qr has no eci, and rmqr carries fit options that mean nothing here. public ecimode ecimode { get; init; } character encoding declaration. the default auto-detects ascii (no eci), iso-8859-1 (assignment 3) or utf-8 (assignment 26) from the content.  public qrcodesegmentation segmentation { get; init; } how the content is split into encoding-mode segments (see qrcodesegmentation ). defaults to single . optimal never selects a larger version, emits the identical bit stream when a split would not shrink the symbol, and defers to the single-mode stream when utf8bom would actually write a byte order mark. size a destination buffer with the same value you encode with.  public qrcodeversionrange version { get; init; } the versions the generator may choose from. defaults to any ; an int or int? converts implicitly, so version = 15 pins one and a null means automatic.  public bool boostecclevel { get; init; } raise the error correction level above the requested one when the chosen version's capacity allows it, without changing the version. the requested level becomes the minimum; the version is still chosen for it, so boosting never produces a larger symbol, only spends padding that would otherwise be wasted. recommended when an icon or custom module shape overlays the symbol. off by default: a raised level rewrites the format information and can change the chosen mask, so a default of on would silently change every existing symbol. sizing is unaffected either way, the buffer size depends only on the version. public bool utf8bom { get; init; } include a utf-8 byte order mark. ignored unless the content is written as utf-8 in byte mode. when a bom would be written, optimal emits the single-mode stream instead of a split (the bom is a stream-level prefix, and a split would relocate it into the middle of the decoded text).  public int quietzonesize { get; init; } quiet zone width in modules. defaults to 4, the iso/iec 18004 value; 0 is valid.  public int? maskpattern { get; init; } pin one of the eight iso/iec 18004 data mask patterns (0-7) instead of the automatic penalty-scored selection. null (the default) selects the lowest-penalty pattern. any pattern yields a valid, decodable symbol; the automatic choice merely optimizes scan reliability. for reproducing a symbol produced elsewhere byte-for-byte (the pattern another encoder chose is reported by maskpattern ), and for exercising a decoder against all eight patterns. like version , an invalid value is an argument error and is rejected here rather than when a generator reads it. public static qrcodegeneratoroptions default { get; } the default configuration, identical to default. ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeGeneratorOptions" aria-label="Link to SkiaSharp.QrCode.QRCodeGeneratorOptions">#</a><code>public readonly struct QRCodeGeneratorOptions : IEquatable&lt;QRCodeGeneratorOptions&gt;</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.QRCodeGeneratorOptions" data-name="skiasharp.qrcode.qrcodegeneratoroptions" data-text="skiasharp.qrcode.qrcodegeneratoroptions public readonly struct qrcodegeneratoroptions : iequatable&lt;qrcodegeneratoroptions&gt; optional settings for qrcodegenerator . default is the complete default configuration, so set only what you need: new qrcodegeneratoroptions { ecimode = ecimode.utf8, quietzonesize = 0 }. standard qr specific rather than shared: the three generators agree on almost nothing. version is a different type in each, quietzonesize has a different specified default in each, micro qr has no eci, and rmqr carries fit options that mean nothing here. property public ecimode ecimode { get; init; } character encoding declaration. the default auto-detects ascii (no eci), iso-8859-1 (assignment 3) or utf-8 (assignment 26) from the content.  property public qrcodesegmentation segmentation { get; init; } how the content is split into encoding-mode segments (see qrcodesegmentation ). defaults to single . optimal never selects a larger version, emits the identical bit stream when a split would not shrink the symbol, and defers to the single-mode stream when utf8bom would actually write a byte order mark. size a destination buffer with the same value you encode with.  property public qrcodeversionrange version { get; init; } the versions the generator may choose from. defaults to any ; an int or int? converts implicitly, so version = 15 pins one and a null means automatic.  property public bool boostecclevel { get; init; } raise the error correction level above the requested one when the chosen version's capacity allows it, without changing the version. the requested level becomes the minimum; the version is still chosen for it, so boosting never produces a larger symbol, only spends padding that would otherwise be wasted. recommended when an icon or custom module shape overlays the symbol. off by default: a raised level rewrites the format information and can change the chosen mask, so a default of on would silently change every existing symbol. sizing is unaffected either way, the buffer size depends only on the version. property public bool utf8bom { get; init; } include a utf-8 byte order mark. ignored unless the content is written as utf-8 in byte mode. when a bom would be written, optimal emits the single-mode stream instead of a split (the bom is a stream-level prefix, and a split would relocate it into the middle of the decoded text).  property public int quietzonesize { get; init; } quiet zone width in modules. defaults to 4, the iso/iec 18004 value; 0 is valid.  property public int? maskpattern { get; init; } pin one of the eight iso/iec 18004 data mask patterns (0-7) instead of the automatic penalty-scored selection. null (the default) selects the lowest-penalty pattern. any pattern yields a valid, decodable symbol; the automatic choice merely optimizes scan reliability. for reproducing a symbol produced elsewhere byte-for-byte (the pattern another encoder chose is reported by maskpattern ), and for exercising a decoder against all eight patterns. like version , an invalid value is an argument error and is rejected here rather than when a generator reads it. property public static qrcodegeneratoroptions default { get; } the default configuration, identical to default. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeGeneratorOptions" aria-label="Link to SkiaSharp.QrCode.QRCodeGeneratorOptions">#</a><span class="kind">struct</span> <span class="name">QRCodeGeneratorOptions</span></h3>
+          <pre class="sig"><code>public readonly struct QRCodeGeneratorOptions : IEquatable&lt;QRCodeGeneratorOptions&gt;</code></pre>
           <p class="doc">Optional settings for QRCodeGenerator . default is the complete default configuration, so set only what you need: new QRCodeGeneratorOptions { EciMode = EciMode.Utf8, QuietZoneSize = 0 }.</p>
           <details class="notes" data-text="standard qr specific rather than shared: the three generators agree on almost nothing. version is a different type in each, quietzonesize has a different specified default in each, micro qr has no eci, and rmqr carries fit options that mean nothing here.">
             <summary>Notes</summary>
             <p class="doc remarks">Standard QR specific rather than shared: the three generators agree on almost nothing. Version is a different type in each, QuietZoneSize has a different specified default in each, Micro QR has no ECI, and rMQR carries fit options that mean nothing here.</p>
           </details>
           <div class="members">
-            <div class="member" data-text="public ecimode ecimode { get; init; } character encoding declaration. the default auto-detects ascii (no eci), iso-8859-1 (assignment 3) or utf-8 (assignment 26) from the content. ">
-              <code>public EciMode EciMode { get; init; }</code>
+            <div class="member" data-text="property public ecimode ecimode { get; init; } character encoding declaration. the default auto-detects ascii (no eci), iso-8859-1 (assignment 3) or utf-8 (assignment 26) from the content. ">
+              <h4><span class="kind">property</span> <span class="name">EciMode</span></h4>
+              <pre class="sig"><code>public EciMode EciMode { get; init; }</code></pre>
               <p class="doc">Character encoding declaration. The default auto-detects ASCII (no ECI), ISO-8859-1 (assignment 3) or UTF-8 (assignment 26) from the content.</p>
             </div>
-            <div class="member" data-text="public qrcodesegmentation segmentation { get; init; } how the content is split into encoding-mode segments (see qrcodesegmentation ). defaults to single . optimal never selects a larger version, emits the identical bit stream when a split would not shrink the symbol, and defers to the single-mode stream when utf8bom would actually write a byte order mark. size a destination buffer with the same value you encode with. ">
-              <code>public QRCodeSegmentation Segmentation { get; init; }</code>
+            <div class="member" data-text="property public qrcodesegmentation segmentation { get; init; } how the content is split into encoding-mode segments (see qrcodesegmentation ). defaults to single . optimal never selects a larger version, emits the identical bit stream when a split would not shrink the symbol, and defers to the single-mode stream when utf8bom would actually write a byte order mark. size a destination buffer with the same value you encode with. ">
+              <h4><span class="kind">property</span> <span class="name">Segmentation</span></h4>
+              <pre class="sig"><code>public QRCodeSegmentation Segmentation { get; init; }</code></pre>
               <p class="doc">How the content is split into encoding-mode segments (see QRCodeSegmentation ). Defaults to Single . Optimal never selects a larger version, emits the identical bit stream when a split would not shrink the symbol, and defers to the single-mode stream when Utf8BOM would actually write a byte order mark. Size a destination buffer with the same value you encode with.</p>
             </div>
-            <div class="member" data-text="public qrcodeversionrange version { get; init; } the versions the generator may choose from. defaults to any ; an int or int? converts implicitly, so version = 15 pins one and a null means automatic. ">
-              <code>public QRCodeVersionRange Version { get; init; }</code>
+            <div class="member" data-text="property public qrcodeversionrange version { get; init; } the versions the generator may choose from. defaults to any ; an int or int? converts implicitly, so version = 15 pins one and a null means automatic. ">
+              <h4><span class="kind">property</span> <span class="name">Version</span></h4>
+              <pre class="sig"><code>public QRCodeVersionRange Version { get; init; }</code></pre>
               <p class="doc">The versions the generator may choose from. Defaults to Any ; an int or int? converts implicitly, so Version = 15 pins one and a null means automatic.</p>
             </div>
-            <div class="member" data-text="public bool boostecclevel { get; init; } raise the error correction level above the requested one when the chosen version's capacity allows it, without changing the version. the requested level becomes the minimum; the version is still chosen for it, so boosting never produces a larger symbol, only spends padding that would otherwise be wasted. recommended when an icon or custom module shape overlays the symbol. off by default: a raised level rewrites the format information and can change the chosen mask, so a default of on would silently change every existing symbol. sizing is unaffected either way, the buffer size depends only on the version.">
-              <code>public bool BoostEccLevel { get; init; }</code>
+            <div class="member" data-text="property public bool boostecclevel { get; init; } raise the error correction level above the requested one when the chosen version's capacity allows it, without changing the version. the requested level becomes the minimum; the version is still chosen for it, so boosting never produces a larger symbol, only spends padding that would otherwise be wasted. recommended when an icon or custom module shape overlays the symbol. off by default: a raised level rewrites the format information and can change the chosen mask, so a default of on would silently change every existing symbol. sizing is unaffected either way, the buffer size depends only on the version.">
+              <h4><span class="kind">property</span> <span class="name">BoostEccLevel</span></h4>
+              <pre class="sig"><code>public bool BoostEccLevel { get; init; }</code></pre>
               <p class="doc">Raise the error correction level above the requested one when the chosen version's capacity allows it, without changing the version. The requested level becomes the minimum; the version is still chosen for it, so boosting never produces a larger symbol, only spends padding that would otherwise be wasted. Recommended when an icon or custom module shape overlays the symbol.</p>
               <details class="notes" data-text="off by default: a raised level rewrites the format information and can change the chosen mask, so a default of on would silently change every existing symbol. sizing is unaffected either way, the buffer size depends only on the version.">
                 <summary>Notes</summary>
                 <p class="doc remarks">Off by default: a raised level rewrites the format information and can change the chosen mask, so a default of on would silently change every existing symbol. Sizing is unaffected either way, the buffer size depends only on the version.</p>
               </details>
             </div>
-            <div class="member" data-text="public bool utf8bom { get; init; } include a utf-8 byte order mark. ignored unless the content is written as utf-8 in byte mode. when a bom would be written, optimal emits the single-mode stream instead of a split (the bom is a stream-level prefix, and a split would relocate it into the middle of the decoded text). ">
-              <code>public bool Utf8BOM { get; init; }</code>
+            <div class="member" data-text="property public bool utf8bom { get; init; } include a utf-8 byte order mark. ignored unless the content is written as utf-8 in byte mode. when a bom would be written, optimal emits the single-mode stream instead of a split (the bom is a stream-level prefix, and a split would relocate it into the middle of the decoded text). ">
+              <h4><span class="kind">property</span> <span class="name">Utf8BOM</span></h4>
+              <pre class="sig"><code>public bool Utf8BOM { get; init; }</code></pre>
               <p class="doc">Include a UTF-8 byte order mark. Ignored unless the content is written as UTF-8 in Byte mode. When a BOM would be written, Optimal emits the single-mode stream instead of a split (the BOM is a stream-level prefix, and a split would relocate it into the middle of the decoded text).</p>
             </div>
-            <div class="member" data-text="public int quietzonesize { get; init; } quiet zone width in modules. defaults to 4, the iso/iec 18004 value; 0 is valid. ">
-              <code>public int QuietZoneSize { get; init; }</code>
+            <div class="member" data-text="property public int quietzonesize { get; init; } quiet zone width in modules. defaults to 4, the iso/iec 18004 value; 0 is valid. ">
+              <h4><span class="kind">property</span> <span class="name">QuietZoneSize</span></h4>
+              <pre class="sig"><code>public int QuietZoneSize { get; init; }</code></pre>
               <p class="doc">Quiet zone width in modules. Defaults to 4, the ISO/IEC 18004 value; 0 is valid.</p>
             </div>
-            <div class="member" data-text="public int? maskpattern { get; init; } pin one of the eight iso/iec 18004 data mask patterns (0-7) instead of the automatic penalty-scored selection. null (the default) selects the lowest-penalty pattern. any pattern yields a valid, decodable symbol; the automatic choice merely optimizes scan reliability. for reproducing a symbol produced elsewhere byte-for-byte (the pattern another encoder chose is reported by maskpattern ), and for exercising a decoder against all eight patterns. like version , an invalid value is an argument error and is rejected here rather than when a generator reads it.">
-              <code>public int? MaskPattern { get; init; }</code>
+            <div class="member" data-text="property public int? maskpattern { get; init; } pin one of the eight iso/iec 18004 data mask patterns (0-7) instead of the automatic penalty-scored selection. null (the default) selects the lowest-penalty pattern. any pattern yields a valid, decodable symbol; the automatic choice merely optimizes scan reliability. for reproducing a symbol produced elsewhere byte-for-byte (the pattern another encoder chose is reported by maskpattern ), and for exercising a decoder against all eight patterns. like version , an invalid value is an argument error and is rejected here rather than when a generator reads it.">
+              <h4><span class="kind">property</span> <span class="name">MaskPattern</span></h4>
+              <pre class="sig"><code>public int? MaskPattern { get; init; }</code></pre>
               <p class="doc">Pin one of the eight ISO/IEC 18004 data mask patterns (0-7) instead of the automatic penalty-scored selection. null (the default) selects the lowest-penalty pattern. Any pattern yields a valid, decodable symbol; the automatic choice merely optimizes scan reliability.</p>
               <details class="notes" data-text="for reproducing a symbol produced elsewhere byte-for-byte (the pattern another encoder chose is reported by maskpattern ), and for exercising a decoder against all eight patterns. like version , an invalid value is an argument error and is rejected here rather than when a generator reads it.">
                 <summary>Notes</summary>
                 <p class="doc remarks">For reproducing a symbol produced elsewhere byte-for-byte (the pattern another encoder chose is reported by MaskPattern ), and for exercising a decoder against all eight patterns. Like Version , an invalid value is an argument error and is rejected here rather than when a generator reads it.</p>
               </details>
             </div>
-            <div class="member" data-text="public static qrcodegeneratoroptions default { get; } the default configuration, identical to default. ">
-              <code>public static QRCodeGeneratorOptions Default { get; }</code>
+            <div class="member" data-text="property public static qrcodegeneratoroptions default { get; } the default configuration, identical to default. ">
+              <h4><span class="kind">property</span> <span class="name">Default</span></h4>
+              <pre class="sig"><code>public static QRCodeGeneratorOptions Default { get; }</code></pre>
               <p class="doc">The default configuration, identical to default.</p>
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.QRCodeRenderer" data-name="skiasharp.qrcode.qrcoderenderer" data-text="skiasharp.qrcode.qrcoderenderer public static class qrcoderenderer provides low-level rendering capabilities for qr codes to skiasharp canvases. offers fine-grained control over appearance, including colors, shapes, gradients, and icon overlays.  public static skrect getfinderpatternrect(qrcodedata data, int patternindex, skrect renderarea); gets the rectangle area for a specified finder pattern in the rendered qr code area. the finder patterns are the large squares typically located at three corners of a qr code. this method calculates their positions based on the qr code's size and quiet zone, ensuring accurate placement within the specified rendering area. public static valuetuple&lt;skrect, skrect&gt; geticonrects(qrcodedata data, skrect area, icondata icondata); calculates icon and border rectangles for the given qr code area. when iconsizemodules is set, sizing is module-based and percent/pixel values are ignored. module-based icons are validated against qr size and core occupancy at render time. icon rectangles are snapped to the module grid; even module sizes cannot be geometrically centered on an odd qr matrix. public static void render(skcanvas canvas, skrect area, microqrcodedata data, skcolor? codecolor, skcolor? backgroundcolor, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); render the specified micro qr data into the given area of the target canvas. micro qr has a single finder pattern and no error-correction headroom for overlays, so the standard qr options for icons and custom finder pattern shapes are intentionally not available. see render for the module-run merge behavior shared with standard qr. public static void render(skcanvas canvas, skrect area, qrcodedata data, skcolor? codecolor, skcolor? backgroundcolor, icondata? icondata = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null, finderpatternshape? finderpatternshape = null); render the specified data into the given area of the target canvas. with the default rectangle shape at modulesizepercent 1.0, horizontal runs of dark modules are drawn as single merged rectangles (fewer native draw calls). merged and per-module rendering are pixel-identical under axis-preserving canvas transforms (translation/scale); under rotation, shared-edge rounding may differ at sub-pixel level. any custom module shape or a module size below 1.0 falls back to per-module drawing. public static void render(skcanvas canvas, skrect area, rmqrcodedata data, skcolor? codecolor, skcolor? backgroundcolor, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); renders an rmqr code onto the canvas. the rectangular symbol (quiet zone included) is drawn with a uniform module scale and centered in area (letterbox); the whole area receives the background. rmqr has one finder pattern and no error-correction headroom for overlays, so there are no icon or finder-shape options. module runs are merged as for the other symbologies (see render ).">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeRenderer" aria-label="Link to SkiaSharp.QrCode.QRCodeRenderer">#</a><code>public static class QRCodeRenderer</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.QRCodeRenderer" data-name="skiasharp.qrcode.qrcoderenderer" data-text="skiasharp.qrcode.qrcoderenderer public static class qrcoderenderer provides low-level rendering capabilities for qr codes to skiasharp canvases. offers fine-grained control over appearance, including colors, shapes, gradients, and icon overlays.  method public static skrect getfinderpatternrect(qrcodedata data, int patternindex, skrect renderarea); gets the rectangle area for a specified finder pattern in the rendered qr code area. the finder patterns are the large squares typically located at three corners of a qr code. this method calculates their positions based on the qr code's size and quiet zone, ensuring accurate placement within the specified rendering area. method public static valuetuple&lt;skrect, skrect&gt; geticonrects(qrcodedata data, skrect area, icondata icondata); calculates icon and border rectangles for the given qr code area. when iconsizemodules is set, sizing is module-based and percent/pixel values are ignored. module-based icons are validated against qr size and core occupancy at render time. icon rectangles are snapped to the module grid; even module sizes cannot be geometrically centered on an odd qr matrix. method public static void render(skcanvas canvas, skrect area, microqrcodedata data, skcolor? codecolor, skcolor? backgroundcolor, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); render the specified micro qr data into the given area of the target canvas. micro qr has a single finder pattern and no error-correction headroom for overlays, so the standard qr options for icons and custom finder pattern shapes are intentionally not available. see render for the module-run merge behavior shared with standard qr. method public static void render(skcanvas canvas, skrect area, qrcodedata data, skcolor? codecolor, skcolor? backgroundcolor, icondata? icondata = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null, finderpatternshape? finderpatternshape = null); render the specified data into the given area of the target canvas. with the default rectangle shape at modulesizepercent 1.0, horizontal runs of dark modules are drawn as single merged rectangles (fewer native draw calls). merged and per-module rendering are pixel-identical under axis-preserving canvas transforms (translation/scale); under rotation, shared-edge rounding may differ at sub-pixel level. any custom module shape or a module size below 1.0 falls back to per-module drawing. method public static void render(skcanvas canvas, skrect area, rmqrcodedata data, skcolor? codecolor, skcolor? backgroundcolor, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); renders an rmqr code onto the canvas. the rectangular symbol (quiet zone included) is drawn with a uniform module scale and centered in area (letterbox); the whole area receives the background. rmqr has one finder pattern and no error-correction headroom for overlays, so there are no icon or finder-shape options. module runs are merged as for the other symbologies (see render ).">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeRenderer" aria-label="Link to SkiaSharp.QrCode.QRCodeRenderer">#</a><span class="kind">class</span> <span class="name">QRCodeRenderer</span></h3>
+          <pre class="sig"><code>public static class QRCodeRenderer</code></pre>
           <p class="doc">Provides low-level rendering capabilities for QR codes to SkiaSharp canvases. Offers fine-grained control over appearance, including colors, shapes, gradients, and icon overlays.</p>
           <div class="members">
-            <div class="member" data-text="public static skrect getfinderpatternrect(qrcodedata data, int patternindex, skrect renderarea); gets the rectangle area for a specified finder pattern in the rendered qr code area. the finder patterns are the large squares typically located at three corners of a qr code. this method calculates their positions based on the qr code's size and quiet zone, ensuring accurate placement within the specified rendering area.">
-              <code>public static SKRect GetFinderPatternRect(QRCodeData data, int patternIndex, SKRect renderArea);</code>
+            <div class="member" data-text="method public static skrect getfinderpatternrect(qrcodedata data, int patternindex, skrect renderarea); gets the rectangle area for a specified finder pattern in the rendered qr code area. the finder patterns are the large squares typically located at three corners of a qr code. this method calculates their positions based on the qr code's size and quiet zone, ensuring accurate placement within the specified rendering area.">
+              <h4><span class="kind">method</span> <span class="name">GetFinderPatternRect</span></h4>
+              <pre class="sig"><code>public static SKRect GetFinderPatternRect(QRCodeData data, int patternIndex, SKRect renderArea);</code></pre>
               <p class="doc">Gets the rectangle area for a specified finder pattern in the rendered QR code area.</p>
               <details class="notes" data-text="the finder patterns are the large squares typically located at three corners of a qr code. this method calculates their positions based on the qr code's size and quiet zone, ensuring accurate placement within the specified rendering area.">
                 <summary>Notes</summary>
                 <p class="doc remarks">The finder patterns are the large squares typically located at three corners of a QR code. This method calculates their positions based on the QR code's size and quiet zone, ensuring accurate placement within the specified rendering area.</p>
               </details>
             </div>
-            <div class="member" data-text="public static valuetuple&lt;skrect, skrect&gt; geticonrects(qrcodedata data, skrect area, icondata icondata); calculates icon and border rectangles for the given qr code area. when iconsizemodules is set, sizing is module-based and percent/pixel values are ignored. module-based icons are validated against qr size and core occupancy at render time. icon rectangles are snapped to the module grid; even module sizes cannot be geometrically centered on an odd qr matrix.">
-              <code>public static ValueTuple&lt;SKRect, SKRect&gt; GetIconRects(QRCodeData data, SKRect area, IconData iconData);</code>
+            <div class="member" data-text="method public static valuetuple&lt;skrect, skrect&gt; geticonrects(qrcodedata data, skrect area, icondata icondata); calculates icon and border rectangles for the given qr code area. when iconsizemodules is set, sizing is module-based and percent/pixel values are ignored. module-based icons are validated against qr size and core occupancy at render time. icon rectangles are snapped to the module grid; even module sizes cannot be geometrically centered on an odd qr matrix.">
+              <h4><span class="kind">method</span> <span class="name">GetIconRects</span></h4>
+              <pre class="sig"><code>public static ValueTuple&lt;SKRect, SKRect&gt; GetIconRects(QRCodeData data, SKRect area, IconData iconData);</code></pre>
               <p class="doc">Calculates icon and border rectangles for the given QR code area.</p>
               <details class="notes" data-text="when iconsizemodules is set, sizing is module-based and percent/pixel values are ignored. module-based icons are validated against qr size and core occupancy at render time. icon rectangles are snapped to the module grid; even module sizes cannot be geometrically centered on an odd qr matrix.">
                 <summary>Notes</summary>
                 <p class="doc remarks">When IconSizeModules is set, sizing is module-based and percent/pixel values are ignored. Module-based icons are validated against QR size and core occupancy at render time. Icon rectangles are snapped to the module grid; even module sizes cannot be geometrically centered on an odd QR matrix.</p>
               </details>
             </div>
-            <div class="member" data-text="public static void render(skcanvas canvas, skrect area, microqrcodedata data, skcolor? codecolor, skcolor? backgroundcolor, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); render the specified micro qr data into the given area of the target canvas. micro qr has a single finder pattern and no error-correction headroom for overlays, so the standard qr options for icons and custom finder pattern shapes are intentionally not available. see render for the module-run merge behavior shared with standard qr.">
-              <code>public static void Render(SKCanvas canvas, SKRect area, MicroQRCodeData data, SKColor? codeColor, SKColor? backgroundColor, ModuleShape? moduleShape = null, float moduleSizePercent = 1, GradientOptions? gradientOptions = null);</code>
+            <div class="member" data-text="method public static void render(skcanvas canvas, skrect area, microqrcodedata data, skcolor? codecolor, skcolor? backgroundcolor, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); render the specified micro qr data into the given area of the target canvas. micro qr has a single finder pattern and no error-correction headroom for overlays, so the standard qr options for icons and custom finder pattern shapes are intentionally not available. see render for the module-run merge behavior shared with standard qr.">
+              <h4><span class="kind">method</span> <span class="name">Render</span></h4>
+              <pre class="sig"><code>public static void Render(SKCanvas canvas, SKRect area, MicroQRCodeData data, SKColor? codeColor, SKColor? backgroundColor, ModuleShape? moduleShape = null, float moduleSizePercent = 1, GradientOptions? gradientOptions = null);</code></pre>
               <p class="doc">Render the specified Micro QR data into the given area of the target canvas.</p>
               <details class="notes" data-text="micro qr has a single finder pattern and no error-correction headroom for overlays, so the standard qr options for icons and custom finder pattern shapes are intentionally not available. see render for the module-run merge behavior shared with standard qr.">
                 <summary>Notes</summary>
                 <p class="doc remarks">Micro QR has a single finder pattern and no error-correction headroom for overlays, so the Standard QR options for icons and custom finder pattern shapes are intentionally not available. See Render for the module-run merge behavior shared with Standard QR.</p>
               </details>
             </div>
-            <div class="member" data-text="public static void render(skcanvas canvas, skrect area, qrcodedata data, skcolor? codecolor, skcolor? backgroundcolor, icondata? icondata = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null, finderpatternshape? finderpatternshape = null); render the specified data into the given area of the target canvas. with the default rectangle shape at modulesizepercent 1.0, horizontal runs of dark modules are drawn as single merged rectangles (fewer native draw calls). merged and per-module rendering are pixel-identical under axis-preserving canvas transforms (translation/scale); under rotation, shared-edge rounding may differ at sub-pixel level. any custom module shape or a module size below 1.0 falls back to per-module drawing.">
-              <code>public static void Render(SKCanvas canvas, SKRect area, QRCodeData data, SKColor? codeColor, SKColor? backgroundColor, IconData? iconData = null, ModuleShape? moduleShape = null, float moduleSizePercent = 1, GradientOptions? gradientOptions = null, FinderPatternShape? finderPatternShape = null);</code>
+            <div class="member" data-text="method public static void render(skcanvas canvas, skrect area, qrcodedata data, skcolor? codecolor, skcolor? backgroundcolor, icondata? icondata = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null, finderpatternshape? finderpatternshape = null); render the specified data into the given area of the target canvas. with the default rectangle shape at modulesizepercent 1.0, horizontal runs of dark modules are drawn as single merged rectangles (fewer native draw calls). merged and per-module rendering are pixel-identical under axis-preserving canvas transforms (translation/scale); under rotation, shared-edge rounding may differ at sub-pixel level. any custom module shape or a module size below 1.0 falls back to per-module drawing.">
+              <h4><span class="kind">method</span> <span class="name">Render</span></h4>
+              <pre class="sig"><code>public static void Render(SKCanvas canvas, SKRect area, QRCodeData data, SKColor? codeColor, SKColor? backgroundColor, IconData? iconData = null, ModuleShape? moduleShape = null, float moduleSizePercent = 1, GradientOptions? gradientOptions = null, FinderPatternShape? finderPatternShape = null);</code></pre>
               <p class="doc">Render the specified data into the given area of the target canvas.</p>
               <details class="notes" data-text="with the default rectangle shape at modulesizepercent 1.0, horizontal runs of dark modules are drawn as single merged rectangles (fewer native draw calls). merged and per-module rendering are pixel-identical under axis-preserving canvas transforms (translation/scale); under rotation, shared-edge rounding may differ at sub-pixel level. any custom module shape or a module size below 1.0 falls back to per-module drawing.">
                 <summary>Notes</summary>
                 <p class="doc remarks">With the default rectangle shape at moduleSizePercent 1.0, horizontal runs of dark modules are drawn as single merged rectangles (fewer native draw calls). Merged and per-module rendering are pixel-identical under axis-preserving canvas transforms (translation/scale); under rotation, shared-edge rounding may differ at sub-pixel level. Any custom module shape or a module size below 1.0 falls back to per-module drawing.</p>
               </details>
             </div>
-            <div class="member" data-text="public static void render(skcanvas canvas, skrect area, rmqrcodedata data, skcolor? codecolor, skcolor? backgroundcolor, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); renders an rmqr code onto the canvas. the rectangular symbol (quiet zone included) is drawn with a uniform module scale and centered in area (letterbox); the whole area receives the background. rmqr has one finder pattern and no error-correction headroom for overlays, so there are no icon or finder-shape options. module runs are merged as for the other symbologies (see render ).">
-              <code>public static void Render(SKCanvas canvas, SKRect area, RmQRCodeData data, SKColor? codeColor, SKColor? backgroundColor, ModuleShape? moduleShape = null, float moduleSizePercent = 1, GradientOptions? gradientOptions = null);</code>
+            <div class="member" data-text="method public static void render(skcanvas canvas, skrect area, rmqrcodedata data, skcolor? codecolor, skcolor? backgroundcolor, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); renders an rmqr code onto the canvas. the rectangular symbol (quiet zone included) is drawn with a uniform module scale and centered in area (letterbox); the whole area receives the background. rmqr has one finder pattern and no error-correction headroom for overlays, so there are no icon or finder-shape options. module runs are merged as for the other symbologies (see render ).">
+              <h4><span class="kind">method</span> <span class="name">Render</span></h4>
+              <pre class="sig"><code>public static void Render(SKCanvas canvas, SKRect area, RmQRCodeData data, SKColor? codeColor, SKColor? backgroundColor, ModuleShape? moduleShape = null, float moduleSizePercent = 1, GradientOptions? gradientOptions = null);</code></pre>
               <p class="doc">Renders an rMQR code onto the canvas. The rectangular symbol (quiet zone included) is drawn with a uniform module scale and centered in area (letterbox); the whole area receives the background.</p>
               <details class="notes" data-text="rmqr has one finder pattern and no error-correction headroom for overlays, so there are no icon or finder-shape options. module runs are merged as for the other symbologies (see render ).">
                 <summary>Notes</summary>
@@ -1271,16 +1428,17 @@
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.QRCodeSegmentation" data-name="skiasharp.qrcode.qrcodesegmentation" data-text="skiasharp.qrcode.qrcodesegmentation public enum qrcodesegmentation : int how qrcodegenerator splits the content into encoding-mode segments. mixed content (for example a url prefix followed by a long numeric identifier) packs into fewer bits when each run is encoded in its densest mode, which can drop the symbol by one or more versions.  single = 0, one segment in the single mode that can represent the whole content (numeric, else alphanumeric, else byte). the default, and the cheapest to encode.  optimal = 1, the mixed-mode split with the fewest total bits. never selects a larger version than single , emits the single bit stream verbatim when a split would not shrink the symbol, and additionally encodes content that overflows every version in a single mode — unless the minimal-bit plan would be misread on decode (a relocated byte order mark), in which case it reports &quot;does not fit&quot; rather than emitting a stream that decodes differently. opt-in because it searches candidate versions; the search itself allocates nothing for typical content and rents pooled buffers for long content. when utf8bom would actually write a byte order mark (a utf-8 byte-mode stream), the split is disabled and the single stream is emitted: the bom is a stream-level prefix, and a split would relocate it into the middle of the decoded text. content whose single mode is numeric or alphanumeric never carries a bom and still splits. size buffers with the same segmentation you encode with, the two can select different versions.">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeSegmentation" aria-label="Link to SkiaSharp.QrCode.QRCodeSegmentation">#</a><code>public enum QRCodeSegmentation : int</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.QRCodeSegmentation" data-name="skiasharp.qrcode.qrcodesegmentation" data-text="skiasharp.qrcode.qrcodesegmentation public enum qrcodesegmentation : int how qrcodegenerator splits the content into encoding-mode segments. mixed content (for example a url prefix followed by a long numeric identifier) packs into fewer bits when each run is encoded in its densest mode, which can drop the symbol by one or more versions.  value single = 0, one segment in the single mode that can represent the whole content (numeric, else alphanumeric, else byte). the default, and the cheapest to encode.  value optimal = 1, the mixed-mode split with the fewest total bits. never selects a larger version than single , emits the single bit stream verbatim when a split would not shrink the symbol, and additionally encodes content that overflows every version in a single mode — unless the minimal-bit plan would be misread on decode (a relocated byte order mark), in which case it reports &quot;does not fit&quot; rather than emitting a stream that decodes differently. opt-in because it searches candidate versions; the search itself allocates nothing for typical content and rents pooled buffers for long content. when utf8bom would actually write a byte order mark (a utf-8 byte-mode stream), the split is disabled and the single stream is emitted: the bom is a stream-level prefix, and a split would relocate it into the middle of the decoded text. content whose single mode is numeric or alphanumeric never carries a bom and still splits. size buffers with the same segmentation you encode with, the two can select different versions.">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeSegmentation" aria-label="Link to SkiaSharp.QrCode.QRCodeSegmentation">#</a><span class="kind">enum</span> <span class="name">QRCodeSegmentation</span></h3>
+          <pre class="sig"><code>public enum QRCodeSegmentation : int</code></pre>
           <p class="doc">How QRCodeGenerator splits the content into encoding-mode segments. Mixed content (for example a URL prefix followed by a long numeric identifier) packs into fewer bits when each run is encoded in its densest mode, which can drop the symbol by one or more versions.</p>
           <div class="members">
-            <div class="member" data-text="single = 0, one segment in the single mode that can represent the whole content (numeric, else alphanumeric, else byte). the default, and the cheapest to encode. ">
-              <code>Single = 0,</code>
+            <div class="member" data-text="value single = 0, one segment in the single mode that can represent the whole content (numeric, else alphanumeric, else byte). the default, and the cheapest to encode. ">
+              <pre class="sig"><code>Single = 0,</code></pre>
               <p class="doc">One segment in the single mode that can represent the whole content (Numeric, else Alphanumeric, else Byte). The default, and the cheapest to encode.</p>
             </div>
-            <div class="member" data-text="optimal = 1, the mixed-mode split with the fewest total bits. never selects a larger version than single , emits the single bit stream verbatim when a split would not shrink the symbol, and additionally encodes content that overflows every version in a single mode — unless the minimal-bit plan would be misread on decode (a relocated byte order mark), in which case it reports &quot;does not fit&quot; rather than emitting a stream that decodes differently. opt-in because it searches candidate versions; the search itself allocates nothing for typical content and rents pooled buffers for long content. when utf8bom would actually write a byte order mark (a utf-8 byte-mode stream), the split is disabled and the single stream is emitted: the bom is a stream-level prefix, and a split would relocate it into the middle of the decoded text. content whose single mode is numeric or alphanumeric never carries a bom and still splits. size buffers with the same segmentation you encode with, the two can select different versions.">
-              <code>Optimal = 1,</code>
+            <div class="member" data-text="value optimal = 1, the mixed-mode split with the fewest total bits. never selects a larger version than single , emits the single bit stream verbatim when a split would not shrink the symbol, and additionally encodes content that overflows every version in a single mode — unless the minimal-bit plan would be misread on decode (a relocated byte order mark), in which case it reports &quot;does not fit&quot; rather than emitting a stream that decodes differently. opt-in because it searches candidate versions; the search itself allocates nothing for typical content and rents pooled buffers for long content. when utf8bom would actually write a byte order mark (a utf-8 byte-mode stream), the split is disabled and the single stream is emitted: the bom is a stream-level prefix, and a split would relocate it into the middle of the decoded text. content whose single mode is numeric or alphanumeric never carries a bom and still splits. size buffers with the same segmentation you encode with, the two can select different versions.">
+              <pre class="sig"><code>Optimal = 1,</code></pre>
               <p class="doc">The mixed-mode split with the fewest total bits. Never selects a larger version than Single , emits the Single bit stream verbatim when a split would not shrink the symbol, and additionally encodes content that overflows every version in a single mode — unless the minimal-bit plan would be misread on decode (a relocated byte order mark), in which case it reports &quot;does not fit&quot; rather than emitting a stream that decodes differently.</p>
               <details class="notes" data-text="opt-in because it searches candidate versions; the search itself allocates nothing for typical content and rents pooled buffers for long content. when utf8bom would actually write a byte order mark (a utf-8 byte-mode stream), the split is disabled and the single stream is emitted: the bom is a stream-level prefix, and a split would relocate it into the middle of the decoded text. content whose single mode is numeric or alphanumeric never carries a bom and still splits. size buffers with the same segmentation you encode with, the two can select different versions.">
                 <summary>Notes</summary>
@@ -1289,75 +1447,92 @@
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.QRCodeVersionRange" data-name="skiasharp.qrcode.qrcodeversionrange" data-text="skiasharp.qrcode.qrcodeversionrange public readonly struct qrcodeversionrange : iequatable&lt;qrcodeversionrange&gt; the standard qr versions a generator may choose from: the smallest one in the range that holds the content is used. a fixed version is exactly , the degenerate case, rather than a separate setting. both bounds are inclusive, unlike range whose end is exclusive. that is why 1..40 is not usable here: it would read as 1 to 40 and mean 1 to 39. public const int maxversion; the highest version defined by iso/iec 18004.  public const int minversion; the lowest version defined by iso/iec 18004.  public qrcodeversionrange(int min, int max); an inclusive range from min to max .  public bool isany { get; } whether this range constrains nothing (the default).  public bool isexact { get; } whether this range pins a single version.  public int max { get; } the highest permitted version (40 when unbounded above).  public int min { get; } the lowest permitted version (1 when unbounded below).  public static qrcodeversionrange any { get; } every version, 1 to 40. identical to default.  public bool contains(int version); whether version falls inside this range.  public override string tostring();  public static qrcodeversionrange atleast(int version); version or larger.  public static qrcodeversionrange atmost(int version); version or smaller.  public static qrcodeversionrange between(int min, int max); an inclusive range from min to max .  public static qrcodeversionrange exactly(int version); exactly version , with no automatic selection.  public static qrcodeversionrange op_implicit(int version); a single version, as exactly . lets an option set read version = 15.  public static qrcodeversionrange op_implicit(int? version); a single version, or any when there is none. lets a caller whose version is optional pass it through without branching. -1 is not accepted as a second spelling of any : a mistyped or defaulted value must fail rather than silently produce an automatically sized symbol.">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeVersionRange" aria-label="Link to SkiaSharp.QrCode.QRCodeVersionRange">#</a><code>public readonly struct QRCodeVersionRange : IEquatable&lt;QRCodeVersionRange&gt;</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.QRCodeVersionRange" data-name="skiasharp.qrcode.qrcodeversionrange" data-text="skiasharp.qrcode.qrcodeversionrange public readonly struct qrcodeversionrange : iequatable&lt;qrcodeversionrange&gt; the standard qr versions a generator may choose from: the smallest one in the range that holds the content is used. a fixed version is exactly , the degenerate case, rather than a separate setting. both bounds are inclusive, unlike range whose end is exclusive. that is why 1..40 is not usable here: it would read as 1 to 40 and mean 1 to 39. constant public const int maxversion; the highest version defined by iso/iec 18004.  constant public const int minversion; the lowest version defined by iso/iec 18004.  constructor public qrcodeversionrange(int min, int max); an inclusive range from min to max .  property public bool isany { get; } whether this range constrains nothing (the default).  property public bool isexact { get; } whether this range pins a single version.  property public int max { get; } the highest permitted version (40 when unbounded above).  property public int min { get; } the lowest permitted version (1 when unbounded below).  property public static qrcodeversionrange any { get; } every version, 1 to 40. identical to default.  method public bool contains(int version); whether version falls inside this range.  method public override string tostring();  method public static qrcodeversionrange atleast(int version); version or larger.  method public static qrcodeversionrange atmost(int version); version or smaller.  method public static qrcodeversionrange between(int min, int max); an inclusive range from min to max .  method public static qrcodeversionrange exactly(int version); exactly version , with no automatic selection.  operator public static qrcodeversionrange op_implicit(int version); a single version, as exactly . lets an option set read version = 15.  operator public static qrcodeversionrange op_implicit(int? version); a single version, or any when there is none. lets a caller whose version is optional pass it through without branching. -1 is not accepted as a second spelling of any : a mistyped or defaulted value must fail rather than silently produce an automatically sized symbol.">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeVersionRange" aria-label="Link to SkiaSharp.QrCode.QRCodeVersionRange">#</a><span class="kind">struct</span> <span class="name">QRCodeVersionRange</span></h3>
+          <pre class="sig"><code>public readonly struct QRCodeVersionRange : IEquatable&lt;QRCodeVersionRange&gt;</code></pre>
           <p class="doc">The Standard QR versions a generator may choose from: the smallest one in the range that holds the content is used. A fixed version is Exactly , the degenerate case, rather than a separate setting.</p>
           <details class="notes" data-text="both bounds are inclusive, unlike range whose end is exclusive. that is why 1..40 is not usable here: it would read as 1 to 40 and mean 1 to 39.">
             <summary>Notes</summary>
             <p class="doc remarks">Both bounds are inclusive, unlike Range whose end is exclusive. That is why 1..40 is not usable here: it would read as 1 to 40 and mean 1 to 39.</p>
           </details>
           <div class="members">
-            <div class="member" data-text="public const int maxversion; the highest version defined by iso/iec 18004. ">
-              <code>public const int MaxVersion;</code>
+            <div class="member" data-text="constant public const int maxversion; the highest version defined by iso/iec 18004. ">
+              <h4><span class="kind">constant</span> <span class="name">MaxVersion</span></h4>
+              <pre class="sig"><code>public const int MaxVersion;</code></pre>
               <p class="doc">The highest version defined by ISO/IEC 18004.</p>
             </div>
-            <div class="member" data-text="public const int minversion; the lowest version defined by iso/iec 18004. ">
-              <code>public const int MinVersion;</code>
+            <div class="member" data-text="constant public const int minversion; the lowest version defined by iso/iec 18004. ">
+              <h4><span class="kind">constant</span> <span class="name">MinVersion</span></h4>
+              <pre class="sig"><code>public const int MinVersion;</code></pre>
               <p class="doc">The lowest version defined by ISO/IEC 18004.</p>
             </div>
-            <div class="member" data-text="public qrcodeversionrange(int min, int max); an inclusive range from min to max . ">
-              <code>public QRCodeVersionRange(int min, int max);</code>
+            <div class="member" data-text="constructor public qrcodeversionrange(int min, int max); an inclusive range from min to max . ">
+              <h4><span class="kind">constructor</span> <span class="name">QRCodeVersionRange</span></h4>
+              <pre class="sig"><code>public QRCodeVersionRange(int min, int max);</code></pre>
               <p class="doc">An inclusive range from min to max .</p>
             </div>
-            <div class="member" data-text="public bool isany { get; } whether this range constrains nothing (the default). ">
-              <code>public bool IsAny { get; }</code>
+            <div class="member" data-text="property public bool isany { get; } whether this range constrains nothing (the default). ">
+              <h4><span class="kind">property</span> <span class="name">IsAny</span></h4>
+              <pre class="sig"><code>public bool IsAny { get; }</code></pre>
               <p class="doc">Whether this range constrains nothing (the default).</p>
             </div>
-            <div class="member" data-text="public bool isexact { get; } whether this range pins a single version. ">
-              <code>public bool IsExact { get; }</code>
+            <div class="member" data-text="property public bool isexact { get; } whether this range pins a single version. ">
+              <h4><span class="kind">property</span> <span class="name">IsExact</span></h4>
+              <pre class="sig"><code>public bool IsExact { get; }</code></pre>
               <p class="doc">Whether this range pins a single version.</p>
             </div>
-            <div class="member" data-text="public int max { get; } the highest permitted version (40 when unbounded above). ">
-              <code>public int Max { get; }</code>
+            <div class="member" data-text="property public int max { get; } the highest permitted version (40 when unbounded above). ">
+              <h4><span class="kind">property</span> <span class="name">Max</span></h4>
+              <pre class="sig"><code>public int Max { get; }</code></pre>
               <p class="doc">The highest permitted version (40 when unbounded above).</p>
             </div>
-            <div class="member" data-text="public int min { get; } the lowest permitted version (1 when unbounded below). ">
-              <code>public int Min { get; }</code>
+            <div class="member" data-text="property public int min { get; } the lowest permitted version (1 when unbounded below). ">
+              <h4><span class="kind">property</span> <span class="name">Min</span></h4>
+              <pre class="sig"><code>public int Min { get; }</code></pre>
               <p class="doc">The lowest permitted version (1 when unbounded below).</p>
             </div>
-            <div class="member" data-text="public static qrcodeversionrange any { get; } every version, 1 to 40. identical to default. ">
-              <code>public static QRCodeVersionRange Any { get; }</code>
+            <div class="member" data-text="property public static qrcodeversionrange any { get; } every version, 1 to 40. identical to default. ">
+              <h4><span class="kind">property</span> <span class="name">Any</span></h4>
+              <pre class="sig"><code>public static QRCodeVersionRange Any { get; }</code></pre>
               <p class="doc">Every version, 1 to 40. Identical to default.</p>
             </div>
-            <div class="member" data-text="public bool contains(int version); whether version falls inside this range. ">
-              <code>public bool Contains(int version);</code>
+            <div class="member" data-text="method public bool contains(int version); whether version falls inside this range. ">
+              <h4><span class="kind">method</span> <span class="name">Contains</span></h4>
+              <pre class="sig"><code>public bool Contains(int version);</code></pre>
               <p class="doc">Whether version falls inside this range.</p>
             </div>
-            <div class="member" data-text="public override string tostring(); ">
-              <code>public override string ToString();</code>
+            <div class="member" data-text="method public override string tostring(); ">
+              <h4><span class="kind">method</span> <span class="name">ToString</span></h4>
+              <pre class="sig"><code>public override string ToString();</code></pre>
             </div>
-            <div class="member" data-text="public static qrcodeversionrange atleast(int version); version or larger. ">
-              <code>public static QRCodeVersionRange AtLeast(int version);</code>
+            <div class="member" data-text="method public static qrcodeversionrange atleast(int version); version or larger. ">
+              <h4><span class="kind">method</span> <span class="name">AtLeast</span></h4>
+              <pre class="sig"><code>public static QRCodeVersionRange AtLeast(int version);</code></pre>
               <p class="doc">version or larger.</p>
             </div>
-            <div class="member" data-text="public static qrcodeversionrange atmost(int version); version or smaller. ">
-              <code>public static QRCodeVersionRange AtMost(int version);</code>
+            <div class="member" data-text="method public static qrcodeversionrange atmost(int version); version or smaller. ">
+              <h4><span class="kind">method</span> <span class="name">AtMost</span></h4>
+              <pre class="sig"><code>public static QRCodeVersionRange AtMost(int version);</code></pre>
               <p class="doc">version or smaller.</p>
             </div>
-            <div class="member" data-text="public static qrcodeversionrange between(int min, int max); an inclusive range from min to max . ">
-              <code>public static QRCodeVersionRange Between(int min, int max);</code>
+            <div class="member" data-text="method public static qrcodeversionrange between(int min, int max); an inclusive range from min to max . ">
+              <h4><span class="kind">method</span> <span class="name">Between</span></h4>
+              <pre class="sig"><code>public static QRCodeVersionRange Between(int min, int max);</code></pre>
               <p class="doc">An inclusive range from min to max .</p>
             </div>
-            <div class="member" data-text="public static qrcodeversionrange exactly(int version); exactly version , with no automatic selection. ">
-              <code>public static QRCodeVersionRange Exactly(int version);</code>
+            <div class="member" data-text="method public static qrcodeversionrange exactly(int version); exactly version , with no automatic selection. ">
+              <h4><span class="kind">method</span> <span class="name">Exactly</span></h4>
+              <pre class="sig"><code>public static QRCodeVersionRange Exactly(int version);</code></pre>
               <p class="doc">Exactly version , with no automatic selection.</p>
             </div>
-            <div class="member" data-text="public static qrcodeversionrange op_implicit(int version); a single version, as exactly . lets an option set read version = 15. ">
-              <code>public static QRCodeVersionRange op_Implicit(int version);</code>
+            <div class="member" data-text="operator public static qrcodeversionrange op_implicit(int version); a single version, as exactly . lets an option set read version = 15. ">
+              <h4><span class="kind">operator</span> <span class="name">op_Implicit</span></h4>
+              <pre class="sig"><code>public static QRCodeVersionRange op_Implicit(int version);</code></pre>
               <p class="doc">A single version, as Exactly . Lets an option set read Version = 15.</p>
             </div>
-            <div class="member" data-text="public static qrcodeversionrange op_implicit(int? version); a single version, or any when there is none. lets a caller whose version is optional pass it through without branching. -1 is not accepted as a second spelling of any : a mistyped or defaulted value must fail rather than silently produce an automatically sized symbol.">
-              <code>public static QRCodeVersionRange op_Implicit(int? version);</code>
+            <div class="member" data-text="operator public static qrcodeversionrange op_implicit(int? version); a single version, or any when there is none. lets a caller whose version is optional pass it through without branching. -1 is not accepted as a second spelling of any : a mistyped or defaulted value must fail rather than silently produce an automatically sized symbol.">
+              <h4><span class="kind">operator</span> <span class="name">op_Implicit</span></h4>
+              <pre class="sig"><code>public static QRCodeVersionRange op_Implicit(int? version);</code></pre>
               <p class="doc">A single version, or Any when there is none.</p>
               <details class="notes" data-text="lets a caller whose version is optional pass it through without branching. -1 is not accepted as a second spelling of any : a mistyped or defaulted value must fail rather than silently produce an automatically sized symbol.">
                 <summary>Notes</summary>
@@ -1366,194 +1541,233 @@
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.RmQRCodeCalculatedSize" data-name="skiasharp.qrcode.rmqrcodecalculatedsize" data-text="skiasharp.qrcode.rmqrcodecalculatedsize public readonly struct rmqrcodecalculatedsize result of trygetrequiredbuffersize : the byte count of the byte-per-module matrix, its dimensions (quiet zone included) and the version that will be used.  public rmqrversion version { get; } the rmqr version that will be generated (requested or automatically selected).  public int buffersize { get; } required destination size in bytes ( width × height ).  public int height { get; } matrix height in modules, quiet zone included.  public int width { get; } matrix width in modules, quiet zone included. ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.RmQRCodeCalculatedSize" aria-label="Link to SkiaSharp.QrCode.RmQRCodeCalculatedSize">#</a><code>public readonly struct RmQRCodeCalculatedSize</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.RmQRCodeCalculatedSize" data-name="skiasharp.qrcode.rmqrcodecalculatedsize" data-text="skiasharp.qrcode.rmqrcodecalculatedsize public readonly struct rmqrcodecalculatedsize result of trygetrequiredbuffersize : the byte count of the byte-per-module matrix, its dimensions (quiet zone included) and the version that will be used.  property public rmqrversion version { get; } the rmqr version that will be generated (requested or automatically selected).  property public int buffersize { get; } required destination size in bytes ( width × height ).  property public int height { get; } matrix height in modules, quiet zone included.  property public int width { get; } matrix width in modules, quiet zone included. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.RmQRCodeCalculatedSize" aria-label="Link to SkiaSharp.QrCode.RmQRCodeCalculatedSize">#</a><span class="kind">struct</span> <span class="name">RmQRCodeCalculatedSize</span></h3>
+          <pre class="sig"><code>public readonly struct RmQRCodeCalculatedSize</code></pre>
           <p class="doc">Result of TryGetRequiredBufferSize : the byte count of the byte-per-module matrix, its dimensions (quiet zone included) and the version that will be used.</p>
           <div class="members">
-            <div class="member" data-text="public rmqrversion version { get; } the rmqr version that will be generated (requested or automatically selected). ">
-              <code>public RmQRVersion Version { get; }</code>
+            <div class="member" data-text="property public rmqrversion version { get; } the rmqr version that will be generated (requested or automatically selected). ">
+              <h4><span class="kind">property</span> <span class="name">Version</span></h4>
+              <pre class="sig"><code>public RmQRVersion Version { get; }</code></pre>
               <p class="doc">The rMQR version that will be generated (requested or automatically selected).</p>
             </div>
-            <div class="member" data-text="public int buffersize { get; } required destination size in bytes ( width × height ). ">
-              <code>public int BufferSize { get; }</code>
+            <div class="member" data-text="property public int buffersize { get; } required destination size in bytes ( width × height ). ">
+              <h4><span class="kind">property</span> <span class="name">BufferSize</span></h4>
+              <pre class="sig"><code>public int BufferSize { get; }</code></pre>
               <p class="doc">Required destination size in bytes ( Width × Height ).</p>
             </div>
-            <div class="member" data-text="public int height { get; } matrix height in modules, quiet zone included. ">
-              <code>public int Height { get; }</code>
+            <div class="member" data-text="property public int height { get; } matrix height in modules, quiet zone included. ">
+              <h4><span class="kind">property</span> <span class="name">Height</span></h4>
+              <pre class="sig"><code>public int Height { get; }</code></pre>
               <p class="doc">Matrix height in modules, quiet zone included.</p>
             </div>
-            <div class="member" data-text="public int width { get; } matrix width in modules, quiet zone included. ">
-              <code>public int Width { get; }</code>
+            <div class="member" data-text="property public int width { get; } matrix width in modules, quiet zone included. ">
+              <h4><span class="kind">property</span> <span class="name">Width</span></h4>
+              <pre class="sig"><code>public int Width { get; }</code></pre>
               <p class="doc">Matrix width in modules, quiet zone included.</p>
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.RmQRCodeData" data-name="skiasharp.qrcode.rmqrcodedata" data-text="skiasharp.qrcode.rmqrcodedata public class rmqrcodedata represents rmqr code data as a 2d boolean matrix (versions r7x43-r17x139, rectangular: 7-17 modules high, 27-139 modules wide). storage mirrors microqrcodedata : core modules only (no quiet zone), bit-packed msb-first in flat row-major order; the quiet zone is virtual and always reads light. serialization uses the &quot;qrx&quot; container: &quot;qrx&quot; + symbol type (1 byte, 2 = rmqr) + width (1 byte) + height (1 byte) + packed core bits. micro qr (symbol type 1) and the legacy standard qr &quot;qrr&quot; streams are rejected. public rmqrcodedata(readonlyspan&lt;byte&gt; rawdata, int quietzonesize);  public rmqrcodedata(rmqrversion version, int quietzonesize); initializes an empty (all light) matrix for the specified version.  public rmqrcodedata(byte[] rawdata, int quietzonesize); deserializes rmqr data previously produced by getrawdata .  public rmqrversion version { get; } gets the rmqr version (r7x43-r17x139).  public bool this[int row, int col] { get; } gets the module state at the specified position (quiet zone included). quiet zone positions always read false.  public int height { get; } gets the matrix height in modules, including the quiet zone.  public int width { get; } gets the matrix width in modules, including the quiet zone.  public modulerect[] getmodulerectangles(); gets the dark modules as merged rectangles in module coordinates, for rendering with any graphics api without skiasharp (svg path data, draw calls, vector output). coordinates use the same space as the indexer (this[row, col]): one unit is one module, origin at the top-left including the quiet zone, x is the column and y is the row. consumers scale by the pixel size of one module; width and height give the total extent in modules. three properties are contractual: rectangles never overlap, cover only dark modules, and cover every dark module. the decomposition shape and ordering are unspecified and may change between versions (currently maximal horizontal runs in row-major order, the same merge the built-in renderer draws). public bool trygetmodulerectangles(span&lt;modulerect&gt; destination, out int written); writes the dark modules as merged rectangles into a caller-provided buffer. same contract as getmodulerectangles without allocations.  public byte[] getrawdata(); serializes the core modules (quiet zone excluded) to a new byte array.  public int getmodulerectanglesmaxcount(); gets an upper bound on the number of rectangles getmodulerectangles can return, suitable for sizing a pooled buffer for trygetmodulerectangles . o(1), no matrix scan.  public int getrawdata(ibufferwriter&lt;byte&gt; writer); writes the serialized data to the specified buffer writer without intermediate allocation.  public int getrawdatasize(); gets the serialized size in bytes (&quot;qrx&quot; header + packed core bits). ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.RmQRCodeData" aria-label="Link to SkiaSharp.QrCode.RmQRCodeData">#</a><code>public class RmQRCodeData</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.RmQRCodeData" data-name="skiasharp.qrcode.rmqrcodedata" data-text="skiasharp.qrcode.rmqrcodedata public class rmqrcodedata represents rmqr code data as a 2d boolean matrix (versions r7x43-r17x139, rectangular: 7-17 modules high, 27-139 modules wide). storage mirrors microqrcodedata : core modules only (no quiet zone), bit-packed msb-first in flat row-major order; the quiet zone is virtual and always reads light. serialization uses the &quot;qrx&quot; container: &quot;qrx&quot; + symbol type (1 byte, 2 = rmqr) + width (1 byte) + height (1 byte) + packed core bits. micro qr (symbol type 1) and the legacy standard qr &quot;qrr&quot; streams are rejected. constructor public rmqrcodedata(readonlyspan&lt;byte&gt; rawdata, int quietzonesize);  constructor public rmqrcodedata(rmqrversion version, int quietzonesize); initializes an empty (all light) matrix for the specified version.  constructor public rmqrcodedata(byte[] rawdata, int quietzonesize); deserializes rmqr data previously produced by getrawdata .  property public rmqrversion version { get; } gets the rmqr version (r7x43-r17x139).  indexer public bool this[int row, int col] { get; } gets the module state at the specified position (quiet zone included). quiet zone positions always read false.  property public int height { get; } gets the matrix height in modules, including the quiet zone.  property public int width { get; } gets the matrix width in modules, including the quiet zone.  method public modulerect[] getmodulerectangles(); gets the dark modules as merged rectangles in module coordinates, for rendering with any graphics api without skiasharp (svg path data, draw calls, vector output). coordinates use the same space as the indexer (this[row, col]): one unit is one module, origin at the top-left including the quiet zone, x is the column and y is the row. consumers scale by the pixel size of one module; width and height give the total extent in modules. three properties are contractual: rectangles never overlap, cover only dark modules, and cover every dark module. the decomposition shape and ordering are unspecified and may change between versions (currently maximal horizontal runs in row-major order, the same merge the built-in renderer draws). method public bool trygetmodulerectangles(span&lt;modulerect&gt; destination, out int written); writes the dark modules as merged rectangles into a caller-provided buffer. same contract as getmodulerectangles without allocations.  method public byte[] getrawdata(); serializes the core modules (quiet zone excluded) to a new byte array.  method public int getmodulerectanglesmaxcount(); gets an upper bound on the number of rectangles getmodulerectangles can return, suitable for sizing a pooled buffer for trygetmodulerectangles . o(1), no matrix scan.  method public int getrawdata(ibufferwriter&lt;byte&gt; writer); writes the serialized data to the specified buffer writer without intermediate allocation.  method public int getrawdatasize(); gets the serialized size in bytes (&quot;qrx&quot; header + packed core bits). ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.RmQRCodeData" aria-label="Link to SkiaSharp.QrCode.RmQRCodeData">#</a><span class="kind">class</span> <span class="name">RmQRCodeData</span></h3>
+          <pre class="sig"><code>public class RmQRCodeData</code></pre>
           <p class="doc">Represents rMQR code data as a 2D boolean matrix (versions R7x43-R17x139, rectangular: 7-17 modules high, 27-139 modules wide).</p>
           <details class="notes" data-text="storage mirrors microqrcodedata : core modules only (no quiet zone), bit-packed msb-first in flat row-major order; the quiet zone is virtual and always reads light. serialization uses the &quot;qrx&quot; container: &quot;qrx&quot; + symbol type (1 byte, 2 = rmqr) + width (1 byte) + height (1 byte) + packed core bits. micro qr (symbol type 1) and the legacy standard qr &quot;qrr&quot; streams are rejected.">
             <summary>Notes</summary>
             <p class="doc remarks">Storage mirrors MicroQRCodeData : core modules only (no quiet zone), bit-packed MSB-first in flat row-major order; the quiet zone is virtual and always reads light. Serialization uses the &quot;QRX&quot; container: &quot;QRX&quot; + symbol type (1 byte, 2 = rMQR) + width (1 byte) + height (1 byte) + packed core bits. Micro QR (symbol type 1) and the legacy Standard QR &quot;QRR&quot; streams are rejected.</p>
           </details>
           <div class="members">
-            <div class="member" data-text="public rmqrcodedata(readonlyspan&lt;byte&gt; rawdata, int quietzonesize); ">
-              <code>public RmQRCodeData(ReadOnlySpan&lt;byte&gt; rawData, int quietZoneSize);</code>
+            <div class="member" data-text="constructor public rmqrcodedata(readonlyspan&lt;byte&gt; rawdata, int quietzonesize); ">
+              <h4><span class="kind">constructor</span> <span class="name">RmQRCodeData</span></h4>
+              <pre class="sig"><code>public RmQRCodeData(ReadOnlySpan&lt;byte&gt; rawData, int quietZoneSize);</code></pre>
             </div>
-            <div class="member" data-text="public rmqrcodedata(rmqrversion version, int quietzonesize); initializes an empty (all light) matrix for the specified version. ">
-              <code>public RmQRCodeData(RmQRVersion version, int quietZoneSize);</code>
+            <div class="member" data-text="constructor public rmqrcodedata(rmqrversion version, int quietzonesize); initializes an empty (all light) matrix for the specified version. ">
+              <h4><span class="kind">constructor</span> <span class="name">RmQRCodeData</span></h4>
+              <pre class="sig"><code>public RmQRCodeData(RmQRVersion version, int quietZoneSize);</code></pre>
               <p class="doc">Initializes an empty (all light) matrix for the specified version.</p>
             </div>
-            <div class="member" data-text="public rmqrcodedata(byte[] rawdata, int quietzonesize); deserializes rmqr data previously produced by getrawdata . ">
-              <code>public RmQRCodeData(byte[] rawData, int quietZoneSize);</code>
+            <div class="member" data-text="constructor public rmqrcodedata(byte[] rawdata, int quietzonesize); deserializes rmqr data previously produced by getrawdata . ">
+              <h4><span class="kind">constructor</span> <span class="name">RmQRCodeData</span></h4>
+              <pre class="sig"><code>public RmQRCodeData(byte[] rawData, int quietZoneSize);</code></pre>
               <p class="doc">Deserializes rMQR data previously produced by GetRawData .</p>
             </div>
-            <div class="member" data-text="public rmqrversion version { get; } gets the rmqr version (r7x43-r17x139). ">
-              <code>public RmQRVersion Version { get; }</code>
+            <div class="member" data-text="property public rmqrversion version { get; } gets the rmqr version (r7x43-r17x139). ">
+              <h4><span class="kind">property</span> <span class="name">Version</span></h4>
+              <pre class="sig"><code>public RmQRVersion Version { get; }</code></pre>
               <p class="doc">Gets the rMQR version (R7x43-R17x139).</p>
             </div>
-            <div class="member" data-text="public bool this[int row, int col] { get; } gets the module state at the specified position (quiet zone included). quiet zone positions always read false. ">
-              <code>public bool this[int row, int col] { get; }</code>
+            <div class="member" data-text="indexer public bool this[int row, int col] { get; } gets the module state at the specified position (quiet zone included). quiet zone positions always read false. ">
+              <h4><span class="kind">indexer</span> <span class="name">this[int row, int col]</span></h4>
+              <pre class="sig"><code>public bool this[int row, int col] { get; }</code></pre>
               <p class="doc">Gets the module state at the specified position (quiet zone included). Quiet zone positions always read false.</p>
             </div>
-            <div class="member" data-text="public int height { get; } gets the matrix height in modules, including the quiet zone. ">
-              <code>public int Height { get; }</code>
+            <div class="member" data-text="property public int height { get; } gets the matrix height in modules, including the quiet zone. ">
+              <h4><span class="kind">property</span> <span class="name">Height</span></h4>
+              <pre class="sig"><code>public int Height { get; }</code></pre>
               <p class="doc">Gets the matrix height in modules, including the quiet zone.</p>
             </div>
-            <div class="member" data-text="public int width { get; } gets the matrix width in modules, including the quiet zone. ">
-              <code>public int Width { get; }</code>
+            <div class="member" data-text="property public int width { get; } gets the matrix width in modules, including the quiet zone. ">
+              <h4><span class="kind">property</span> <span class="name">Width</span></h4>
+              <pre class="sig"><code>public int Width { get; }</code></pre>
               <p class="doc">Gets the matrix width in modules, including the quiet zone.</p>
             </div>
-            <div class="member" data-text="public modulerect[] getmodulerectangles(); gets the dark modules as merged rectangles in module coordinates, for rendering with any graphics api without skiasharp (svg path data, draw calls, vector output). coordinates use the same space as the indexer (this[row, col]): one unit is one module, origin at the top-left including the quiet zone, x is the column and y is the row. consumers scale by the pixel size of one module; width and height give the total extent in modules. three properties are contractual: rectangles never overlap, cover only dark modules, and cover every dark module. the decomposition shape and ordering are unspecified and may change between versions (currently maximal horizontal runs in row-major order, the same merge the built-in renderer draws).">
-              <code>public ModuleRect[] GetModuleRectangles();</code>
+            <div class="member" data-text="method public modulerect[] getmodulerectangles(); gets the dark modules as merged rectangles in module coordinates, for rendering with any graphics api without skiasharp (svg path data, draw calls, vector output). coordinates use the same space as the indexer (this[row, col]): one unit is one module, origin at the top-left including the quiet zone, x is the column and y is the row. consumers scale by the pixel size of one module; width and height give the total extent in modules. three properties are contractual: rectangles never overlap, cover only dark modules, and cover every dark module. the decomposition shape and ordering are unspecified and may change between versions (currently maximal horizontal runs in row-major order, the same merge the built-in renderer draws).">
+              <h4><span class="kind">method</span> <span class="name">GetModuleRectangles</span></h4>
+              <pre class="sig"><code>public ModuleRect[] GetModuleRectangles();</code></pre>
               <p class="doc">Gets the dark modules as merged rectangles in module coordinates, for rendering with any graphics API without SkiaSharp (SVG path data, draw calls, vector output).</p>
               <details class="notes" data-text="coordinates use the same space as the indexer (this[row, col]): one unit is one module, origin at the top-left including the quiet zone, x is the column and y is the row. consumers scale by the pixel size of one module; width and height give the total extent in modules. three properties are contractual: rectangles never overlap, cover only dark modules, and cover every dark module. the decomposition shape and ordering are unspecified and may change between versions (currently maximal horizontal runs in row-major order, the same merge the built-in renderer draws).">
                 <summary>Notes</summary>
                 <p class="doc remarks">Coordinates use the same space as the indexer (this[row, col]): one unit is one module, origin at the top-left including the quiet zone, X is the column and Y is the row. Consumers scale by the pixel size of one module; Width and Height give the total extent in modules. Three properties are contractual: rectangles never overlap, cover only dark modules, and cover every dark module. The decomposition shape and ordering are unspecified and may change between versions (currently maximal horizontal runs in row-major order, the same merge the built-in renderer draws).</p>
               </details>
             </div>
-            <div class="member" data-text="public bool trygetmodulerectangles(span&lt;modulerect&gt; destination, out int written); writes the dark modules as merged rectangles into a caller-provided buffer. same contract as getmodulerectangles without allocations. ">
-              <code>public bool TryGetModuleRectangles(Span&lt;ModuleRect&gt; destination, out int written);</code>
+            <div class="member" data-text="method public bool trygetmodulerectangles(span&lt;modulerect&gt; destination, out int written); writes the dark modules as merged rectangles into a caller-provided buffer. same contract as getmodulerectangles without allocations. ">
+              <h4><span class="kind">method</span> <span class="name">TryGetModuleRectangles</span></h4>
+              <pre class="sig"><code>public bool TryGetModuleRectangles(Span&lt;ModuleRect&gt; destination, out int written);</code></pre>
               <p class="doc">Writes the dark modules as merged rectangles into a caller-provided buffer. Same contract as GetModuleRectangles without allocations.</p>
             </div>
-            <div class="member" data-text="public byte[] getrawdata(); serializes the core modules (quiet zone excluded) to a new byte array. ">
-              <code>public byte[] GetRawData();</code>
+            <div class="member" data-text="method public byte[] getrawdata(); serializes the core modules (quiet zone excluded) to a new byte array. ">
+              <h4><span class="kind">method</span> <span class="name">GetRawData</span></h4>
+              <pre class="sig"><code>public byte[] GetRawData();</code></pre>
               <p class="doc">Serializes the core modules (quiet zone excluded) to a new byte array.</p>
             </div>
-            <div class="member" data-text="public int getmodulerectanglesmaxcount(); gets an upper bound on the number of rectangles getmodulerectangles can return, suitable for sizing a pooled buffer for trygetmodulerectangles . o(1), no matrix scan. ">
-              <code>public int GetModuleRectanglesMaxCount();</code>
+            <div class="member" data-text="method public int getmodulerectanglesmaxcount(); gets an upper bound on the number of rectangles getmodulerectangles can return, suitable for sizing a pooled buffer for trygetmodulerectangles . o(1), no matrix scan. ">
+              <h4><span class="kind">method</span> <span class="name">GetModuleRectanglesMaxCount</span></h4>
+              <pre class="sig"><code>public int GetModuleRectanglesMaxCount();</code></pre>
               <p class="doc">Gets an upper bound on the number of rectangles GetModuleRectangles can return, suitable for sizing a pooled buffer for TryGetModuleRectangles . O(1), no matrix scan.</p>
             </div>
-            <div class="member" data-text="public int getrawdata(ibufferwriter&lt;byte&gt; writer); writes the serialized data to the specified buffer writer without intermediate allocation. ">
-              <code>public int GetRawData(IBufferWriter&lt;byte&gt; writer);</code>
+            <div class="member" data-text="method public int getrawdata(ibufferwriter&lt;byte&gt; writer); writes the serialized data to the specified buffer writer without intermediate allocation. ">
+              <h4><span class="kind">method</span> <span class="name">GetRawData</span></h4>
+              <pre class="sig"><code>public int GetRawData(IBufferWriter&lt;byte&gt; writer);</code></pre>
               <p class="doc">Writes the serialized data to the specified buffer writer without intermediate allocation.</p>
             </div>
-            <div class="member" data-text="public int getrawdatasize(); gets the serialized size in bytes (&quot;qrx&quot; header + packed core bits). ">
-              <code>public int GetRawDataSize();</code>
+            <div class="member" data-text="method public int getrawdatasize(); gets the serialized size in bytes (&quot;qrx&quot; header + packed core bits). ">
+              <h4><span class="kind">method</span> <span class="name">GetRawDataSize</span></h4>
+              <pre class="sig"><code>public int GetRawDataSize();</code></pre>
               <p class="doc">Gets the serialized size in bytes (&quot;QRX&quot; header + packed core bits).</p>
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.RmQRCodeDecodeInfo" data-name="skiasharp.qrcode.rmqrcodedecodeinfo" data-text="skiasharp.qrcode.rmqrcodedecodeinfo public readonly struct rmqrcodedecodeinfo diagnostic information from an rmqr decode attempt ( rmqrcodedecoder ): status, and when the format information could be read, the version and ecc level plus the number of reed-solomon codeword corrections applied. rmqr has a single data mask, so there is no mask pattern to report.  public qrcodedecodestatus status { get; } decode outcome; success when text was produced.  public rmqrecclevel ecclevel { get; } the ecc level read from the format information (valid once the format decoded).  public rmqrversion version { get; } the symbol version (from the physical dimensions), or 0 when the input is not an rmqr matrix.  public int errorscorrected { get; } total reed-solomon codeword corrections across all blocks (0 for a clean symbol). ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.RmQRCodeDecodeInfo" aria-label="Link to SkiaSharp.QrCode.RmQRCodeDecodeInfo">#</a><code>public readonly struct RmQRCodeDecodeInfo</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.RmQRCodeDecodeInfo" data-name="skiasharp.qrcode.rmqrcodedecodeinfo" data-text="skiasharp.qrcode.rmqrcodedecodeinfo public readonly struct rmqrcodedecodeinfo diagnostic information from an rmqr decode attempt ( rmqrcodedecoder ): status, and when the format information could be read, the version and ecc level plus the number of reed-solomon codeword corrections applied. rmqr has a single data mask, so there is no mask pattern to report.  property public qrcodedecodestatus status { get; } decode outcome; success when text was produced.  property public rmqrecclevel ecclevel { get; } the ecc level read from the format information (valid once the format decoded).  property public rmqrversion version { get; } the symbol version (from the physical dimensions), or 0 when the input is not an rmqr matrix.  property public int errorscorrected { get; } total reed-solomon codeword corrections across all blocks (0 for a clean symbol). ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.RmQRCodeDecodeInfo" aria-label="Link to SkiaSharp.QrCode.RmQRCodeDecodeInfo">#</a><span class="kind">struct</span> <span class="name">RmQRCodeDecodeInfo</span></h3>
+          <pre class="sig"><code>public readonly struct RmQRCodeDecodeInfo</code></pre>
           <p class="doc">Diagnostic information from an rMQR decode attempt ( RmQRCodeDecoder ): status, and when the format information could be read, the version and ECC level plus the number of Reed-Solomon codeword corrections applied. rMQR has a single data mask, so there is no mask pattern to report.</p>
           <div class="members">
-            <div class="member" data-text="public qrcodedecodestatus status { get; } decode outcome; success when text was produced. ">
-              <code>public QRCodeDecodeStatus Status { get; }</code>
+            <div class="member" data-text="property public qrcodedecodestatus status { get; } decode outcome; success when text was produced. ">
+              <h4><span class="kind">property</span> <span class="name">Status</span></h4>
+              <pre class="sig"><code>public QRCodeDecodeStatus Status { get; }</code></pre>
               <p class="doc">Decode outcome; Success when text was produced.</p>
             </div>
-            <div class="member" data-text="public rmqrecclevel ecclevel { get; } the ecc level read from the format information (valid once the format decoded). ">
-              <code>public RmQREccLevel EccLevel { get; }</code>
+            <div class="member" data-text="property public rmqrecclevel ecclevel { get; } the ecc level read from the format information (valid once the format decoded). ">
+              <h4><span class="kind">property</span> <span class="name">EccLevel</span></h4>
+              <pre class="sig"><code>public RmQREccLevel EccLevel { get; }</code></pre>
               <p class="doc">The ECC level read from the format information (valid once the format decoded).</p>
             </div>
-            <div class="member" data-text="public rmqrversion version { get; } the symbol version (from the physical dimensions), or 0 when the input is not an rmqr matrix. ">
-              <code>public RmQRVersion Version { get; }</code>
+            <div class="member" data-text="property public rmqrversion version { get; } the symbol version (from the physical dimensions), or 0 when the input is not an rmqr matrix. ">
+              <h4><span class="kind">property</span> <span class="name">Version</span></h4>
+              <pre class="sig"><code>public RmQRVersion Version { get; }</code></pre>
               <p class="doc">The symbol version (from the physical dimensions), or 0 when the input is not an rMQR matrix.</p>
             </div>
-            <div class="member" data-text="public int errorscorrected { get; } total reed-solomon codeword corrections across all blocks (0 for a clean symbol). ">
-              <code>public int ErrorsCorrected { get; }</code>
+            <div class="member" data-text="property public int errorscorrected { get; } total reed-solomon codeword corrections across all blocks (0 for a clean symbol). ">
+              <h4><span class="kind">property</span> <span class="name">ErrorsCorrected</span></h4>
+              <pre class="sig"><code>public int ErrorsCorrected { get; }</code></pre>
               <p class="doc">Total Reed-Solomon codeword corrections across all blocks (0 for a clean symbol).</p>
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.RmQRCodeDecoder" data-name="skiasharp.qrcode.rmqrcodedecoder" data-text="skiasharp.qrcode.rmqrcodedecoder public static class rmqrcodedecoder rmqr code (iso/iec 23941) decoder: module matrix → text. sibling of qrcodedecoder and microqrcodedecoder ; explicitly typed so standard qr scanning stays unaffected. matrix-level and image-level decoding ( trydecode / trydecodeimage ). every overload accepts an rmqr matrix with or without a light quiet zone: the dark bounding box (finder corner top-left, sub-finder corner bottom-right, timing patterns on all four edges) locates the core, so uniform and asymmetric borders are stripped automatically. reed-solomon corrections are applied at full block strength (⌊ecc/2⌋ per block) and reported in errorscorrected . numeric, alphanumeric and byte segments (iso-8859-1 / utf-8, with or without eci) are supported, plus kanji segments decoded as jis x 0208; the generator never emits kanji, so it is a read-only mode here. a kanji cell outside the jis x 0208 repertoire fails the whole symbol with unmappedcharacter rather than substituting a replacement character. public static bool trydecode(readonlyspan&lt;byte&gt; modules, int width, int height, span&lt;char&gt; destination, out int charswritten, out rmqrcodedecodeinfo info); decodes the text content from a module matrix into a caller-provided buffer without per-call heap allocation.  public static bool trydecode(readonlyspan&lt;byte&gt; modules, int width, int height, out string text, out rmqrcodedecodeinfo info); decodes the text content from a module matrix.  public static bool trydecode(rmqrcodedata data, out string text); decodes the text content of an rmqrcodedata matrix.  public static bool trydecode(rmqrcodedata data, out string text, out rmqrcodedecodeinfo info); decodes the text content of an rmqrcodedata matrix with diagnostics.  public static bool trydecode(skbitmap bitmap, out string text); detects and decodes an rmqr code from a bitmap image. targets clean, well-lit images such as screenshots, rendered symbols and scans: arbitrary rotation, mirroring, reflectance reversal (light-on-dark), uniform or non-uniform scaling, translation and mild perspective distortion are handled. strong perspective, uneven lighting and blur are out of scope. public static bool trydecode(skbitmap bitmap, out string text, out rmqrcodedecodeinfo info); detects and decodes an rmqr code from a bitmap image, with diagnostic information. see trydecode for the supported image envelope. public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, span&lt;char&gt; destination, out int charswritten, out rmqrcodedecodeinfo info); detects and decodes an rmqr code from grayscale image pixels into a caller-provided buffer without per-call heap allocation.  public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, out string text, out rmqrcodedecodeinfo info); detects and decodes an rmqr code from grayscale image pixels.  public static int getmaxdecodedlength(rmqrversion version); calculates the maximum possible decoded character count for an rmqr version, across ecc levels and encoding modes. use to size the destination buffer for the allocation-free trydecode overload. ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.RmQRCodeDecoder" aria-label="Link to SkiaSharp.QrCode.RmQRCodeDecoder">#</a><code>public static class RmQRCodeDecoder</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.RmQRCodeDecoder" data-name="skiasharp.qrcode.rmqrcodedecoder" data-text="skiasharp.qrcode.rmqrcodedecoder public static class rmqrcodedecoder rmqr code (iso/iec 23941) decoder: module matrix → text. sibling of qrcodedecoder and microqrcodedecoder ; explicitly typed so standard qr scanning stays unaffected. matrix-level and image-level decoding ( trydecode / trydecodeimage ). every overload accepts an rmqr matrix with or without a light quiet zone: the dark bounding box (finder corner top-left, sub-finder corner bottom-right, timing patterns on all four edges) locates the core, so uniform and asymmetric borders are stripped automatically. reed-solomon corrections are applied at full block strength (⌊ecc/2⌋ per block) and reported in errorscorrected . numeric, alphanumeric and byte segments (iso-8859-1 / utf-8, with or without eci) are supported, plus kanji segments decoded as jis x 0208; the generator never emits kanji, so it is a read-only mode here. a kanji cell outside the jis x 0208 repertoire fails the whole symbol with unmappedcharacter rather than substituting a replacement character. method public static bool trydecode(readonlyspan&lt;byte&gt; modules, int width, int height, span&lt;char&gt; destination, out int charswritten, out rmqrcodedecodeinfo info); decodes the text content from a module matrix into a caller-provided buffer without per-call heap allocation.  method public static bool trydecode(readonlyspan&lt;byte&gt; modules, int width, int height, out string text, out rmqrcodedecodeinfo info); decodes the text content from a module matrix.  method public static bool trydecode(rmqrcodedata data, out string text); decodes the text content of an rmqrcodedata matrix.  method public static bool trydecode(rmqrcodedata data, out string text, out rmqrcodedecodeinfo info); decodes the text content of an rmqrcodedata matrix with diagnostics.  method public static bool trydecode(skbitmap bitmap, out string text); detects and decodes an rmqr code from a bitmap image. targets clean, well-lit images such as screenshots, rendered symbols and scans: arbitrary rotation, mirroring, reflectance reversal (light-on-dark), uniform or non-uniform scaling, translation and mild perspective distortion are handled. strong perspective, uneven lighting and blur are out of scope. method public static bool trydecode(skbitmap bitmap, out string text, out rmqrcodedecodeinfo info); detects and decodes an rmqr code from a bitmap image, with diagnostic information. see trydecode for the supported image envelope. method public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, span&lt;char&gt; destination, out int charswritten, out rmqrcodedecodeinfo info); detects and decodes an rmqr code from grayscale image pixels into a caller-provided buffer without per-call heap allocation.  method public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, out string text, out rmqrcodedecodeinfo info); detects and decodes an rmqr code from grayscale image pixels.  method public static int getmaxdecodedlength(rmqrversion version); calculates the maximum possible decoded character count for an rmqr version, across ecc levels and encoding modes. use to size the destination buffer for the allocation-free trydecode overload. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.RmQRCodeDecoder" aria-label="Link to SkiaSharp.QrCode.RmQRCodeDecoder">#</a><span class="kind">class</span> <span class="name">RmQRCodeDecoder</span></h3>
+          <pre class="sig"><code>public static class RmQRCodeDecoder</code></pre>
           <p class="doc">rMQR Code (ISO/IEC 23941) decoder: module matrix → text. Sibling of QRCodeDecoder and MicroQRCodeDecoder ; explicitly typed so Standard QR scanning stays unaffected. Matrix-level and image-level decoding ( TryDecode / TryDecodeImage ).</p>
           <details class="notes" data-text="every overload accepts an rmqr matrix with or without a light quiet zone: the dark bounding box (finder corner top-left, sub-finder corner bottom-right, timing patterns on all four edges) locates the core, so uniform and asymmetric borders are stripped automatically. reed-solomon corrections are applied at full block strength (⌊ecc/2⌋ per block) and reported in errorscorrected . numeric, alphanumeric and byte segments (iso-8859-1 / utf-8, with or without eci) are supported, plus kanji segments decoded as jis x 0208; the generator never emits kanji, so it is a read-only mode here. a kanji cell outside the jis x 0208 repertoire fails the whole symbol with unmappedcharacter rather than substituting a replacement character.">
             <summary>Notes</summary>
             <p class="doc remarks">Every overload accepts an rMQR matrix with or without a light quiet zone: the dark bounding box (finder corner top-left, sub-finder corner bottom-right, timing patterns on all four edges) locates the core, so uniform and asymmetric borders are stripped automatically. Reed-Solomon corrections are applied at full block strength (⌊ecc/2⌋ per block) and reported in ErrorsCorrected . Numeric, Alphanumeric and Byte segments (ISO-8859-1 / UTF-8, with or without ECI) are supported, plus Kanji segments decoded as JIS X 0208; the generator never emits Kanji, so it is a read-only mode here. A Kanji cell outside the JIS X 0208 repertoire fails the whole symbol with UnmappedCharacter rather than substituting a replacement character.</p>
           </details>
           <div class="members">
-            <div class="member" data-text="public static bool trydecode(readonlyspan&lt;byte&gt; modules, int width, int height, span&lt;char&gt; destination, out int charswritten, out rmqrcodedecodeinfo info); decodes the text content from a module matrix into a caller-provided buffer without per-call heap allocation. ">
-              <code>public static bool TryDecode(ReadOnlySpan&lt;byte&gt; modules, int width, int height, Span&lt;char&gt; destination, out int charsWritten, out RmQRCodeDecodeInfo info);</code>
+            <div class="member" data-text="method public static bool trydecode(readonlyspan&lt;byte&gt; modules, int width, int height, span&lt;char&gt; destination, out int charswritten, out rmqrcodedecodeinfo info); decodes the text content from a module matrix into a caller-provided buffer without per-call heap allocation. ">
+              <h4><span class="kind">method</span> <span class="name">TryDecode</span></h4>
+              <pre class="sig"><code>public static bool TryDecode(ReadOnlySpan&lt;byte&gt; modules, int width, int height, Span&lt;char&gt; destination, out int charsWritten, out RmQRCodeDecodeInfo info);</code></pre>
               <p class="doc">Decodes the text content from a module matrix into a caller-provided buffer without per-call heap allocation.</p>
             </div>
-            <div class="member" data-text="public static bool trydecode(readonlyspan&lt;byte&gt; modules, int width, int height, out string text, out rmqrcodedecodeinfo info); decodes the text content from a module matrix. ">
-              <code>public static bool TryDecode(ReadOnlySpan&lt;byte&gt; modules, int width, int height, out string text, out RmQRCodeDecodeInfo info);</code>
+            <div class="member" data-text="method public static bool trydecode(readonlyspan&lt;byte&gt; modules, int width, int height, out string text, out rmqrcodedecodeinfo info); decodes the text content from a module matrix. ">
+              <h4><span class="kind">method</span> <span class="name">TryDecode</span></h4>
+              <pre class="sig"><code>public static bool TryDecode(ReadOnlySpan&lt;byte&gt; modules, int width, int height, out string text, out RmQRCodeDecodeInfo info);</code></pre>
               <p class="doc">Decodes the text content from a module matrix.</p>
             </div>
-            <div class="member" data-text="public static bool trydecode(rmqrcodedata data, out string text); decodes the text content of an rmqrcodedata matrix. ">
-              <code>public static bool TryDecode(RmQRCodeData data, out string text);</code>
+            <div class="member" data-text="method public static bool trydecode(rmqrcodedata data, out string text); decodes the text content of an rmqrcodedata matrix. ">
+              <h4><span class="kind">method</span> <span class="name">TryDecode</span></h4>
+              <pre class="sig"><code>public static bool TryDecode(RmQRCodeData data, out string text);</code></pre>
               <p class="doc">Decodes the text content of an RmQRCodeData matrix.</p>
             </div>
-            <div class="member" data-text="public static bool trydecode(rmqrcodedata data, out string text, out rmqrcodedecodeinfo info); decodes the text content of an rmqrcodedata matrix with diagnostics. ">
-              <code>public static bool TryDecode(RmQRCodeData data, out string text, out RmQRCodeDecodeInfo info);</code>
+            <div class="member" data-text="method public static bool trydecode(rmqrcodedata data, out string text, out rmqrcodedecodeinfo info); decodes the text content of an rmqrcodedata matrix with diagnostics. ">
+              <h4><span class="kind">method</span> <span class="name">TryDecode</span></h4>
+              <pre class="sig"><code>public static bool TryDecode(RmQRCodeData data, out string text, out RmQRCodeDecodeInfo info);</code></pre>
               <p class="doc">Decodes the text content of an RmQRCodeData matrix with diagnostics.</p>
             </div>
-            <div class="member" data-text="public static bool trydecode(skbitmap bitmap, out string text); detects and decodes an rmqr code from a bitmap image. targets clean, well-lit images such as screenshots, rendered symbols and scans: arbitrary rotation, mirroring, reflectance reversal (light-on-dark), uniform or non-uniform scaling, translation and mild perspective distortion are handled. strong perspective, uneven lighting and blur are out of scope.">
-              <code>public static bool TryDecode(SKBitmap bitmap, out string text);</code>
+            <div class="member" data-text="method public static bool trydecode(skbitmap bitmap, out string text); detects and decodes an rmqr code from a bitmap image. targets clean, well-lit images such as screenshots, rendered symbols and scans: arbitrary rotation, mirroring, reflectance reversal (light-on-dark), uniform or non-uniform scaling, translation and mild perspective distortion are handled. strong perspective, uneven lighting and blur are out of scope.">
+              <h4><span class="kind">method</span> <span class="name">TryDecode</span></h4>
+              <pre class="sig"><code>public static bool TryDecode(SKBitmap bitmap, out string text);</code></pre>
               <p class="doc">Detects and decodes an rMQR Code from a bitmap image.</p>
               <details class="notes" data-text="targets clean, well-lit images such as screenshots, rendered symbols and scans: arbitrary rotation, mirroring, reflectance reversal (light-on-dark), uniform or non-uniform scaling, translation and mild perspective distortion are handled. strong perspective, uneven lighting and blur are out of scope.">
                 <summary>Notes</summary>
                 <p class="doc remarks">Targets clean, well-lit images such as screenshots, rendered symbols and scans: arbitrary rotation, mirroring, reflectance reversal (light-on-dark), uniform or non-uniform scaling, translation and mild perspective distortion are handled. Strong perspective, uneven lighting and blur are out of scope.</p>
               </details>
             </div>
-            <div class="member" data-text="public static bool trydecode(skbitmap bitmap, out string text, out rmqrcodedecodeinfo info); detects and decodes an rmqr code from a bitmap image, with diagnostic information. see trydecode for the supported image envelope.">
-              <code>public static bool TryDecode(SKBitmap bitmap, out string text, out RmQRCodeDecodeInfo info);</code>
+            <div class="member" data-text="method public static bool trydecode(skbitmap bitmap, out string text, out rmqrcodedecodeinfo info); detects and decodes an rmqr code from a bitmap image, with diagnostic information. see trydecode for the supported image envelope.">
+              <h4><span class="kind">method</span> <span class="name">TryDecode</span></h4>
+              <pre class="sig"><code>public static bool TryDecode(SKBitmap bitmap, out string text, out RmQRCodeDecodeInfo info);</code></pre>
               <p class="doc">Detects and decodes an rMQR Code from a bitmap image, with diagnostic information.</p>
               <details class="notes" data-text="see trydecode for the supported image envelope.">
                 <summary>Notes</summary>
                 <p class="doc remarks">See TryDecode for the supported image envelope.</p>
               </details>
             </div>
-            <div class="member" data-text="public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, span&lt;char&gt; destination, out int charswritten, out rmqrcodedecodeinfo info); detects and decodes an rmqr code from grayscale image pixels into a caller-provided buffer without per-call heap allocation. ">
-              <code>public static bool TryDecodeImage(ReadOnlySpan&lt;byte&gt; luminance, int width, int height, Span&lt;char&gt; destination, out int charsWritten, out RmQRCodeDecodeInfo info);</code>
+            <div class="member" data-text="method public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, span&lt;char&gt; destination, out int charswritten, out rmqrcodedecodeinfo info); detects and decodes an rmqr code from grayscale image pixels into a caller-provided buffer without per-call heap allocation. ">
+              <h4><span class="kind">method</span> <span class="name">TryDecodeImage</span></h4>
+              <pre class="sig"><code>public static bool TryDecodeImage(ReadOnlySpan&lt;byte&gt; luminance, int width, int height, Span&lt;char&gt; destination, out int charsWritten, out RmQRCodeDecodeInfo info);</code></pre>
               <p class="doc">Detects and decodes an rMQR Code from grayscale image pixels into a caller-provided buffer without per-call heap allocation.</p>
             </div>
-            <div class="member" data-text="public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, out string text, out rmqrcodedecodeinfo info); detects and decodes an rmqr code from grayscale image pixels. ">
-              <code>public static bool TryDecodeImage(ReadOnlySpan&lt;byte&gt; luminance, int width, int height, out string text, out RmQRCodeDecodeInfo info);</code>
+            <div class="member" data-text="method public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, out string text, out rmqrcodedecodeinfo info); detects and decodes an rmqr code from grayscale image pixels. ">
+              <h4><span class="kind">method</span> <span class="name">TryDecodeImage</span></h4>
+              <pre class="sig"><code>public static bool TryDecodeImage(ReadOnlySpan&lt;byte&gt; luminance, int width, int height, out string text, out RmQRCodeDecodeInfo info);</code></pre>
               <p class="doc">Detects and decodes an rMQR Code from grayscale image pixels.</p>
             </div>
-            <div class="member" data-text="public static int getmaxdecodedlength(rmqrversion version); calculates the maximum possible decoded character count for an rmqr version, across ecc levels and encoding modes. use to size the destination buffer for the allocation-free trydecode overload. ">
-              <code>public static int GetMaxDecodedLength(RmQRVersion version);</code>
+            <div class="member" data-text="method public static int getmaxdecodedlength(rmqrversion version); calculates the maximum possible decoded character count for an rmqr version, across ecc levels and encoding modes. use to size the destination buffer for the allocation-free trydecode overload. ">
+              <h4><span class="kind">method</span> <span class="name">GetMaxDecodedLength</span></h4>
+              <pre class="sig"><code>public static int GetMaxDecodedLength(RmQRVersion version);</code></pre>
               <p class="doc">Calculates the maximum possible decoded character count for an rMQR version, across ECC levels and encoding modes. Use to size the destination buffer for the allocation-free TryDecode overload.</p>
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.RmQRCodeGenerator" data-name="skiasharp.qrcode.rmqrcodegenerator" data-text="skiasharp.qrcode.rmqrcodegenerator public static class rmqrcodegenerator rmqr code (iso/iec 23941, r7x43-r17x139) generator: text → rectangular module matrix. sibling of qrcodegenerator and microqrcodegenerator with rmqr-typed version, ecc and fit parameters. version selection: an exact rmqrversion , or automatic fit among the versions that hold the content by rmqrfitstrategy (default minimizearea : fewest modules, the choice both reference encoders make; note it can prefer a taller, narrower symbol, e.g. 12 digits at m give r11x27 (297 modules) rather than r7x43 (301); use minimizeheight or a fixed rmqrheight for the flattest symbol), optionally restricted to one height. modes: numeric, alphanumeric and byte. byte mode emits eci assignment 3 for iso-8859-1 and assignment 26 for utf-8 (automatically selected by default, or explicitly requested). kanji is not written, use utf-8 instead; rmqrcodedecoder does read the kanji segments other encoders produce, so the two directions are deliberately asymmetric. the quiet zone defaults to the iso/iec 23941 value of 2 modules. public static rmqrcodedata creatermqrcode(readonlyspan&lt;char&gt; textspan, rmqrecclevel ecclevel, in rmqrcodegeneratoroptions options = null);  public static rmqrcodedata creatermqrcode(string plaintext, rmqrecclevel ecclevel, in rmqrcodegeneratoroptions options = null); creates an rmqr code from the provided plain text.  public static bool trygetrequiredbuffersize(readonlyspan&lt;char&gt; text, rmqrecclevel ecclevel, out rmqrcodecalculatedsize size, in rmqrcodegeneratoroptions options = null); calculates the required buffer size, dimensions and version for encoding the specified text as an rmqr code, reporting a content overflow as false rather than as an exception. false means the content does not fit, and nothing else: argument errors throw (rationale: specs/rmqr-encoder.md). rmqr holds 5-150 bytes, so an overflow is an ordinary answer here rather than a defect, which is why this is the only sizing method on this type. pass the same options you will encode with: segmentation and eci can select different versions, so a buffer sized for one can be too small for the other. public static int creatermqrcode(readonlyspan&lt;char&gt; textspan, rmqrecclevel ecclevel, span&lt;byte&gt; destination, in rmqrcodegeneratoroptions options = null); creates an rmqr code and writes the module matrix into the caller-provided buffer without per-call heap allocation. output format matches the other generators: one byte per module (0 = light, 1 = dark), flat row-major over the full width, quiet zone included. use trygetrequiredbuffersize to size the destination.">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.RmQRCodeGenerator" aria-label="Link to SkiaSharp.QrCode.RmQRCodeGenerator">#</a><code>public static class RmQRCodeGenerator</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.RmQRCodeGenerator" data-name="skiasharp.qrcode.rmqrcodegenerator" data-text="skiasharp.qrcode.rmqrcodegenerator public static class rmqrcodegenerator rmqr code (iso/iec 23941, r7x43-r17x139) generator: text → rectangular module matrix. sibling of qrcodegenerator and microqrcodegenerator with rmqr-typed version, ecc and fit parameters. version selection: an exact rmqrversion , or automatic fit among the versions that hold the content by rmqrfitstrategy (default minimizearea : fewest modules, the choice both reference encoders make; note it can prefer a taller, narrower symbol, e.g. 12 digits at m give r11x27 (297 modules) rather than r7x43 (301); use minimizeheight or a fixed rmqrheight for the flattest symbol), optionally restricted to one height. modes: numeric, alphanumeric and byte. byte mode emits eci assignment 3 for iso-8859-1 and assignment 26 for utf-8 (automatically selected by default, or explicitly requested). kanji is not written, use utf-8 instead; rmqrcodedecoder does read the kanji segments other encoders produce, so the two directions are deliberately asymmetric. the quiet zone defaults to the iso/iec 23941 value of 2 modules. method public static rmqrcodedata creatermqrcode(readonlyspan&lt;char&gt; textspan, rmqrecclevel ecclevel, in rmqrcodegeneratoroptions options = null);  method public static rmqrcodedata creatermqrcode(string plaintext, rmqrecclevel ecclevel, in rmqrcodegeneratoroptions options = null); creates an rmqr code from the provided plain text.  method public static bool trygetrequiredbuffersize(readonlyspan&lt;char&gt; text, rmqrecclevel ecclevel, out rmqrcodecalculatedsize size, in rmqrcodegeneratoroptions options = null); calculates the required buffer size, dimensions and version for encoding the specified text as an rmqr code, reporting a content overflow as false rather than as an exception. false means the content does not fit, and nothing else: argument errors throw (rationale: specs/rmqr-encoder.md). rmqr holds 5-150 bytes, so an overflow is an ordinary answer here rather than a defect, which is why this is the only sizing method on this type. pass the same options you will encode with: segmentation and eci can select different versions, so a buffer sized for one can be too small for the other. method public static int creatermqrcode(readonlyspan&lt;char&gt; textspan, rmqrecclevel ecclevel, span&lt;byte&gt; destination, in rmqrcodegeneratoroptions options = null); creates an rmqr code and writes the module matrix into the caller-provided buffer without per-call heap allocation. output format matches the other generators: one byte per module (0 = light, 1 = dark), flat row-major over the full width, quiet zone included. use trygetrequiredbuffersize to size the destination.">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.RmQRCodeGenerator" aria-label="Link to SkiaSharp.QrCode.RmQRCodeGenerator">#</a><span class="kind">class</span> <span class="name">RmQRCodeGenerator</span></h3>
+          <pre class="sig"><code>public static class RmQRCodeGenerator</code></pre>
           <p class="doc">rMQR Code (ISO/IEC 23941, R7x43-R17x139) generator: text → rectangular module matrix. Sibling of QRCodeGenerator and MicroQRCodeGenerator with rMQR-typed version, ECC and fit parameters.</p>
           <details class="notes" data-text="version selection: an exact rmqrversion , or automatic fit among the versions that hold the content by rmqrfitstrategy (default minimizearea : fewest modules, the choice both reference encoders make; note it can prefer a taller, narrower symbol, e.g. 12 digits at m give r11x27 (297 modules) rather than r7x43 (301); use minimizeheight or a fixed rmqrheight for the flattest symbol), optionally restricted to one height. modes: numeric, alphanumeric and byte. byte mode emits eci assignment 3 for iso-8859-1 and assignment 26 for utf-8 (automatically selected by default, or explicitly requested). kanji is not written, use utf-8 instead; rmqrcodedecoder does read the kanji segments other encoders produce, so the two directions are deliberately asymmetric. the quiet zone defaults to the iso/iec 23941 value of 2 modules.">
             <summary>Notes</summary>
             <p class="doc remarks">Version selection: an exact RmQRVersion , or automatic fit among the versions that hold the content by RmQRFitStrategy (default MinimizeArea : fewest modules, the choice both reference encoders make; note it can prefer a taller, narrower symbol, e.g. 12 digits at M give R11x27 (297 modules) rather than R7x43 (301); use MinimizeHeight or a fixed RmQRHeight for the flattest symbol), optionally restricted to one height. Modes: Numeric, Alphanumeric and Byte. Byte mode emits ECI assignment 3 for ISO-8859-1 and assignment 26 for UTF-8 (automatically selected by default, or explicitly requested). Kanji is not written, use UTF-8 instead; RmQRCodeDecoder does read the Kanji segments other encoders produce, so the two directions are deliberately asymmetric. The quiet zone defaults to the ISO/IEC 23941 value of 2 modules.</p>
           </details>
           <div class="members">
-            <div class="member" data-text="public static rmqrcodedata creatermqrcode(readonlyspan&lt;char&gt; textspan, rmqrecclevel ecclevel, in rmqrcodegeneratoroptions options = null); ">
-              <code>public static RmQRCodeData CreateRmQRCode(ReadOnlySpan&lt;char&gt; textSpan, RmQREccLevel eccLevel, in RmQRCodeGeneratorOptions options = null);</code>
+            <div class="member" data-text="method public static rmqrcodedata creatermqrcode(readonlyspan&lt;char&gt; textspan, rmqrecclevel ecclevel, in rmqrcodegeneratoroptions options = null); ">
+              <h4><span class="kind">method</span> <span class="name">CreateRmQRCode</span></h4>
+              <pre class="sig"><code>public static RmQRCodeData CreateRmQRCode(ReadOnlySpan&lt;char&gt; textSpan, RmQREccLevel eccLevel, in RmQRCodeGeneratorOptions options = null);</code></pre>
             </div>
-            <div class="member" data-text="public static rmqrcodedata creatermqrcode(string plaintext, rmqrecclevel ecclevel, in rmqrcodegeneratoroptions options = null); creates an rmqr code from the provided plain text. ">
-              <code>public static RmQRCodeData CreateRmQRCode(string plainText, RmQREccLevel eccLevel, in RmQRCodeGeneratorOptions options = null);</code>
+            <div class="member" data-text="method public static rmqrcodedata creatermqrcode(string plaintext, rmqrecclevel ecclevel, in rmqrcodegeneratoroptions options = null); creates an rmqr code from the provided plain text. ">
+              <h4><span class="kind">method</span> <span class="name">CreateRmQRCode</span></h4>
+              <pre class="sig"><code>public static RmQRCodeData CreateRmQRCode(string plainText, RmQREccLevel eccLevel, in RmQRCodeGeneratorOptions options = null);</code></pre>
               <p class="doc">Creates an rMQR code from the provided plain text.</p>
             </div>
-            <div class="member" data-text="public static bool trygetrequiredbuffersize(readonlyspan&lt;char&gt; text, rmqrecclevel ecclevel, out rmqrcodecalculatedsize size, in rmqrcodegeneratoroptions options = null); calculates the required buffer size, dimensions and version for encoding the specified text as an rmqr code, reporting a content overflow as false rather than as an exception. false means the content does not fit, and nothing else: argument errors throw (rationale: specs/rmqr-encoder.md). rmqr holds 5-150 bytes, so an overflow is an ordinary answer here rather than a defect, which is why this is the only sizing method on this type. pass the same options you will encode with: segmentation and eci can select different versions, so a buffer sized for one can be too small for the other.">
-              <code>public static bool TryGetRequiredBufferSize(ReadOnlySpan&lt;char&gt; text, RmQREccLevel eccLevel, out RmQRCodeCalculatedSize size, in RmQRCodeGeneratorOptions options = null);</code>
+            <div class="member" data-text="method public static bool trygetrequiredbuffersize(readonlyspan&lt;char&gt; text, rmqrecclevel ecclevel, out rmqrcodecalculatedsize size, in rmqrcodegeneratoroptions options = null); calculates the required buffer size, dimensions and version for encoding the specified text as an rmqr code, reporting a content overflow as false rather than as an exception. false means the content does not fit, and nothing else: argument errors throw (rationale: specs/rmqr-encoder.md). rmqr holds 5-150 bytes, so an overflow is an ordinary answer here rather than a defect, which is why this is the only sizing method on this type. pass the same options you will encode with: segmentation and eci can select different versions, so a buffer sized for one can be too small for the other.">
+              <h4><span class="kind">method</span> <span class="name">TryGetRequiredBufferSize</span></h4>
+              <pre class="sig"><code>public static bool TryGetRequiredBufferSize(ReadOnlySpan&lt;char&gt; text, RmQREccLevel eccLevel, out RmQRCodeCalculatedSize size, in RmQRCodeGeneratorOptions options = null);</code></pre>
               <p class="doc">Calculates the required buffer size, dimensions and version for encoding the specified text as an rMQR code, reporting a content overflow as false rather than as an exception.</p>
               <details class="notes" data-text="false means the content does not fit, and nothing else: argument errors throw (rationale: specs/rmqr-encoder.md). rmqr holds 5-150 bytes, so an overflow is an ordinary answer here rather than a defect, which is why this is the only sizing method on this type. pass the same options you will encode with: segmentation and eci can select different versions, so a buffer sized for one can be too small for the other.">
                 <summary>Notes</summary>
                 <p class="doc remarks">false means the content does not fit, and nothing else: argument errors throw (rationale: specs/rmqr-encoder.md). rMQR holds 5-150 bytes, so an overflow is an ordinary answer here rather than a defect, which is why this is the only sizing method on this type. Pass the same options you will encode with: segmentation and ECI can select different versions, so a buffer sized for one can be too small for the other.</p>
               </details>
             </div>
-            <div class="member" data-text="public static int creatermqrcode(readonlyspan&lt;char&gt; textspan, rmqrecclevel ecclevel, span&lt;byte&gt; destination, in rmqrcodegeneratoroptions options = null); creates an rmqr code and writes the module matrix into the caller-provided buffer without per-call heap allocation. output format matches the other generators: one byte per module (0 = light, 1 = dark), flat row-major over the full width, quiet zone included. use trygetrequiredbuffersize to size the destination.">
-              <code>public static int CreateRmQRCode(ReadOnlySpan&lt;char&gt; textSpan, RmQREccLevel eccLevel, Span&lt;byte&gt; destination, in RmQRCodeGeneratorOptions options = null);</code>
+            <div class="member" data-text="method public static int creatermqrcode(readonlyspan&lt;char&gt; textspan, rmqrecclevel ecclevel, span&lt;byte&gt; destination, in rmqrcodegeneratoroptions options = null); creates an rmqr code and writes the module matrix into the caller-provided buffer without per-call heap allocation. output format matches the other generators: one byte per module (0 = light, 1 = dark), flat row-major over the full width, quiet zone included. use trygetrequiredbuffersize to size the destination.">
+              <h4><span class="kind">method</span> <span class="name">CreateRmQRCode</span></h4>
+              <pre class="sig"><code>public static int CreateRmQRCode(ReadOnlySpan&lt;char&gt; textSpan, RmQREccLevel eccLevel, Span&lt;byte&gt; destination, in RmQRCodeGeneratorOptions options = null);</code></pre>
               <p class="doc">Creates an rMQR code and writes the module matrix into the caller-provided buffer without per-call heap allocation.</p>
               <details class="notes" data-text="output format matches the other generators: one byte per module (0 = light, 1 = dark), flat row-major over the full width, quiet zone included. use trygetrequiredbuffersize to size the destination.">
                 <summary>Notes</summary>
@@ -1562,120 +1776,132 @@
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.RmQRCodeGeneratorOptions" data-name="skiasharp.qrcode.rmqrcodegeneratoroptions" data-text="skiasharp.qrcode.rmqrcodegeneratoroptions public readonly struct rmqrcodegeneratoroptions : iequatable&lt;rmqrcodegeneratoroptions&gt; optional settings for rmqrcodegenerator . default is the complete default configuration and is what an omitted argument sends, so the shortest correct call is creatermqrcode(text, ecclevel). rmqr specific rather than shared: version is a different type in each symbology, quietzonesize has a different specified default, and fitstrategy , height and segmentation have no meaning outside rmqr. there is no version range here because rmqr's 32 versions are not totally ordered; fit is constrained by strategy and height instead. public ecimode ecimode { get; init; } character encoding declaration. the default auto-detects ascii (no eci), iso-8859-1 (assignment 3) or utf-8 (assignment 26) from the content. only default , iso8859_1 and utf8 are accepted. declaring latin-1 over content it cannot represent throws rather than silently re-encoding. public rmqrfitstrategy fitstrategy { get; init; } how to choose among the versions that hold the content. defaults to minimizearea , the choice both reference encoders make.  public rmqrheight? height { get; init; } restrict automatic fitting to one symbol height, or null (the default) to consider every height. must agree with version when both are set.  public rmqrsegmentation segmentation { get; init; } whether to split the content into mixed-mode segments. defaults to single . size a destination buffer with the same value you encode with: the two modes can select different versions.  public rmqrversion? version { get; init; } a specific version, or null (the default) to fit one automatically by fitstrategy and height .  public int quietzonesize { get; init; } quiet zone width in modules. defaults to 2, the iso/iec 23941 value; 0 is valid.  public static rmqrcodegeneratoroptions default { get; } the default configuration, identical to default. ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.RmQRCodeGeneratorOptions" aria-label="Link to SkiaSharp.QrCode.RmQRCodeGeneratorOptions">#</a><code>public readonly struct RmQRCodeGeneratorOptions : IEquatable&lt;RmQRCodeGeneratorOptions&gt;</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.RmQRCodeGeneratorOptions" data-name="skiasharp.qrcode.rmqrcodegeneratoroptions" data-text="skiasharp.qrcode.rmqrcodegeneratoroptions public readonly struct rmqrcodegeneratoroptions : iequatable&lt;rmqrcodegeneratoroptions&gt; optional settings for rmqrcodegenerator . default is the complete default configuration and is what an omitted argument sends, so the shortest correct call is creatermqrcode(text, ecclevel). rmqr specific rather than shared: version is a different type in each symbology, quietzonesize has a different specified default, and fitstrategy , height and segmentation have no meaning outside rmqr. there is no version range here because rmqr's 32 versions are not totally ordered; fit is constrained by strategy and height instead. property public ecimode ecimode { get; init; } character encoding declaration. the default auto-detects ascii (no eci), iso-8859-1 (assignment 3) or utf-8 (assignment 26) from the content. only default , iso8859_1 and utf8 are accepted. declaring latin-1 over content it cannot represent throws rather than silently re-encoding. property public rmqrfitstrategy fitstrategy { get; init; } how to choose among the versions that hold the content. defaults to minimizearea , the choice both reference encoders make.  property public rmqrheight? height { get; init; } restrict automatic fitting to one symbol height, or null (the default) to consider every height. must agree with version when both are set.  property public rmqrsegmentation segmentation { get; init; } whether to split the content into mixed-mode segments. defaults to single . size a destination buffer with the same value you encode with: the two modes can select different versions.  property public rmqrversion? version { get; init; } a specific version, or null (the default) to fit one automatically by fitstrategy and height .  property public int quietzonesize { get; init; } quiet zone width in modules. defaults to 2, the iso/iec 23941 value; 0 is valid.  property public static rmqrcodegeneratoroptions default { get; } the default configuration, identical to default. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.RmQRCodeGeneratorOptions" aria-label="Link to SkiaSharp.QrCode.RmQRCodeGeneratorOptions">#</a><span class="kind">struct</span> <span class="name">RmQRCodeGeneratorOptions</span></h3>
+          <pre class="sig"><code>public readonly struct RmQRCodeGeneratorOptions : IEquatable&lt;RmQRCodeGeneratorOptions&gt;</code></pre>
           <p class="doc">Optional settings for RmQRCodeGenerator . default is the complete default configuration and is what an omitted argument sends, so the shortest correct call is CreateRmQRCode(text, eccLevel).</p>
           <details class="notes" data-text="rmqr specific rather than shared: version is a different type in each symbology, quietzonesize has a different specified default, and fitstrategy , height and segmentation have no meaning outside rmqr. there is no version range here because rmqr's 32 versions are not totally ordered; fit is constrained by strategy and height instead.">
             <summary>Notes</summary>
             <p class="doc remarks">rMQR specific rather than shared: Version is a different type in each symbology, QuietZoneSize has a different specified default, and FitStrategy , Height and Segmentation have no meaning outside rMQR. There is no version range here because rMQR's 32 versions are not totally ordered; fit is constrained by strategy and height instead.</p>
           </details>
           <div class="members">
-            <div class="member" data-text="public ecimode ecimode { get; init; } character encoding declaration. the default auto-detects ascii (no eci), iso-8859-1 (assignment 3) or utf-8 (assignment 26) from the content. only default , iso8859_1 and utf8 are accepted. declaring latin-1 over content it cannot represent throws rather than silently re-encoding.">
-              <code>public EciMode EciMode { get; init; }</code>
+            <div class="member" data-text="property public ecimode ecimode { get; init; } character encoding declaration. the default auto-detects ascii (no eci), iso-8859-1 (assignment 3) or utf-8 (assignment 26) from the content. only default , iso8859_1 and utf8 are accepted. declaring latin-1 over content it cannot represent throws rather than silently re-encoding.">
+              <h4><span class="kind">property</span> <span class="name">EciMode</span></h4>
+              <pre class="sig"><code>public EciMode EciMode { get; init; }</code></pre>
               <p class="doc">Character encoding declaration. The default auto-detects ASCII (no ECI), ISO-8859-1 (assignment 3) or UTF-8 (assignment 26) from the content.</p>
               <details class="notes" data-text="only default , iso8859_1 and utf8 are accepted. declaring latin-1 over content it cannot represent throws rather than silently re-encoding.">
                 <summary>Notes</summary>
                 <p class="doc remarks">Only Default , Iso8859_1 and Utf8 are accepted. Declaring Latin-1 over content it cannot represent throws rather than silently re-encoding.</p>
               </details>
             </div>
-            <div class="member" data-text="public rmqrfitstrategy fitstrategy { get; init; } how to choose among the versions that hold the content. defaults to minimizearea , the choice both reference encoders make. ">
-              <code>public RmQRFitStrategy FitStrategy { get; init; }</code>
+            <div class="member" data-text="property public rmqrfitstrategy fitstrategy { get; init; } how to choose among the versions that hold the content. defaults to minimizearea , the choice both reference encoders make. ">
+              <h4><span class="kind">property</span> <span class="name">FitStrategy</span></h4>
+              <pre class="sig"><code>public RmQRFitStrategy FitStrategy { get; init; }</code></pre>
               <p class="doc">How to choose among the versions that hold the content. Defaults to MinimizeArea , the choice both reference encoders make.</p>
             </div>
-            <div class="member" data-text="public rmqrheight? height { get; init; } restrict automatic fitting to one symbol height, or null (the default) to consider every height. must agree with version when both are set. ">
-              <code>public RmQRHeight? Height { get; init; }</code>
+            <div class="member" data-text="property public rmqrheight? height { get; init; } restrict automatic fitting to one symbol height, or null (the default) to consider every height. must agree with version when both are set. ">
+              <h4><span class="kind">property</span> <span class="name">Height</span></h4>
+              <pre class="sig"><code>public RmQRHeight? Height { get; init; }</code></pre>
               <p class="doc">Restrict automatic fitting to one symbol height, or null (the default) to consider every height. Must agree with Version when both are set.</p>
             </div>
-            <div class="member" data-text="public rmqrsegmentation segmentation { get; init; } whether to split the content into mixed-mode segments. defaults to single . size a destination buffer with the same value you encode with: the two modes can select different versions. ">
-              <code>public RmQRSegmentation Segmentation { get; init; }</code>
+            <div class="member" data-text="property public rmqrsegmentation segmentation { get; init; } whether to split the content into mixed-mode segments. defaults to single . size a destination buffer with the same value you encode with: the two modes can select different versions. ">
+              <h4><span class="kind">property</span> <span class="name">Segmentation</span></h4>
+              <pre class="sig"><code>public RmQRSegmentation Segmentation { get; init; }</code></pre>
               <p class="doc">Whether to split the content into mixed-mode segments. Defaults to Single . Size a destination buffer with the same value you encode with: the two modes can select different versions.</p>
             </div>
-            <div class="member" data-text="public rmqrversion? version { get; init; } a specific version, or null (the default) to fit one automatically by fitstrategy and height . ">
-              <code>public RmQRVersion? Version { get; init; }</code>
+            <div class="member" data-text="property public rmqrversion? version { get; init; } a specific version, or null (the default) to fit one automatically by fitstrategy and height . ">
+              <h4><span class="kind">property</span> <span class="name">Version</span></h4>
+              <pre class="sig"><code>public RmQRVersion? Version { get; init; }</code></pre>
               <p class="doc">A specific version, or null (the default) to fit one automatically by FitStrategy and Height .</p>
             </div>
-            <div class="member" data-text="public int quietzonesize { get; init; } quiet zone width in modules. defaults to 2, the iso/iec 23941 value; 0 is valid. ">
-              <code>public int QuietZoneSize { get; init; }</code>
+            <div class="member" data-text="property public int quietzonesize { get; init; } quiet zone width in modules. defaults to 2, the iso/iec 23941 value; 0 is valid. ">
+              <h4><span class="kind">property</span> <span class="name">QuietZoneSize</span></h4>
+              <pre class="sig"><code>public int QuietZoneSize { get; init; }</code></pre>
               <p class="doc">Quiet zone width in modules. Defaults to 2, the ISO/IEC 23941 value; 0 is valid.</p>
             </div>
-            <div class="member" data-text="public static rmqrcodegeneratoroptions default { get; } the default configuration, identical to default. ">
-              <code>public static RmQRCodeGeneratorOptions Default { get; }</code>
+            <div class="member" data-text="property public static rmqrcodegeneratoroptions default { get; } the default configuration, identical to default. ">
+              <h4><span class="kind">property</span> <span class="name">Default</span></h4>
+              <pre class="sig"><code>public static RmQRCodeGeneratorOptions Default { get; }</code></pre>
               <p class="doc">The default configuration, identical to default.</p>
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.RmQREccLevel" data-name="skiasharp.qrcode.rmqrecclevel" data-text="skiasharp.qrcode.rmqrecclevel public enum rmqrecclevel : int rmqr code error correction level (iso/iec 23941). rmqr defines only two levels; the numeric value is the ecc bit carried in the format information.  m = 0, medium: about 15% of codewords recoverable.  h = 1, high: about 30% of codewords recoverable. ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.RmQREccLevel" aria-label="Link to SkiaSharp.QrCode.RmQREccLevel">#</a><code>public enum RmQREccLevel : int</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.RmQREccLevel" data-name="skiasharp.qrcode.rmqrecclevel" data-text="skiasharp.qrcode.rmqrecclevel public enum rmqrecclevel : int rmqr code error correction level (iso/iec 23941). rmqr defines only two levels; the numeric value is the ecc bit carried in the format information.  value m = 0, medium: about 15% of codewords recoverable.  value h = 1, high: about 30% of codewords recoverable. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.RmQREccLevel" aria-label="Link to SkiaSharp.QrCode.RmQREccLevel">#</a><span class="kind">enum</span> <span class="name">RmQREccLevel</span></h3>
+          <pre class="sig"><code>public enum RmQREccLevel : int</code></pre>
           <p class="doc">rMQR Code error correction level (ISO/IEC 23941). rMQR defines only two levels; the numeric value is the ECC bit carried in the format information.</p>
           <div class="members">
-            <div class="member" data-text="m = 0, medium: about 15% of codewords recoverable. ">
-              <code>M = 0,</code>
+            <div class="member" data-text="value m = 0, medium: about 15% of codewords recoverable. ">
+              <pre class="sig"><code>M = 0,</code></pre>
               <p class="doc">Medium: about 15% of codewords recoverable.</p>
             </div>
-            <div class="member" data-text="h = 1, high: about 30% of codewords recoverable. ">
-              <code>H = 1,</code>
+            <div class="member" data-text="value h = 1, high: about 30% of codewords recoverable. ">
+              <pre class="sig"><code>H = 1,</code></pre>
               <p class="doc">High: about 30% of codewords recoverable.</p>
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.RmQRFitStrategy" data-name="skiasharp.qrcode.rmqrfitstrategy" data-text="skiasharp.qrcode.rmqrfitstrategy public enum rmqrfitstrategy : int how rmqrcodegenerator chooses among the rmqr versions that can hold the content when no exact version is requested. rmqr sizes are two-dimensional, so &quot;smallest&quot; is a policy: fewest modules, narrowest, or shortest.  minimizearea = 0, fewest modules (height × width); ties prefer the smaller height, i.e. the wider symbol. the default.  minimizewidth = 1, smallest width; ties prefer the smaller height.  minimizeheight = 2, smallest height; ties prefer the smaller width. ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.RmQRFitStrategy" aria-label="Link to SkiaSharp.QrCode.RmQRFitStrategy">#</a><code>public enum RmQRFitStrategy : int</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.RmQRFitStrategy" data-name="skiasharp.qrcode.rmqrfitstrategy" data-text="skiasharp.qrcode.rmqrfitstrategy public enum rmqrfitstrategy : int how rmqrcodegenerator chooses among the rmqr versions that can hold the content when no exact version is requested. rmqr sizes are two-dimensional, so &quot;smallest&quot; is a policy: fewest modules, narrowest, or shortest.  value minimizearea = 0, fewest modules (height × width); ties prefer the smaller height, i.e. the wider symbol. the default.  value minimizewidth = 1, smallest width; ties prefer the smaller height.  value minimizeheight = 2, smallest height; ties prefer the smaller width. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.RmQRFitStrategy" aria-label="Link to SkiaSharp.QrCode.RmQRFitStrategy">#</a><span class="kind">enum</span> <span class="name">RmQRFitStrategy</span></h3>
+          <pre class="sig"><code>public enum RmQRFitStrategy : int</code></pre>
           <p class="doc">How RmQRCodeGenerator chooses among the rMQR versions that can hold the content when no exact version is requested. rMQR sizes are two-dimensional, so &quot;smallest&quot; is a policy: fewest modules, narrowest, or shortest.</p>
           <div class="members">
-            <div class="member" data-text="minimizearea = 0, fewest modules (height × width); ties prefer the smaller height, i.e. the wider symbol. the default. ">
-              <code>MinimizeArea = 0,</code>
+            <div class="member" data-text="value minimizearea = 0, fewest modules (height × width); ties prefer the smaller height, i.e. the wider symbol. the default. ">
+              <pre class="sig"><code>MinimizeArea = 0,</code></pre>
               <p class="doc">Fewest modules (height × width); ties prefer the smaller height, i.e. the wider symbol. The default.</p>
             </div>
-            <div class="member" data-text="minimizewidth = 1, smallest width; ties prefer the smaller height. ">
-              <code>MinimizeWidth = 1,</code>
+            <div class="member" data-text="value minimizewidth = 1, smallest width; ties prefer the smaller height. ">
+              <pre class="sig"><code>MinimizeWidth = 1,</code></pre>
               <p class="doc">Smallest width; ties prefer the smaller height.</p>
             </div>
-            <div class="member" data-text="minimizeheight = 2, smallest height; ties prefer the smaller width. ">
-              <code>MinimizeHeight = 2,</code>
+            <div class="member" data-text="value minimizeheight = 2, smallest height; ties prefer the smaller width. ">
+              <pre class="sig"><code>MinimizeHeight = 2,</code></pre>
               <p class="doc">Smallest height; ties prefer the smaller width.</p>
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.RmQRHeight" data-name="skiasharp.qrcode.rmqrheight" data-text="skiasharp.qrcode.rmqrheight public enum rmqrheight : int fixed rmqr symbol height in modules for automatic width selection (&quot;fixed height, automatic width&quot;): the generator only considers the versions of this height and picks among them by rmqrfitstrategy . values are the module heights themselves.  h7 = 7, 7 modules high (widths 43-139).  h9 = 9, 9 modules high (widths 43-139).  h11 = 11, 11 modules high (widths 27-139).  h13 = 13, 13 modules high (widths 27-139).  h15 = 15, 15 modules high (widths 43-139).  h17 = 17, 17 modules high (widths 43-139). ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.RmQRHeight" aria-label="Link to SkiaSharp.QrCode.RmQRHeight">#</a><code>public enum RmQRHeight : int</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.RmQRHeight" data-name="skiasharp.qrcode.rmqrheight" data-text="skiasharp.qrcode.rmqrheight public enum rmqrheight : int fixed rmqr symbol height in modules for automatic width selection (&quot;fixed height, automatic width&quot;): the generator only considers the versions of this height and picks among them by rmqrfitstrategy . values are the module heights themselves.  value h7 = 7, 7 modules high (widths 43-139).  value h9 = 9, 9 modules high (widths 43-139).  value h11 = 11, 11 modules high (widths 27-139).  value h13 = 13, 13 modules high (widths 27-139).  value h15 = 15, 15 modules high (widths 43-139).  value h17 = 17, 17 modules high (widths 43-139). ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.RmQRHeight" aria-label="Link to SkiaSharp.QrCode.RmQRHeight">#</a><span class="kind">enum</span> <span class="name">RmQRHeight</span></h3>
+          <pre class="sig"><code>public enum RmQRHeight : int</code></pre>
           <p class="doc">Fixed rMQR symbol height in modules for automatic width selection (&quot;fixed height, automatic width&quot;): the generator only considers the versions of this height and picks among them by RmQRFitStrategy . Values are the module heights themselves.</p>
           <div class="members">
-            <div class="member" data-text="h7 = 7, 7 modules high (widths 43-139). ">
-              <code>H7 = 7,</code>
+            <div class="member" data-text="value h7 = 7, 7 modules high (widths 43-139). ">
+              <pre class="sig"><code>H7 = 7,</code></pre>
               <p class="doc">7 modules high (widths 43-139).</p>
             </div>
-            <div class="member" data-text="h9 = 9, 9 modules high (widths 43-139). ">
-              <code>H9 = 9,</code>
+            <div class="member" data-text="value h9 = 9, 9 modules high (widths 43-139). ">
+              <pre class="sig"><code>H9 = 9,</code></pre>
               <p class="doc">9 modules high (widths 43-139).</p>
             </div>
-            <div class="member" data-text="h11 = 11, 11 modules high (widths 27-139). ">
-              <code>H11 = 11,</code>
+            <div class="member" data-text="value h11 = 11, 11 modules high (widths 27-139). ">
+              <pre class="sig"><code>H11 = 11,</code></pre>
               <p class="doc">11 modules high (widths 27-139).</p>
             </div>
-            <div class="member" data-text="h13 = 13, 13 modules high (widths 27-139). ">
-              <code>H13 = 13,</code>
+            <div class="member" data-text="value h13 = 13, 13 modules high (widths 27-139). ">
+              <pre class="sig"><code>H13 = 13,</code></pre>
               <p class="doc">13 modules high (widths 27-139).</p>
             </div>
-            <div class="member" data-text="h15 = 15, 15 modules high (widths 43-139). ">
-              <code>H15 = 15,</code>
+            <div class="member" data-text="value h15 = 15, 15 modules high (widths 43-139). ">
+              <pre class="sig"><code>H15 = 15,</code></pre>
               <p class="doc">15 modules high (widths 43-139).</p>
             </div>
-            <div class="member" data-text="h17 = 17, 17 modules high (widths 43-139). ">
-              <code>H17 = 17,</code>
+            <div class="member" data-text="value h17 = 17, 17 modules high (widths 43-139). ">
+              <pre class="sig"><code>H17 = 17,</code></pre>
               <p class="doc">17 modules high (widths 43-139).</p>
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.RmQRSegmentation" data-name="skiasharp.qrcode.rmqrsegmentation" data-text="skiasharp.qrcode.rmqrsegmentation public enum rmqrsegmentation : int how rmqrcodegenerator splits the content into encoding-mode segments. rmqr capacities are small, so mixing modes (for example a byte prefix followed by a numeric tail) can drop the symbol by one or more versions.  single = 0, one segment in the single mode that can represent the whole content (numeric, else alphanumeric, else byte). the default, and the cheapest to encode.  optimal = 1, the mixed-mode split with the fewest total bits. never selects a symbol with more core modules than single , emits the single bit stream verbatim when a split would not shrink it, and additionally encodes content that overflows every version in a single mode — unless the minimal-bit plan would be misread on decode (a relocated byte order mark), in which case it reports &quot;does not fit&quot; rather than emitting a stream that decodes differently. opt-in because it searches candidate versions; the search itself allocates nothing, and content no split can help is ruled out before it starts. fewer core modules is not the same as a smaller image: rmqrfitstrategy ranks by core modules while the quiet zone adds to each dimension, so a flatter symbol can render onto a larger grid. size buffers with the same segmentation you encode with.">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.RmQRSegmentation" aria-label="Link to SkiaSharp.QrCode.RmQRSegmentation">#</a><code>public enum RmQRSegmentation : int</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.RmQRSegmentation" data-name="skiasharp.qrcode.rmqrsegmentation" data-text="skiasharp.qrcode.rmqrsegmentation public enum rmqrsegmentation : int how rmqrcodegenerator splits the content into encoding-mode segments. rmqr capacities are small, so mixing modes (for example a byte prefix followed by a numeric tail) can drop the symbol by one or more versions.  value single = 0, one segment in the single mode that can represent the whole content (numeric, else alphanumeric, else byte). the default, and the cheapest to encode.  value optimal = 1, the mixed-mode split with the fewest total bits. never selects a symbol with more core modules than single , emits the single bit stream verbatim when a split would not shrink it, and additionally encodes content that overflows every version in a single mode — unless the minimal-bit plan would be misread on decode (a relocated byte order mark), in which case it reports &quot;does not fit&quot; rather than emitting a stream that decodes differently. opt-in because it searches candidate versions; the search itself allocates nothing, and content no split can help is ruled out before it starts. fewer core modules is not the same as a smaller image: rmqrfitstrategy ranks by core modules while the quiet zone adds to each dimension, so a flatter symbol can render onto a larger grid. size buffers with the same segmentation you encode with.">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.RmQRSegmentation" aria-label="Link to SkiaSharp.QrCode.RmQRSegmentation">#</a><span class="kind">enum</span> <span class="name">RmQRSegmentation</span></h3>
+          <pre class="sig"><code>public enum RmQRSegmentation : int</code></pre>
           <p class="doc">How RmQRCodeGenerator splits the content into encoding-mode segments. rMQR capacities are small, so mixing modes (for example a Byte prefix followed by a Numeric tail) can drop the symbol by one or more versions.</p>
           <div class="members">
-            <div class="member" data-text="single = 0, one segment in the single mode that can represent the whole content (numeric, else alphanumeric, else byte). the default, and the cheapest to encode. ">
-              <code>Single = 0,</code>
+            <div class="member" data-text="value single = 0, one segment in the single mode that can represent the whole content (numeric, else alphanumeric, else byte). the default, and the cheapest to encode. ">
+              <pre class="sig"><code>Single = 0,</code></pre>
               <p class="doc">One segment in the single mode that can represent the whole content (Numeric, else Alphanumeric, else Byte). The default, and the cheapest to encode.</p>
             </div>
-            <div class="member" data-text="optimal = 1, the mixed-mode split with the fewest total bits. never selects a symbol with more core modules than single , emits the single bit stream verbatim when a split would not shrink it, and additionally encodes content that overflows every version in a single mode — unless the minimal-bit plan would be misread on decode (a relocated byte order mark), in which case it reports &quot;does not fit&quot; rather than emitting a stream that decodes differently. opt-in because it searches candidate versions; the search itself allocates nothing, and content no split can help is ruled out before it starts. fewer core modules is not the same as a smaller image: rmqrfitstrategy ranks by core modules while the quiet zone adds to each dimension, so a flatter symbol can render onto a larger grid. size buffers with the same segmentation you encode with.">
-              <code>Optimal = 1,</code>
+            <div class="member" data-text="value optimal = 1, the mixed-mode split with the fewest total bits. never selects a symbol with more core modules than single , emits the single bit stream verbatim when a split would not shrink it, and additionally encodes content that overflows every version in a single mode — unless the minimal-bit plan would be misread on decode (a relocated byte order mark), in which case it reports &quot;does not fit&quot; rather than emitting a stream that decodes differently. opt-in because it searches candidate versions; the search itself allocates nothing, and content no split can help is ruled out before it starts. fewer core modules is not the same as a smaller image: rmqrfitstrategy ranks by core modules while the quiet zone adds to each dimension, so a flatter symbol can render onto a larger grid. size buffers with the same segmentation you encode with.">
+              <pre class="sig"><code>Optimal = 1,</code></pre>
               <p class="doc">The mixed-mode split with the fewest total bits. Never selects a symbol with more core modules than Single , emits the Single bit stream verbatim when a split would not shrink it, and additionally encodes content that overflows every version in a single mode — unless the minimal-bit plan would be misread on decode (a relocated byte order mark), in which case it reports &quot;does not fit&quot; rather than emitting a stream that decodes differently.</p>
               <details class="notes" data-text="opt-in because it searches candidate versions; the search itself allocates nothing, and content no split can help is ruled out before it starts. fewer core modules is not the same as a smaller image: rmqrfitstrategy ranks by core modules while the quiet zone adds to each dimension, so a flatter symbol can render onto a larger grid. size buffers with the same segmentation you encode with.">
                 <summary>Notes</summary>
@@ -1684,136 +1910,137 @@
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.RmQRVersion" data-name="skiasharp.qrcode.rmqrversion" data-text="skiasharp.qrcode.rmqrversion public enum rmqrversion : int rmqr code symbol version (iso/iec 23941): 32 rectangular sizes named r{height}x{width}. values follow the iso version index (height-major order) plus one, so (int)version - 1 is the 5-bit version index carried in the format information and (int)version is libzint's rmqr version number.  r7x43 = 1, 7 × 43 modules.  r7x59 = 2, 7 × 59 modules.  r7x77 = 3, 7 × 77 modules.  r7x99 = 4, 7 × 99 modules.  r7x139 = 5, 7 × 139 modules.  r9x43 = 6, 9 × 43 modules.  r9x59 = 7, 9 × 59 modules.  r9x77 = 8, 9 × 77 modules.  r9x99 = 9, 9 × 99 modules.  r9x139 = 10, 9 × 139 modules.  r11x27 = 11, 11 × 27 modules.  r11x43 = 12, 11 × 43 modules.  r11x59 = 13, 11 × 59 modules.  r11x77 = 14, 11 × 77 modules.  r11x99 = 15, 11 × 99 modules.  r11x139 = 16, 11 × 139 modules.  r13x27 = 17, 13 × 27 modules.  r13x43 = 18, 13 × 43 modules.  r13x59 = 19, 13 × 59 modules.  r13x77 = 20, 13 × 77 modules.  r13x99 = 21, 13 × 99 modules.  r13x139 = 22, 13 × 139 modules.  r15x43 = 23, 15 × 43 modules.  r15x59 = 24, 15 × 59 modules.  r15x77 = 25, 15 × 77 modules.  r15x99 = 26, 15 × 99 modules.  r15x139 = 27, 15 × 139 modules.  r17x43 = 28, 17 × 43 modules.  r17x59 = 29, 17 × 59 modules.  r17x77 = 30, 17 × 77 modules.  r17x99 = 31, 17 × 99 modules.  r17x139 = 32, 17 × 139 modules. ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.RmQRVersion" aria-label="Link to SkiaSharp.QrCode.RmQRVersion">#</a><code>public enum RmQRVersion : int</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.RmQRVersion" data-name="skiasharp.qrcode.rmqrversion" data-text="skiasharp.qrcode.rmqrversion public enum rmqrversion : int rmqr code symbol version (iso/iec 23941): 32 rectangular sizes named r{height}x{width}. values follow the iso version index (height-major order) plus one, so (int)version - 1 is the 5-bit version index carried in the format information and (int)version is libzint's rmqr version number.  value r7x43 = 1, 7 × 43 modules.  value r7x59 = 2, 7 × 59 modules.  value r7x77 = 3, 7 × 77 modules.  value r7x99 = 4, 7 × 99 modules.  value r7x139 = 5, 7 × 139 modules.  value r9x43 = 6, 9 × 43 modules.  value r9x59 = 7, 9 × 59 modules.  value r9x77 = 8, 9 × 77 modules.  value r9x99 = 9, 9 × 99 modules.  value r9x139 = 10, 9 × 139 modules.  value r11x27 = 11, 11 × 27 modules.  value r11x43 = 12, 11 × 43 modules.  value r11x59 = 13, 11 × 59 modules.  value r11x77 = 14, 11 × 77 modules.  value r11x99 = 15, 11 × 99 modules.  value r11x139 = 16, 11 × 139 modules.  value r13x27 = 17, 13 × 27 modules.  value r13x43 = 18, 13 × 43 modules.  value r13x59 = 19, 13 × 59 modules.  value r13x77 = 20, 13 × 77 modules.  value r13x99 = 21, 13 × 99 modules.  value r13x139 = 22, 13 × 139 modules.  value r15x43 = 23, 15 × 43 modules.  value r15x59 = 24, 15 × 59 modules.  value r15x77 = 25, 15 × 77 modules.  value r15x99 = 26, 15 × 99 modules.  value r15x139 = 27, 15 × 139 modules.  value r17x43 = 28, 17 × 43 modules.  value r17x59 = 29, 17 × 59 modules.  value r17x77 = 30, 17 × 77 modules.  value r17x99 = 31, 17 × 99 modules.  value r17x139 = 32, 17 × 139 modules. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.RmQRVersion" aria-label="Link to SkiaSharp.QrCode.RmQRVersion">#</a><span class="kind">enum</span> <span class="name">RmQRVersion</span></h3>
+          <pre class="sig"><code>public enum RmQRVersion : int</code></pre>
           <p class="doc">rMQR Code symbol version (ISO/IEC 23941): 32 rectangular sizes named R{height}x{width}. Values follow the ISO version index (height-major order) plus one, so (int)version - 1 is the 5-bit version index carried in the format information and (int)version is libzint's rMQR version number.</p>
           <div class="members">
-            <div class="member" data-text="r7x43 = 1, 7 × 43 modules. ">
-              <code>R7x43 = 1,</code>
+            <div class="member" data-text="value r7x43 = 1, 7 × 43 modules. ">
+              <pre class="sig"><code>R7x43 = 1,</code></pre>
               <p class="doc">7 × 43 modules.</p>
             </div>
-            <div class="member" data-text="r7x59 = 2, 7 × 59 modules. ">
-              <code>R7x59 = 2,</code>
+            <div class="member" data-text="value r7x59 = 2, 7 × 59 modules. ">
+              <pre class="sig"><code>R7x59 = 2,</code></pre>
               <p class="doc">7 × 59 modules.</p>
             </div>
-            <div class="member" data-text="r7x77 = 3, 7 × 77 modules. ">
-              <code>R7x77 = 3,</code>
+            <div class="member" data-text="value r7x77 = 3, 7 × 77 modules. ">
+              <pre class="sig"><code>R7x77 = 3,</code></pre>
               <p class="doc">7 × 77 modules.</p>
             </div>
-            <div class="member" data-text="r7x99 = 4, 7 × 99 modules. ">
-              <code>R7x99 = 4,</code>
+            <div class="member" data-text="value r7x99 = 4, 7 × 99 modules. ">
+              <pre class="sig"><code>R7x99 = 4,</code></pre>
               <p class="doc">7 × 99 modules.</p>
             </div>
-            <div class="member" data-text="r7x139 = 5, 7 × 139 modules. ">
-              <code>R7x139 = 5,</code>
+            <div class="member" data-text="value r7x139 = 5, 7 × 139 modules. ">
+              <pre class="sig"><code>R7x139 = 5,</code></pre>
               <p class="doc">7 × 139 modules.</p>
             </div>
-            <div class="member" data-text="r9x43 = 6, 9 × 43 modules. ">
-              <code>R9x43 = 6,</code>
+            <div class="member" data-text="value r9x43 = 6, 9 × 43 modules. ">
+              <pre class="sig"><code>R9x43 = 6,</code></pre>
               <p class="doc">9 × 43 modules.</p>
             </div>
-            <div class="member" data-text="r9x59 = 7, 9 × 59 modules. ">
-              <code>R9x59 = 7,</code>
+            <div class="member" data-text="value r9x59 = 7, 9 × 59 modules. ">
+              <pre class="sig"><code>R9x59 = 7,</code></pre>
               <p class="doc">9 × 59 modules.</p>
             </div>
-            <div class="member" data-text="r9x77 = 8, 9 × 77 modules. ">
-              <code>R9x77 = 8,</code>
+            <div class="member" data-text="value r9x77 = 8, 9 × 77 modules. ">
+              <pre class="sig"><code>R9x77 = 8,</code></pre>
               <p class="doc">9 × 77 modules.</p>
             </div>
-            <div class="member" data-text="r9x99 = 9, 9 × 99 modules. ">
-              <code>R9x99 = 9,</code>
+            <div class="member" data-text="value r9x99 = 9, 9 × 99 modules. ">
+              <pre class="sig"><code>R9x99 = 9,</code></pre>
               <p class="doc">9 × 99 modules.</p>
             </div>
-            <div class="member" data-text="r9x139 = 10, 9 × 139 modules. ">
-              <code>R9x139 = 10,</code>
+            <div class="member" data-text="value r9x139 = 10, 9 × 139 modules. ">
+              <pre class="sig"><code>R9x139 = 10,</code></pre>
               <p class="doc">9 × 139 modules.</p>
             </div>
-            <div class="member" data-text="r11x27 = 11, 11 × 27 modules. ">
-              <code>R11x27 = 11,</code>
+            <div class="member" data-text="value r11x27 = 11, 11 × 27 modules. ">
+              <pre class="sig"><code>R11x27 = 11,</code></pre>
               <p class="doc">11 × 27 modules.</p>
             </div>
-            <div class="member" data-text="r11x43 = 12, 11 × 43 modules. ">
-              <code>R11x43 = 12,</code>
+            <div class="member" data-text="value r11x43 = 12, 11 × 43 modules. ">
+              <pre class="sig"><code>R11x43 = 12,</code></pre>
               <p class="doc">11 × 43 modules.</p>
             </div>
-            <div class="member" data-text="r11x59 = 13, 11 × 59 modules. ">
-              <code>R11x59 = 13,</code>
+            <div class="member" data-text="value r11x59 = 13, 11 × 59 modules. ">
+              <pre class="sig"><code>R11x59 = 13,</code></pre>
               <p class="doc">11 × 59 modules.</p>
             </div>
-            <div class="member" data-text="r11x77 = 14, 11 × 77 modules. ">
-              <code>R11x77 = 14,</code>
+            <div class="member" data-text="value r11x77 = 14, 11 × 77 modules. ">
+              <pre class="sig"><code>R11x77 = 14,</code></pre>
               <p class="doc">11 × 77 modules.</p>
             </div>
-            <div class="member" data-text="r11x99 = 15, 11 × 99 modules. ">
-              <code>R11x99 = 15,</code>
+            <div class="member" data-text="value r11x99 = 15, 11 × 99 modules. ">
+              <pre class="sig"><code>R11x99 = 15,</code></pre>
               <p class="doc">11 × 99 modules.</p>
             </div>
-            <div class="member" data-text="r11x139 = 16, 11 × 139 modules. ">
-              <code>R11x139 = 16,</code>
+            <div class="member" data-text="value r11x139 = 16, 11 × 139 modules. ">
+              <pre class="sig"><code>R11x139 = 16,</code></pre>
               <p class="doc">11 × 139 modules.</p>
             </div>
-            <div class="member" data-text="r13x27 = 17, 13 × 27 modules. ">
-              <code>R13x27 = 17,</code>
+            <div class="member" data-text="value r13x27 = 17, 13 × 27 modules. ">
+              <pre class="sig"><code>R13x27 = 17,</code></pre>
               <p class="doc">13 × 27 modules.</p>
             </div>
-            <div class="member" data-text="r13x43 = 18, 13 × 43 modules. ">
-              <code>R13x43 = 18,</code>
+            <div class="member" data-text="value r13x43 = 18, 13 × 43 modules. ">
+              <pre class="sig"><code>R13x43 = 18,</code></pre>
               <p class="doc">13 × 43 modules.</p>
             </div>
-            <div class="member" data-text="r13x59 = 19, 13 × 59 modules. ">
-              <code>R13x59 = 19,</code>
+            <div class="member" data-text="value r13x59 = 19, 13 × 59 modules. ">
+              <pre class="sig"><code>R13x59 = 19,</code></pre>
               <p class="doc">13 × 59 modules.</p>
             </div>
-            <div class="member" data-text="r13x77 = 20, 13 × 77 modules. ">
-              <code>R13x77 = 20,</code>
+            <div class="member" data-text="value r13x77 = 20, 13 × 77 modules. ">
+              <pre class="sig"><code>R13x77 = 20,</code></pre>
               <p class="doc">13 × 77 modules.</p>
             </div>
-            <div class="member" data-text="r13x99 = 21, 13 × 99 modules. ">
-              <code>R13x99 = 21,</code>
+            <div class="member" data-text="value r13x99 = 21, 13 × 99 modules. ">
+              <pre class="sig"><code>R13x99 = 21,</code></pre>
               <p class="doc">13 × 99 modules.</p>
             </div>
-            <div class="member" data-text="r13x139 = 22, 13 × 139 modules. ">
-              <code>R13x139 = 22,</code>
+            <div class="member" data-text="value r13x139 = 22, 13 × 139 modules. ">
+              <pre class="sig"><code>R13x139 = 22,</code></pre>
               <p class="doc">13 × 139 modules.</p>
             </div>
-            <div class="member" data-text="r15x43 = 23, 15 × 43 modules. ">
-              <code>R15x43 = 23,</code>
+            <div class="member" data-text="value r15x43 = 23, 15 × 43 modules. ">
+              <pre class="sig"><code>R15x43 = 23,</code></pre>
               <p class="doc">15 × 43 modules.</p>
             </div>
-            <div class="member" data-text="r15x59 = 24, 15 × 59 modules. ">
-              <code>R15x59 = 24,</code>
+            <div class="member" data-text="value r15x59 = 24, 15 × 59 modules. ">
+              <pre class="sig"><code>R15x59 = 24,</code></pre>
               <p class="doc">15 × 59 modules.</p>
             </div>
-            <div class="member" data-text="r15x77 = 25, 15 × 77 modules. ">
-              <code>R15x77 = 25,</code>
+            <div class="member" data-text="value r15x77 = 25, 15 × 77 modules. ">
+              <pre class="sig"><code>R15x77 = 25,</code></pre>
               <p class="doc">15 × 77 modules.</p>
             </div>
-            <div class="member" data-text="r15x99 = 26, 15 × 99 modules. ">
-              <code>R15x99 = 26,</code>
+            <div class="member" data-text="value r15x99 = 26, 15 × 99 modules. ">
+              <pre class="sig"><code>R15x99 = 26,</code></pre>
               <p class="doc">15 × 99 modules.</p>
             </div>
-            <div class="member" data-text="r15x139 = 27, 15 × 139 modules. ">
-              <code>R15x139 = 27,</code>
+            <div class="member" data-text="value r15x139 = 27, 15 × 139 modules. ">
+              <pre class="sig"><code>R15x139 = 27,</code></pre>
               <p class="doc">15 × 139 modules.</p>
             </div>
-            <div class="member" data-text="r17x43 = 28, 17 × 43 modules. ">
-              <code>R17x43 = 28,</code>
+            <div class="member" data-text="value r17x43 = 28, 17 × 43 modules. ">
+              <pre class="sig"><code>R17x43 = 28,</code></pre>
               <p class="doc">17 × 43 modules.</p>
             </div>
-            <div class="member" data-text="r17x59 = 29, 17 × 59 modules. ">
-              <code>R17x59 = 29,</code>
+            <div class="member" data-text="value r17x59 = 29, 17 × 59 modules. ">
+              <pre class="sig"><code>R17x59 = 29,</code></pre>
               <p class="doc">17 × 59 modules.</p>
             </div>
-            <div class="member" data-text="r17x77 = 30, 17 × 77 modules. ">
-              <code>R17x77 = 30,</code>
+            <div class="member" data-text="value r17x77 = 30, 17 × 77 modules. ">
+              <pre class="sig"><code>R17x77 = 30,</code></pre>
               <p class="doc">17 × 77 modules.</p>
             </div>
-            <div class="member" data-text="r17x99 = 31, 17 × 99 modules. ">
-              <code>R17x99 = 31,</code>
+            <div class="member" data-text="value r17x99 = 31, 17 × 99 modules. ">
+              <pre class="sig"><code>R17x99 = 31,</code></pre>
               <p class="doc">17 × 99 modules.</p>
             </div>
-            <div class="member" data-text="r17x139 = 32, 17 × 139 modules. ">
-              <code>R17x139 = 32,</code>
+            <div class="member" data-text="value r17x139 = 32, 17 × 139 modules. ">
+              <pre class="sig"><code>R17x139 = 32,</code></pre>
               <p class="doc">17 × 139 modules.</p>
             </div>
           </div>
@@ -1821,67 +2048,83 @@
       </section>
       <section class="ns">
         <h2>namespace SkiaSharp.QrCode.Image</h2>
-        <article class="type" id="SkiaSharp.QrCode.Image.CircleFinderPatternShape" data-name="skiasharp.qrcode.image.circlefinderpatternshape" data-text="skiasharp.qrcode.image.circlefinderpatternshape public sealed class circlefinderpatternshape : finderpatternshape circular finder pattern. (three nested circles, 7x7, 5x5, 3x3)  public static readonly circlefinderpatternshape default; gets the default instance.  public bool requiresantialiasing { get; } requires antialiasing to prevent jagged edges on curves.  public override void draw(skcanvas canvas, skrect rect, skpaint paint);  public override void draw(skcanvas canvas, skrect rect, skpaint paint, skcolor backgroundcolor);  public override void draw(skcanvas canvas, skrect rect, skpaint paint, skpaint backgroundpaint); ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.CircleFinderPatternShape" aria-label="Link to SkiaSharp.QrCode.Image.CircleFinderPatternShape">#</a><code>public sealed class CircleFinderPatternShape : FinderPatternShape</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.Image.CircleFinderPatternShape" data-name="skiasharp.qrcode.image.circlefinderpatternshape" data-text="skiasharp.qrcode.image.circlefinderpatternshape public sealed class circlefinderpatternshape : finderpatternshape circular finder pattern. (three nested circles, 7x7, 5x5, 3x3)  field public static readonly circlefinderpatternshape default; gets the default instance.  property public bool requiresantialiasing { get; } requires antialiasing to prevent jagged edges on curves.  method public override void draw(skcanvas canvas, skrect rect, skpaint paint);  method public override void draw(skcanvas canvas, skrect rect, skpaint paint, skcolor backgroundcolor);  method public override void draw(skcanvas canvas, skrect rect, skpaint paint, skpaint backgroundpaint); ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.CircleFinderPatternShape" aria-label="Link to SkiaSharp.QrCode.Image.CircleFinderPatternShape">#</a><span class="kind">class</span> <span class="name">CircleFinderPatternShape</span></h3>
+          <pre class="sig"><code>public sealed class CircleFinderPatternShape : FinderPatternShape</code></pre>
           <p class="doc">Circular finder pattern. (three nested circles, 7x7, 5x5, 3x3)</p>
           <div class="members">
-            <div class="member" data-text="public static readonly circlefinderpatternshape default; gets the default instance. ">
-              <code>public static readonly CircleFinderPatternShape Default;</code>
+            <div class="member" data-text="field public static readonly circlefinderpatternshape default; gets the default instance. ">
+              <h4><span class="kind">field</span> <span class="name">Default</span></h4>
+              <pre class="sig"><code>public static readonly CircleFinderPatternShape Default;</code></pre>
               <p class="doc">Gets the default instance.</p>
             </div>
-            <div class="member" data-text="public bool requiresantialiasing { get; } requires antialiasing to prevent jagged edges on curves. ">
-              <code>public bool RequiresAntialiasing { get; }</code>
+            <div class="member" data-text="property public bool requiresantialiasing { get; } requires antialiasing to prevent jagged edges on curves. ">
+              <h4><span class="kind">property</span> <span class="name">RequiresAntialiasing</span></h4>
+              <pre class="sig"><code>public bool RequiresAntialiasing { get; }</code></pre>
               <p class="doc">Requires antialiasing to prevent jagged edges on curves.</p>
             </div>
-            <div class="member" data-text="public override void draw(skcanvas canvas, skrect rect, skpaint paint); ">
-              <code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint);</code>
+            <div class="member" data-text="method public override void draw(skcanvas canvas, skrect rect, skpaint paint); ">
+              <h4><span class="kind">method</span> <span class="name">Draw</span></h4>
+              <pre class="sig"><code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint);</code></pre>
             </div>
-            <div class="member" data-text="public override void draw(skcanvas canvas, skrect rect, skpaint paint, skcolor backgroundcolor); ">
-              <code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint, SKColor backgroundColor);</code>
+            <div class="member" data-text="method public override void draw(skcanvas canvas, skrect rect, skpaint paint, skcolor backgroundcolor); ">
+              <h4><span class="kind">method</span> <span class="name">Draw</span></h4>
+              <pre class="sig"><code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint, SKColor backgroundColor);</code></pre>
             </div>
-            <div class="member" data-text="public override void draw(skcanvas canvas, skrect rect, skpaint paint, skpaint backgroundpaint); ">
-              <code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint, SKPaint backgroundPaint);</code>
+            <div class="member" data-text="method public override void draw(skcanvas canvas, skrect rect, skpaint paint, skpaint backgroundpaint); ">
+              <h4><span class="kind">method</span> <span class="name">Draw</span></h4>
+              <pre class="sig"><code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint, SKPaint backgroundPaint);</code></pre>
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.Image.CircleModuleShape" data-name="skiasharp.qrcode.image.circlemoduleshape" data-text="skiasharp.qrcode.image.circlemoduleshape public sealed class circlemoduleshape : moduleshape draws modules as circles.  public static readonly circlemoduleshape default; gets the default instance.  public bool requiresantialiasing { get; } requires antialiasing to prevent jagged edges on curves.  public override void draw(skcanvas canvas, skrect rect, skpaint paint); ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.CircleModuleShape" aria-label="Link to SkiaSharp.QrCode.Image.CircleModuleShape">#</a><code>public sealed class CircleModuleShape : ModuleShape</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.Image.CircleModuleShape" data-name="skiasharp.qrcode.image.circlemoduleshape" data-text="skiasharp.qrcode.image.circlemoduleshape public sealed class circlemoduleshape : moduleshape draws modules as circles.  field public static readonly circlemoduleshape default; gets the default instance.  property public bool requiresantialiasing { get; } requires antialiasing to prevent jagged edges on curves.  method public override void draw(skcanvas canvas, skrect rect, skpaint paint); ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.CircleModuleShape" aria-label="Link to SkiaSharp.QrCode.Image.CircleModuleShape">#</a><span class="kind">class</span> <span class="name">CircleModuleShape</span></h3>
+          <pre class="sig"><code>public sealed class CircleModuleShape : ModuleShape</code></pre>
           <p class="doc">Draws modules as circles.</p>
           <div class="members">
-            <div class="member" data-text="public static readonly circlemoduleshape default; gets the default instance. ">
-              <code>public static readonly CircleModuleShape Default;</code>
+            <div class="member" data-text="field public static readonly circlemoduleshape default; gets the default instance. ">
+              <h4><span class="kind">field</span> <span class="name">Default</span></h4>
+              <pre class="sig"><code>public static readonly CircleModuleShape Default;</code></pre>
               <p class="doc">Gets the default instance.</p>
             </div>
-            <div class="member" data-text="public bool requiresantialiasing { get; } requires antialiasing to prevent jagged edges on curves. ">
-              <code>public bool RequiresAntialiasing { get; }</code>
+            <div class="member" data-text="property public bool requiresantialiasing { get; } requires antialiasing to prevent jagged edges on curves. ">
+              <h4><span class="kind">property</span> <span class="name">RequiresAntialiasing</span></h4>
+              <pre class="sig"><code>public bool RequiresAntialiasing { get; }</code></pre>
               <p class="doc">Requires antialiasing to prevent jagged edges on curves.</p>
             </div>
-            <div class="member" data-text="public override void draw(skcanvas canvas, skrect rect, skpaint paint); ">
-              <code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint);</code>
+            <div class="member" data-text="method public override void draw(skcanvas canvas, skrect rect, skpaint paint); ">
+              <h4><span class="kind">method</span> <span class="name">Draw</span></h4>
+              <pre class="sig"><code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint);</code></pre>
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.Image.FinderPatternShape" data-name="skiasharp.qrcode.image.finderpatternshape" data-text="skiasharp.qrcode.image.finderpatternshape public abstract class finderpatternshape defines the shape of qr code finder pattern (position detection patterns).  protected finderpatternshape();  public bool requiresantialiasing { get; } gets whether this shape requires antialiasing for smooth rendering. curved shapes such as circles and rounded rectangles should return true ; straight-edged shapes such as rectangles can return false .  public abstract void draw(skcanvas canvas, skrect rect, skpaint paint); draw a finder pattern at the specified location.  public virtual void draw(skcanvas canvas, skrect rect, skpaint paint, skcolor backgroundcolor); draw a finder pattern at the specified location with background color support.  public virtual void draw(skcanvas canvas, skrect rect, skpaint paint, skpaint backgroundpaint); draw a finder pattern at the specified location using an existing background paint. the default implementation preserves compatibility with custom finder shapes that override the color-based overload. built-in shapes override this overload so the renderer can reuse its background paint. the renderer may set the paint's blend mode to clear while drawing on an isolated layer so transparent and translucent light modules reveal the background rendered beneath the finder pattern. implementations should therefore draw with this paint directly instead of copying only its color. the renderer owns backgroundpaint and may reuse it across calls; implementations must not modify or dispose it. custom shapes should override this overload when they need to reuse the renderer's configured background paint or when they must support non-opaque backgrounds (blend modes). existing custom shapes may continue to override draw , but that overload cannot use the renderer's blend mode.">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.FinderPatternShape" aria-label="Link to SkiaSharp.QrCode.Image.FinderPatternShape">#</a><code>public abstract class FinderPatternShape</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.Image.FinderPatternShape" data-name="skiasharp.qrcode.image.finderpatternshape" data-text="skiasharp.qrcode.image.finderpatternshape public abstract class finderpatternshape defines the shape of qr code finder pattern (position detection patterns).  constructor protected finderpatternshape();  property public bool requiresantialiasing { get; } gets whether this shape requires antialiasing for smooth rendering. curved shapes such as circles and rounded rectangles should return true ; straight-edged shapes such as rectangles can return false .  method public abstract void draw(skcanvas canvas, skrect rect, skpaint paint); draw a finder pattern at the specified location.  method public virtual void draw(skcanvas canvas, skrect rect, skpaint paint, skcolor backgroundcolor); draw a finder pattern at the specified location with background color support.  method public virtual void draw(skcanvas canvas, skrect rect, skpaint paint, skpaint backgroundpaint); draw a finder pattern at the specified location using an existing background paint. the default implementation preserves compatibility with custom finder shapes that override the color-based overload. built-in shapes override this overload so the renderer can reuse its background paint. the renderer may set the paint's blend mode to clear while drawing on an isolated layer so transparent and translucent light modules reveal the background rendered beneath the finder pattern. implementations should therefore draw with this paint directly instead of copying only its color. the renderer owns backgroundpaint and may reuse it across calls; implementations must not modify or dispose it. custom shapes should override this overload when they need to reuse the renderer's configured background paint or when they must support non-opaque backgrounds (blend modes). existing custom shapes may continue to override draw , but that overload cannot use the renderer's blend mode.">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.FinderPatternShape" aria-label="Link to SkiaSharp.QrCode.Image.FinderPatternShape">#</a><span class="kind">class</span> <span class="name">FinderPatternShape</span></h3>
+          <pre class="sig"><code>public abstract class FinderPatternShape</code></pre>
           <p class="doc">Defines the shape of QR code finder pattern (position detection patterns).</p>
           <div class="members">
-            <div class="member" data-text="protected finderpatternshape(); ">
-              <code>protected FinderPatternShape();</code>
+            <div class="member" data-text="constructor protected finderpatternshape(); ">
+              <h4><span class="kind">constructor</span> <span class="name">FinderPatternShape</span></h4>
+              <pre class="sig"><code>protected FinderPatternShape();</code></pre>
             </div>
-            <div class="member" data-text="public bool requiresantialiasing { get; } gets whether this shape requires antialiasing for smooth rendering. curved shapes such as circles and rounded rectangles should return true ; straight-edged shapes such as rectangles can return false . ">
-              <code>public bool RequiresAntialiasing { get; }</code>
+            <div class="member" data-text="property public bool requiresantialiasing { get; } gets whether this shape requires antialiasing for smooth rendering. curved shapes such as circles and rounded rectangles should return true ; straight-edged shapes such as rectangles can return false . ">
+              <h4><span class="kind">property</span> <span class="name">RequiresAntialiasing</span></h4>
+              <pre class="sig"><code>public bool RequiresAntialiasing { get; }</code></pre>
               <p class="doc">Gets whether this shape requires antialiasing for smooth rendering. Curved shapes such as circles and rounded rectangles should return true ; straight-edged shapes such as rectangles can return false .</p>
             </div>
-            <div class="member" data-text="public abstract void draw(skcanvas canvas, skrect rect, skpaint paint); draw a finder pattern at the specified location. ">
-              <code>public abstract void Draw(SKCanvas canvas, SKRect rect, SKPaint paint);</code>
+            <div class="member" data-text="method public abstract void draw(skcanvas canvas, skrect rect, skpaint paint); draw a finder pattern at the specified location. ">
+              <h4><span class="kind">method</span> <span class="name">Draw</span></h4>
+              <pre class="sig"><code>public abstract void Draw(SKCanvas canvas, SKRect rect, SKPaint paint);</code></pre>
               <p class="doc">Draw a finder pattern at the specified location.</p>
             </div>
-            <div class="member" data-text="public virtual void draw(skcanvas canvas, skrect rect, skpaint paint, skcolor backgroundcolor); draw a finder pattern at the specified location with background color support. ">
-              <code>public virtual void Draw(SKCanvas canvas, SKRect rect, SKPaint paint, SKColor backgroundColor);</code>
+            <div class="member" data-text="method public virtual void draw(skcanvas canvas, skrect rect, skpaint paint, skcolor backgroundcolor); draw a finder pattern at the specified location with background color support. ">
+              <h4><span class="kind">method</span> <span class="name">Draw</span></h4>
+              <pre class="sig"><code>public virtual void Draw(SKCanvas canvas, SKRect rect, SKPaint paint, SKColor backgroundColor);</code></pre>
               <p class="doc">Draw a finder pattern at the specified location with background color support.</p>
             </div>
-            <div class="member" data-text="public virtual void draw(skcanvas canvas, skrect rect, skpaint paint, skpaint backgroundpaint); draw a finder pattern at the specified location using an existing background paint. the default implementation preserves compatibility with custom finder shapes that override the color-based overload. built-in shapes override this overload so the renderer can reuse its background paint. the renderer may set the paint's blend mode to clear while drawing on an isolated layer so transparent and translucent light modules reveal the background rendered beneath the finder pattern. implementations should therefore draw with this paint directly instead of copying only its color. the renderer owns backgroundpaint and may reuse it across calls; implementations must not modify or dispose it. custom shapes should override this overload when they need to reuse the renderer's configured background paint or when they must support non-opaque backgrounds (blend modes). existing custom shapes may continue to override draw , but that overload cannot use the renderer's blend mode.">
-              <code>public virtual void Draw(SKCanvas canvas, SKRect rect, SKPaint paint, SKPaint backgroundPaint);</code>
+            <div class="member" data-text="method public virtual void draw(skcanvas canvas, skrect rect, skpaint paint, skpaint backgroundpaint); draw a finder pattern at the specified location using an existing background paint. the default implementation preserves compatibility with custom finder shapes that override the color-based overload. built-in shapes override this overload so the renderer can reuse its background paint. the renderer may set the paint's blend mode to clear while drawing on an isolated layer so transparent and translucent light modules reveal the background rendered beneath the finder pattern. implementations should therefore draw with this paint directly instead of copying only its color. the renderer owns backgroundpaint and may reuse it across calls; implementations must not modify or dispose it. custom shapes should override this overload when they need to reuse the renderer's configured background paint or when they must support non-opaque backgrounds (blend modes). existing custom shapes may continue to override draw , but that overload cannot use the renderer's blend mode.">
+              <h4><span class="kind">method</span> <span class="name">Draw</span></h4>
+              <pre class="sig"><code>public virtual void Draw(SKCanvas canvas, SKRect rect, SKPaint paint, SKPaint backgroundPaint);</code></pre>
               <p class="doc">Draw a finder pattern at the specified location using an existing background paint.</p>
               <details class="notes" data-text="the default implementation preserves compatibility with custom finder shapes that override the color-based overload. built-in shapes override this overload so the renderer can reuse its background paint. the renderer may set the paint's blend mode to clear while drawing on an isolated layer so transparent and translucent light modules reveal the background rendered beneath the finder pattern. implementations should therefore draw with this paint directly instead of copying only its color. the renderer owns backgroundpaint and may reuse it across calls; implementations must not modify or dispose it. custom shapes should override this overload when they need to reuse the renderer's configured background paint or when they must support non-opaque backgrounds (blend modes). existing custom shapes may continue to override draw , but that overload cannot use the renderer's blend mode.">
                 <summary>Notes</summary>
@@ -1890,86 +2133,93 @@
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.Image.GradientDirection" data-name="skiasharp.qrcode.image.gradientdirection" data-text="skiasharp.qrcode.image.gradientdirection public enum gradientdirection : int defines the direction of gradient flow for qr code rendering. linear gradients flow in a straight line across the entire qr code area. the direction determines the start and end points of the gradient. common use cases: lefttoright or toptobottom : simple horizontal/vertical gradients toplefttobottomright : diagonal gradients for dynamic appearance none : use when solid color is desired (disables gradient) none = 0, no gradient. use solid color specified in qr code rendering options. however, if solid is required, it's better to omit gradient options entirely.  lefttoright = 1, gradient flows from left edge to right edge horizontally.  righttoleft = 2, gradient flows from right edge to left edge horizontally.  toptobottom = 3, gradient flows from top edge to bottom edge vertically.  bottomtotop = 4, gradient flows from bottom edge to top edge vertically.  toplefttobottomright = 5, gradient flows diagonally from top-left corner to bottom-right corner.  toprighttobottomleft = 6, gradient flows diagonally from top-right corner to bottom-left corner.  bottomlefttotopright = 7, gradient flows diagonally from bottom-left corner to top-right corner.  bottomrighttotopleft = 8, gradient flows diagonally from bottom-right corner to top-left corner. ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.GradientDirection" aria-label="Link to SkiaSharp.QrCode.Image.GradientDirection">#</a><code>public enum GradientDirection : int</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.Image.GradientDirection" data-name="skiasharp.qrcode.image.gradientdirection" data-text="skiasharp.qrcode.image.gradientdirection public enum gradientdirection : int defines the direction of gradient flow for qr code rendering. linear gradients flow in a straight line across the entire qr code area. the direction determines the start and end points of the gradient. common use cases: lefttoright or toptobottom : simple horizontal/vertical gradients toplefttobottomright : diagonal gradients for dynamic appearance none : use when solid color is desired (disables gradient) value none = 0, no gradient. use solid color specified in qr code rendering options. however, if solid is required, it's better to omit gradient options entirely.  value lefttoright = 1, gradient flows from left edge to right edge horizontally.  value righttoleft = 2, gradient flows from right edge to left edge horizontally.  value toptobottom = 3, gradient flows from top edge to bottom edge vertically.  value bottomtotop = 4, gradient flows from bottom edge to top edge vertically.  value toplefttobottomright = 5, gradient flows diagonally from top-left corner to bottom-right corner.  value toprighttobottomleft = 6, gradient flows diagonally from top-right corner to bottom-left corner.  value bottomlefttotopright = 7, gradient flows diagonally from bottom-left corner to top-right corner.  value bottomrighttotopleft = 8, gradient flows diagonally from bottom-right corner to top-left corner. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.GradientDirection" aria-label="Link to SkiaSharp.QrCode.Image.GradientDirection">#</a><span class="kind">enum</span> <span class="name">GradientDirection</span></h3>
+          <pre class="sig"><code>public enum GradientDirection : int</code></pre>
           <p class="doc">Defines the direction of gradient flow for QR code rendering.</p>
           <details class="notes" data-text="linear gradients flow in a straight line across the entire qr code area. the direction determines the start and end points of the gradient. common use cases: lefttoright or toptobottom : simple horizontal/vertical gradients toplefttobottomright : diagonal gradients for dynamic appearance none : use when solid color is desired (disables gradient)">
             <summary>Notes</summary>
             <p class="doc remarks">Linear gradients flow in a straight line across the entire QR code area. The direction determines the start and end points of the gradient. Common Use Cases: LeftToRight or TopToBottom : Simple horizontal/vertical gradients TopLeftToBottomRight : Diagonal gradients for dynamic appearance None : Use when solid color is desired (disables gradient)</p>
           </details>
           <div class="members">
-            <div class="member" data-text="none = 0, no gradient. use solid color specified in qr code rendering options. however, if solid is required, it's better to omit gradient options entirely. ">
-              <code>None = 0,</code>
+            <div class="member" data-text="value none = 0, no gradient. use solid color specified in qr code rendering options. however, if solid is required, it's better to omit gradient options entirely. ">
+              <pre class="sig"><code>None = 0,</code></pre>
               <p class="doc">No gradient. Use solid color specified in QR code rendering options. However, if solid is required, it's better to omit gradient options entirely.</p>
             </div>
-            <div class="member" data-text="lefttoright = 1, gradient flows from left edge to right edge horizontally. ">
-              <code>LeftToRight = 1,</code>
+            <div class="member" data-text="value lefttoright = 1, gradient flows from left edge to right edge horizontally. ">
+              <pre class="sig"><code>LeftToRight = 1,</code></pre>
               <p class="doc">Gradient flows from left edge to right edge horizontally.</p>
             </div>
-            <div class="member" data-text="righttoleft = 2, gradient flows from right edge to left edge horizontally. ">
-              <code>RightToLeft = 2,</code>
+            <div class="member" data-text="value righttoleft = 2, gradient flows from right edge to left edge horizontally. ">
+              <pre class="sig"><code>RightToLeft = 2,</code></pre>
               <p class="doc">Gradient flows from right edge to left edge horizontally.</p>
             </div>
-            <div class="member" data-text="toptobottom = 3, gradient flows from top edge to bottom edge vertically. ">
-              <code>TopToBottom = 3,</code>
+            <div class="member" data-text="value toptobottom = 3, gradient flows from top edge to bottom edge vertically. ">
+              <pre class="sig"><code>TopToBottom = 3,</code></pre>
               <p class="doc">Gradient flows from top edge to bottom edge vertically.</p>
             </div>
-            <div class="member" data-text="bottomtotop = 4, gradient flows from bottom edge to top edge vertically. ">
-              <code>BottomToTop = 4,</code>
+            <div class="member" data-text="value bottomtotop = 4, gradient flows from bottom edge to top edge vertically. ">
+              <pre class="sig"><code>BottomToTop = 4,</code></pre>
               <p class="doc">Gradient flows from bottom edge to top edge vertically.</p>
             </div>
-            <div class="member" data-text="toplefttobottomright = 5, gradient flows diagonally from top-left corner to bottom-right corner. ">
-              <code>TopLeftToBottomRight = 5,</code>
+            <div class="member" data-text="value toplefttobottomright = 5, gradient flows diagonally from top-left corner to bottom-right corner. ">
+              <pre class="sig"><code>TopLeftToBottomRight = 5,</code></pre>
               <p class="doc">Gradient flows diagonally from top-left corner to bottom-right corner.</p>
             </div>
-            <div class="member" data-text="toprighttobottomleft = 6, gradient flows diagonally from top-right corner to bottom-left corner. ">
-              <code>TopRightToBottomLeft = 6,</code>
+            <div class="member" data-text="value toprighttobottomleft = 6, gradient flows diagonally from top-right corner to bottom-left corner. ">
+              <pre class="sig"><code>TopRightToBottomLeft = 6,</code></pre>
               <p class="doc">Gradient flows diagonally from top-right corner to bottom-left corner.</p>
             </div>
-            <div class="member" data-text="bottomlefttotopright = 7, gradient flows diagonally from bottom-left corner to top-right corner. ">
-              <code>BottomLeftToTopRight = 7,</code>
+            <div class="member" data-text="value bottomlefttotopright = 7, gradient flows diagonally from bottom-left corner to top-right corner. ">
+              <pre class="sig"><code>BottomLeftToTopRight = 7,</code></pre>
               <p class="doc">Gradient flows diagonally from bottom-left corner to top-right corner.</p>
             </div>
-            <div class="member" data-text="bottomrighttotopleft = 8, gradient flows diagonally from bottom-right corner to top-left corner. ">
-              <code>BottomRightToTopLeft = 8,</code>
+            <div class="member" data-text="value bottomrighttotopleft = 8, gradient flows diagonally from bottom-right corner to top-left corner. ">
+              <pre class="sig"><code>BottomRightToTopLeft = 8,</code></pre>
               <p class="doc">Gradient flows diagonally from bottom-right corner to top-left corner.</p>
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.Image.GradientOptions" data-name="skiasharp.qrcode.image.gradientoptions" data-text="skiasharp.qrcode.image.gradientoptions public class gradientoptions : iequatable&lt;gradientoptions&gt; defines gradient configuration for qr code rendering. this record configures linear gradients that are applied across the entire qr code. gradients can flow in various directions (horizontal, vertical, diagonal). for simple two-color gradients, specify two colors in colors . for multi-color gradients, provide additional colors and optionally specify colorpositions . public static readonly gradientoptions default; a ready-made gradient: dark orange to firebrick, running from the top-left corner to the bottom-right. use it when you want a gradient without choosing colors.  public gradientoptions(skcolor[] colors, gradientdirection direction = 1, float[]? colorpositions = null); initializes a new instance of the gradientoptions record.  public gradientdirection direction { get; init; } the gradient direction. determines the start and end points of the gradient across the qr code area. public skcolor[] colors { get; init; } gradient colors for multi-color gradients. at least 2 colors are required. the gradient flows from the first color to the last color in the direction specified by direction . public float[]? colorpositions { get; init; } optional color stops (0.0 to 1.0) for the gradient. if null, colors are evenly distributed across the gradient. if specified, the array length must match colors length. values must be in ascending order from 0.0 (start) to 1.0 (end). for example: [0.0f, 0.3f, 1.0f] for three colors.">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.GradientOptions" aria-label="Link to SkiaSharp.QrCode.Image.GradientOptions">#</a><code>public class GradientOptions : IEquatable&lt;GradientOptions&gt;</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.Image.GradientOptions" data-name="skiasharp.qrcode.image.gradientoptions" data-text="skiasharp.qrcode.image.gradientoptions public class gradientoptions : iequatable&lt;gradientoptions&gt; defines gradient configuration for qr code rendering. this record configures linear gradients that are applied across the entire qr code. gradients can flow in various directions (horizontal, vertical, diagonal). for simple two-color gradients, specify two colors in colors . for multi-color gradients, provide additional colors and optionally specify colorpositions . field public static readonly gradientoptions default; a ready-made gradient: dark orange to firebrick, running from the top-left corner to the bottom-right. use it when you want a gradient without choosing colors.  constructor public gradientoptions(skcolor[] colors, gradientdirection direction = 1, float[]? colorpositions = null); initializes a new instance of the gradientoptions record.  property public gradientdirection direction { get; init; } the gradient direction. determines the start and end points of the gradient across the qr code area. property public skcolor[] colors { get; init; } gradient colors for multi-color gradients. at least 2 colors are required. the gradient flows from the first color to the last color in the direction specified by direction . property public float[]? colorpositions { get; init; } optional color stops (0.0 to 1.0) for the gradient. if null, colors are evenly distributed across the gradient. if specified, the array length must match colors length. values must be in ascending order from 0.0 (start) to 1.0 (end). for example: [0.0f, 0.3f, 1.0f] for three colors.">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.GradientOptions" aria-label="Link to SkiaSharp.QrCode.Image.GradientOptions">#</a><span class="kind">class</span> <span class="name">GradientOptions</span></h3>
+          <pre class="sig"><code>public class GradientOptions : IEquatable&lt;GradientOptions&gt;</code></pre>
           <p class="doc">Defines gradient configuration for QR code rendering.</p>
           <details class="notes" data-text="this record configures linear gradients that are applied across the entire qr code. gradients can flow in various directions (horizontal, vertical, diagonal). for simple two-color gradients, specify two colors in colors . for multi-color gradients, provide additional colors and optionally specify colorpositions .">
             <summary>Notes</summary>
             <p class="doc remarks">This record configures linear gradients that are applied across the entire QR code. Gradients can flow in various directions (horizontal, vertical, diagonal). For simple two-color gradients, specify two colors in Colors . For multi-color gradients, provide additional colors and optionally specify ColorPositions .</p>
           </details>
           <div class="members">
-            <div class="member" data-text="public static readonly gradientoptions default; a ready-made gradient: dark orange to firebrick, running from the top-left corner to the bottom-right. use it when you want a gradient without choosing colors. ">
-              <code>public static readonly GradientOptions Default;</code>
+            <div class="member" data-text="field public static readonly gradientoptions default; a ready-made gradient: dark orange to firebrick, running from the top-left corner to the bottom-right. use it when you want a gradient without choosing colors. ">
+              <h4><span class="kind">field</span> <span class="name">Default</span></h4>
+              <pre class="sig"><code>public static readonly GradientOptions Default;</code></pre>
               <p class="doc">A ready-made gradient: dark orange to firebrick, running from the top-left corner to the bottom-right. Use it when you want a gradient without choosing colors.</p>
             </div>
-            <div class="member" data-text="public gradientoptions(skcolor[] colors, gradientdirection direction = 1, float[]? colorpositions = null); initializes a new instance of the gradientoptions record. ">
-              <code>public GradientOptions(SKColor[] colors, GradientDirection direction = 1, float[]? colorPositions = null);</code>
+            <div class="member" data-text="constructor public gradientoptions(skcolor[] colors, gradientdirection direction = 1, float[]? colorpositions = null); initializes a new instance of the gradientoptions record. ">
+              <h4><span class="kind">constructor</span> <span class="name">GradientOptions</span></h4>
+              <pre class="sig"><code>public GradientOptions(SKColor[] colors, GradientDirection direction = 1, float[]? colorPositions = null);</code></pre>
               <p class="doc">Initializes a new instance of the GradientOptions record.</p>
             </div>
-            <div class="member" data-text="public gradientdirection direction { get; init; } the gradient direction. determines the start and end points of the gradient across the qr code area.">
-              <code>public GradientDirection Direction { get; init; }</code>
+            <div class="member" data-text="property public gradientdirection direction { get; init; } the gradient direction. determines the start and end points of the gradient across the qr code area.">
+              <h4><span class="kind">property</span> <span class="name">Direction</span></h4>
+              <pre class="sig"><code>public GradientDirection Direction { get; init; }</code></pre>
               <p class="doc">The gradient direction.</p>
               <details class="notes" data-text="determines the start and end points of the gradient across the qr code area.">
                 <summary>Notes</summary>
                 <p class="doc remarks">Determines the start and end points of the gradient across the QR code area.</p>
               </details>
             </div>
-            <div class="member" data-text="public skcolor[] colors { get; init; } gradient colors for multi-color gradients. at least 2 colors are required. the gradient flows from the first color to the last color in the direction specified by direction .">
-              <code>public SKColor[] Colors { get; init; }</code>
+            <div class="member" data-text="property public skcolor[] colors { get; init; } gradient colors for multi-color gradients. at least 2 colors are required. the gradient flows from the first color to the last color in the direction specified by direction .">
+              <h4><span class="kind">property</span> <span class="name">Colors</span></h4>
+              <pre class="sig"><code>public SKColor[] Colors { get; init; }</code></pre>
               <p class="doc">Gradient colors for multi-color gradients.</p>
               <details class="notes" data-text="at least 2 colors are required. the gradient flows from the first color to the last color in the direction specified by direction .">
                 <summary>Notes</summary>
                 <p class="doc remarks">At least 2 colors are required. The gradient flows from the first color to the last color in the direction specified by Direction .</p>
               </details>
             </div>
-            <div class="member" data-text="public float[]? colorpositions { get; init; } optional color stops (0.0 to 1.0) for the gradient. if null, colors are evenly distributed across the gradient. if specified, the array length must match colors length. values must be in ascending order from 0.0 (start) to 1.0 (end). for example: [0.0f, 0.3f, 1.0f] for three colors.">
-              <code>public float[]? ColorPositions { get; init; }</code>
+            <div class="member" data-text="property public float[]? colorpositions { get; init; } optional color stops (0.0 to 1.0) for the gradient. if null, colors are evenly distributed across the gradient. if specified, the array length must match colors length. values must be in ascending order from 0.0 (start) to 1.0 (end). for example: [0.0f, 0.3f, 1.0f] for three colors.">
+              <h4><span class="kind">property</span> <span class="name">ColorPositions</span></h4>
+              <pre class="sig"><code>public float[]? ColorPositions { get; init; }</code></pre>
               <p class="doc">Optional color stops (0.0 to 1.0) for the gradient.</p>
               <details class="notes" data-text="if null, colors are evenly distributed across the gradient. if specified, the array length must match colors length. values must be in ascending order from 0.0 (start) to 1.0 (end). for example: [0.0f, 0.3f, 1.0f] for three colors.">
                 <summary>Notes</summary>
@@ -1978,47 +2228,57 @@
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.Image.IconData" data-name="skiasharp.qrcode.image.icondata" data-text="skiasharp.qrcode.image.icondata public class icondata the logo or image drawn at the center of a qr code, and its size. the icon covers modules, so the symbol relies on error correction to stay readable. use the highest error correction level ( h ) and keep the icon small. when the size is given in modules, rendering throws if the icon and its border span more than maxcoreoccupancypercent percent of the core width; sizes given as a percentage of the image are not checked against the symbol at all. [obsolete] public icondata();  public iconshape icon { get; set; } the icon shape to overlay on the qr code.  public int iconborderwidth { get; set; } the border width around the icon in pixels. creates a background-colored padding around the icon. ignored when iconsizemodules is set.  public int iconsizepercent { get; set; } the size of the icon as a percentage of the qr code size (1-100). ignored when iconsizemodules is set.  public int maxcoreoccupancypercent { get; set; } maximum allowed icon occupancy of the qr core area, as a percentage (1-100). used only for module-based sizing. default is 30.  public int? iconbordermodules { get; set; } the border width around the icon in qr modules. when iconsizemodules is set and this is null, defaults to 1.  public int? iconsizemodules { get; set; } the size of the icon body in qr modules. when set, module-based sizing is used and iconsizepercent / iconborderwidth are ignored.  public static icondata fromimage(skbitmap image, int iconsizepercent = 10, int iconborderwidth = 2); create icondata from a bitmap image using percent/pixel sizing.  public static icondata fromimagebymodules(skbitmap image, int iconsizemodules, int iconbordermodules = 1, int maxcoreoccupancypercent = 30); create icondata from a bitmap image using module-based sizing. prefer combining this with withmodulepixelsize so each module maps to an integer pixel size. optional withsize can then set a larger canvas; content is centered and padded. validation against qr size/core occupancy happens at render time.">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.IconData" aria-label="Link to SkiaSharp.QrCode.Image.IconData">#</a><code>public class IconData</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.Image.IconData" data-name="skiasharp.qrcode.image.icondata" data-text="skiasharp.qrcode.image.icondata public class icondata the logo or image drawn at the center of a qr code, and its size. the icon covers modules, so the symbol relies on error correction to stay readable. use the highest error correction level ( h ) and keep the icon small. when the size is given in modules, rendering throws if the icon and its border span more than maxcoreoccupancypercent percent of the core width; sizes given as a percentage of the image are not checked against the symbol at all. constructor [obsolete] public icondata();  property public iconshape icon { get; set; } the icon shape to overlay on the qr code.  property public int iconborderwidth { get; set; } the border width around the icon in pixels. creates a background-colored padding around the icon. ignored when iconsizemodules is set.  property public int iconsizepercent { get; set; } the size of the icon as a percentage of the qr code size (1-100). ignored when iconsizemodules is set.  property public int maxcoreoccupancypercent { get; set; } maximum allowed icon occupancy of the qr core area, as a percentage (1-100). used only for module-based sizing. default is 30.  property public int? iconbordermodules { get; set; } the border width around the icon in qr modules. when iconsizemodules is set and this is null, defaults to 1.  property public int? iconsizemodules { get; set; } the size of the icon body in qr modules. when set, module-based sizing is used and iconsizepercent / iconborderwidth are ignored.  method public static icondata fromimage(skbitmap image, int iconsizepercent = 10, int iconborderwidth = 2); create icondata from a bitmap image using percent/pixel sizing.  method public static icondata fromimagebymodules(skbitmap image, int iconsizemodules, int iconbordermodules = 1, int maxcoreoccupancypercent = 30); create icondata from a bitmap image using module-based sizing. prefer combining this with withmodulepixelsize so each module maps to an integer pixel size. optional withsize can then set a larger canvas; content is centered and padded. validation against qr size/core occupancy happens at render time.">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.IconData" aria-label="Link to SkiaSharp.QrCode.Image.IconData">#</a><span class="kind">class</span> <span class="name">IconData</span></h3>
+          <pre class="sig"><code>public class IconData</code></pre>
           <p class="doc">The logo or image drawn at the center of a QR code, and its size.</p>
           <details class="notes" data-text="the icon covers modules, so the symbol relies on error correction to stay readable. use the highest error correction level ( h ) and keep the icon small. when the size is given in modules, rendering throws if the icon and its border span more than maxcoreoccupancypercent percent of the core width; sizes given as a percentage of the image are not checked against the symbol at all.">
             <summary>Notes</summary>
             <p class="doc remarks">The icon covers modules, so the symbol relies on error correction to stay readable. Use the highest error correction level ( H ) and keep the icon small. When the size is given in modules, rendering throws if the icon and its border span more than MaxCoreOccupancyPercent percent of the core width; sizes given as a percentage of the image are not checked against the symbol at all.</p>
           </details>
           <div class="members">
-            <div class="member" data-text="public icondata(); ">
-              <code>public IconData();</code> <span class="tag">obsolete</span>
+            <div class="member" data-text="constructor public icondata(); ">
+              <h4><span class="kind">constructor</span> <span class="name">IconData</span> <span class="tag">obsolete</span></h4>
+              <pre class="sig"><code>public IconData();</code></pre>
             </div>
-            <div class="member" data-text="public iconshape icon { get; set; } the icon shape to overlay on the qr code. ">
-              <code>public IconShape Icon { get; set; }</code>
+            <div class="member" data-text="property public iconshape icon { get; set; } the icon shape to overlay on the qr code. ">
+              <h4><span class="kind">property</span> <span class="name">Icon</span></h4>
+              <pre class="sig"><code>public IconShape Icon { get; set; }</code></pre>
               <p class="doc">The icon shape to overlay on the QR code.</p>
             </div>
-            <div class="member" data-text="public int iconborderwidth { get; set; } the border width around the icon in pixels. creates a background-colored padding around the icon. ignored when iconsizemodules is set. ">
-              <code>public int IconBorderWidth { get; set; }</code>
+            <div class="member" data-text="property public int iconborderwidth { get; set; } the border width around the icon in pixels. creates a background-colored padding around the icon. ignored when iconsizemodules is set. ">
+              <h4><span class="kind">property</span> <span class="name">IconBorderWidth</span></h4>
+              <pre class="sig"><code>public int IconBorderWidth { get; set; }</code></pre>
               <p class="doc">The border width around the icon in pixels. Creates a background-colored padding around the icon. Ignored when IconSizeModules is set.</p>
             </div>
-            <div class="member" data-text="public int iconsizepercent { get; set; } the size of the icon as a percentage of the qr code size (1-100). ignored when iconsizemodules is set. ">
-              <code>public int IconSizePercent { get; set; }</code>
+            <div class="member" data-text="property public int iconsizepercent { get; set; } the size of the icon as a percentage of the qr code size (1-100). ignored when iconsizemodules is set. ">
+              <h4><span class="kind">property</span> <span class="name">IconSizePercent</span></h4>
+              <pre class="sig"><code>public int IconSizePercent { get; set; }</code></pre>
               <p class="doc">The size of the icon as a percentage of the QR code size (1-100). Ignored when IconSizeModules is set.</p>
             </div>
-            <div class="member" data-text="public int maxcoreoccupancypercent { get; set; } maximum allowed icon occupancy of the qr core area, as a percentage (1-100). used only for module-based sizing. default is 30. ">
-              <code>public int MaxCoreOccupancyPercent { get; set; }</code>
+            <div class="member" data-text="property public int maxcoreoccupancypercent { get; set; } maximum allowed icon occupancy of the qr core area, as a percentage (1-100). used only for module-based sizing. default is 30. ">
+              <h4><span class="kind">property</span> <span class="name">MaxCoreOccupancyPercent</span></h4>
+              <pre class="sig"><code>public int MaxCoreOccupancyPercent { get; set; }</code></pre>
               <p class="doc">Maximum allowed icon occupancy of the QR core area, as a percentage (1-100). Used only for module-based sizing. Default is 30.</p>
             </div>
-            <div class="member" data-text="public int? iconbordermodules { get; set; } the border width around the icon in qr modules. when iconsizemodules is set and this is null, defaults to 1. ">
-              <code>public int? IconBorderModules { get; set; }</code>
+            <div class="member" data-text="property public int? iconbordermodules { get; set; } the border width around the icon in qr modules. when iconsizemodules is set and this is null, defaults to 1. ">
+              <h4><span class="kind">property</span> <span class="name">IconBorderModules</span></h4>
+              <pre class="sig"><code>public int? IconBorderModules { get; set; }</code></pre>
               <p class="doc">The border width around the icon in QR modules. When IconSizeModules is set and this is null, defaults to 1.</p>
             </div>
-            <div class="member" data-text="public int? iconsizemodules { get; set; } the size of the icon body in qr modules. when set, module-based sizing is used and iconsizepercent / iconborderwidth are ignored. ">
-              <code>public int? IconSizeModules { get; set; }</code>
+            <div class="member" data-text="property public int? iconsizemodules { get; set; } the size of the icon body in qr modules. when set, module-based sizing is used and iconsizepercent / iconborderwidth are ignored. ">
+              <h4><span class="kind">property</span> <span class="name">IconSizeModules</span></h4>
+              <pre class="sig"><code>public int? IconSizeModules { get; set; }</code></pre>
               <p class="doc">The size of the icon body in QR modules. When set, module-based sizing is used and IconSizePercent / IconBorderWidth are ignored.</p>
             </div>
-            <div class="member" data-text="public static icondata fromimage(skbitmap image, int iconsizepercent = 10, int iconborderwidth = 2); create icondata from a bitmap image using percent/pixel sizing. ">
-              <code>public static IconData FromImage(SKBitmap image, int iconSizePercent = 10, int iconBorderWidth = 2);</code>
+            <div class="member" data-text="method public static icondata fromimage(skbitmap image, int iconsizepercent = 10, int iconborderwidth = 2); create icondata from a bitmap image using percent/pixel sizing. ">
+              <h4><span class="kind">method</span> <span class="name">FromImage</span></h4>
+              <pre class="sig"><code>public static IconData FromImage(SKBitmap image, int iconSizePercent = 10, int iconBorderWidth = 2);</code></pre>
               <p class="doc">Create IconData from a bitmap image using percent/pixel sizing.</p>
             </div>
-            <div class="member" data-text="public static icondata fromimagebymodules(skbitmap image, int iconsizemodules, int iconbordermodules = 1, int maxcoreoccupancypercent = 30); create icondata from a bitmap image using module-based sizing. prefer combining this with withmodulepixelsize so each module maps to an integer pixel size. optional withsize can then set a larger canvas; content is centered and padded. validation against qr size/core occupancy happens at render time.">
-              <code>public static IconData FromImageByModules(SKBitmap image, int iconSizeModules, int iconBorderModules = 1, int maxCoreOccupancyPercent = 30);</code>
+            <div class="member" data-text="method public static icondata fromimagebymodules(skbitmap image, int iconsizemodules, int iconbordermodules = 1, int maxcoreoccupancypercent = 30); create icondata from a bitmap image using module-based sizing. prefer combining this with withmodulepixelsize so each module maps to an integer pixel size. optional withsize can then set a larger canvas; content is centered and padded. validation against qr size/core occupancy happens at render time.">
+              <h4><span class="kind">method</span> <span class="name">FromImageByModules</span></h4>
+              <pre class="sig"><code>public static IconData FromImageByModules(SKBitmap image, int iconSizeModules, int iconBorderModules = 1, int maxCoreOccupancyPercent = 30);</code></pre>
               <p class="doc">Create IconData from a bitmap image using module-based sizing.</p>
               <details class="notes" data-text="prefer combining this with withmodulepixelsize so each module maps to an integer pixel size. optional withsize can then set a larger canvas; content is centered and padded. validation against qr size/core occupancy happens at render time.">
                 <summary>Notes</summary>
@@ -2027,408 +2287,493 @@
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.Image.IconShape" data-name="skiasharp.qrcode.image.iconshape" data-text="skiasharp.qrcode.image.iconshape public abstract class iconshape defines the shape and rendering behavior of a qr code center icon/logo.  protected iconshape();  public abstract void draw(skcanvas canvas, skrect rect, skrect borderrect, skcolor backgroundcolor); draw an icon bitmap at the specified location. ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.IconShape" aria-label="Link to SkiaSharp.QrCode.Image.IconShape">#</a><code>public abstract class IconShape</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.Image.IconShape" data-name="skiasharp.qrcode.image.iconshape" data-text="skiasharp.qrcode.image.iconshape public abstract class iconshape defines the shape and rendering behavior of a qr code center icon/logo.  constructor protected iconshape();  method public abstract void draw(skcanvas canvas, skrect rect, skrect borderrect, skcolor backgroundcolor); draw an icon bitmap at the specified location. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.IconShape" aria-label="Link to SkiaSharp.QrCode.Image.IconShape">#</a><span class="kind">class</span> <span class="name">IconShape</span></h3>
+          <pre class="sig"><code>public abstract class IconShape</code></pre>
           <p class="doc">Defines the shape and rendering behavior of a QR code center icon/logo.</p>
           <div class="members">
-            <div class="member" data-text="protected iconshape(); ">
-              <code>protected IconShape();</code>
+            <div class="member" data-text="constructor protected iconshape(); ">
+              <h4><span class="kind">constructor</span> <span class="name">IconShape</span></h4>
+              <pre class="sig"><code>protected IconShape();</code></pre>
             </div>
-            <div class="member" data-text="public abstract void draw(skcanvas canvas, skrect rect, skrect borderrect, skcolor backgroundcolor); draw an icon bitmap at the specified location. ">
-              <code>public abstract void Draw(SKCanvas canvas, SKRect rect, SKRect borderRect, SKColor backgroundColor);</code>
+            <div class="member" data-text="method public abstract void draw(skcanvas canvas, skrect rect, skrect borderrect, skcolor backgroundcolor); draw an icon bitmap at the specified location. ">
+              <h4><span class="kind">method</span> <span class="name">Draw</span></h4>
+              <pre class="sig"><code>public abstract void Draw(SKCanvas canvas, SKRect rect, SKRect borderRect, SKColor backgroundColor);</code></pre>
               <p class="doc">Draw an icon bitmap at the specified location.</p>
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.Image.ImageIconShape" data-name="skiasharp.qrcode.image.imageiconshape" data-text="skiasharp.qrcode.image.imageiconshape public sealed class imageiconshape : iconshape icon shape that draws an image.  public imageiconshape(skbitmap image); creates an icon from an image.  public override void draw(skcanvas canvas, skrect rect, skrect borderrect, skcolor backgroundcolor); ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.ImageIconShape" aria-label="Link to SkiaSharp.QrCode.Image.ImageIconShape">#</a><code>public sealed class ImageIconShape : IconShape</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.Image.ImageIconShape" data-name="skiasharp.qrcode.image.imageiconshape" data-text="skiasharp.qrcode.image.imageiconshape public sealed class imageiconshape : iconshape icon shape that draws an image.  constructor public imageiconshape(skbitmap image); creates an icon from an image.  method public override void draw(skcanvas canvas, skrect rect, skrect borderrect, skcolor backgroundcolor); ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.ImageIconShape" aria-label="Link to SkiaSharp.QrCode.Image.ImageIconShape">#</a><span class="kind">class</span> <span class="name">ImageIconShape</span></h3>
+          <pre class="sig"><code>public sealed class ImageIconShape : IconShape</code></pre>
           <p class="doc">Icon shape that draws an image.</p>
           <div class="members">
-            <div class="member" data-text="public imageiconshape(skbitmap image); creates an icon from an image. ">
-              <code>public ImageIconShape(SKBitmap image);</code>
+            <div class="member" data-text="constructor public imageiconshape(skbitmap image); creates an icon from an image. ">
+              <h4><span class="kind">constructor</span> <span class="name">ImageIconShape</span></h4>
+              <pre class="sig"><code>public ImageIconShape(SKBitmap image);</code></pre>
               <p class="doc">Creates an icon from an image.</p>
             </div>
-            <div class="member" data-text="public override void draw(skcanvas canvas, skrect rect, skrect borderrect, skcolor backgroundcolor); ">
-              <code>public override void Draw(SKCanvas canvas, SKRect rect, SKRect borderRect, SKColor backgroundColor);</code>
+            <div class="member" data-text="method public override void draw(skcanvas canvas, skrect rect, skrect borderrect, skcolor backgroundcolor); ">
+              <h4><span class="kind">method</span> <span class="name">Draw</span></h4>
+              <pre class="sig"><code>public override void Draw(SKCanvas canvas, SKRect rect, SKRect borderRect, SKColor backgroundColor);</code></pre>
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.Image.ImageTextIconShape" data-name="skiasharp.qrcode.image.imagetexticonshape" data-text="skiasharp.qrcode.image.imagetexticonshape public sealed class imagetexticonshape : iconshape icon shape that draws an image with text positioned relative to it.  public imagetexticonshape(skbitmap image, string text, skcolor textcolor, skfont font, sktextalign horizontalalign = 1, textverticalalignment verticalalign = 0, int textpadding = 0); creates an icon shape that displays an image with text positioned relative to it.  public override void draw(skcanvas canvas, skrect rect, skrect borderrect, skcolor backgroundcolor); ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.ImageTextIconShape" aria-label="Link to SkiaSharp.QrCode.Image.ImageTextIconShape">#</a><code>public sealed class ImageTextIconShape : IconShape</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.Image.ImageTextIconShape" data-name="skiasharp.qrcode.image.imagetexticonshape" data-text="skiasharp.qrcode.image.imagetexticonshape public sealed class imagetexticonshape : iconshape icon shape that draws an image with text positioned relative to it.  constructor public imagetexticonshape(skbitmap image, string text, skcolor textcolor, skfont font, sktextalign horizontalalign = 1, textverticalalignment verticalalign = 0, int textpadding = 0); creates an icon shape that displays an image with text positioned relative to it.  method public override void draw(skcanvas canvas, skrect rect, skrect borderrect, skcolor backgroundcolor); ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.ImageTextIconShape" aria-label="Link to SkiaSharp.QrCode.Image.ImageTextIconShape">#</a><span class="kind">class</span> <span class="name">ImageTextIconShape</span></h3>
+          <pre class="sig"><code>public sealed class ImageTextIconShape : IconShape</code></pre>
           <p class="doc">Icon shape that draws an image with text positioned relative to it.</p>
           <div class="members">
-            <div class="member" data-text="public imagetexticonshape(skbitmap image, string text, skcolor textcolor, skfont font, sktextalign horizontalalign = 1, textverticalalignment verticalalign = 0, int textpadding = 0); creates an icon shape that displays an image with text positioned relative to it. ">
-              <code>public ImageTextIconShape(SKBitmap image, string text, SKColor textColor, SKFont font, SKTextAlign horizontalAlign = 1, TextVerticalAlignment verticalAlign = 0, int textPadding = 0);</code>
+            <div class="member" data-text="constructor public imagetexticonshape(skbitmap image, string text, skcolor textcolor, skfont font, sktextalign horizontalalign = 1, textverticalalignment verticalalign = 0, int textpadding = 0); creates an icon shape that displays an image with text positioned relative to it. ">
+              <h4><span class="kind">constructor</span> <span class="name">ImageTextIconShape</span></h4>
+              <pre class="sig"><code>public ImageTextIconShape(SKBitmap image, string text, SKColor textColor, SKFont font, SKTextAlign horizontalAlign = 1, TextVerticalAlignment verticalAlign = 0, int textPadding = 0);</code></pre>
               <p class="doc">Creates an icon shape that displays an image with text positioned relative to it.</p>
             </div>
-            <div class="member" data-text="public override void draw(skcanvas canvas, skrect rect, skrect borderrect, skcolor backgroundcolor); ">
-              <code>public override void Draw(SKCanvas canvas, SKRect rect, SKRect borderRect, SKColor backgroundColor);</code>
+            <div class="member" data-text="method public override void draw(skcanvas canvas, skrect rect, skrect borderrect, skcolor backgroundcolor); ">
+              <h4><span class="kind">method</span> <span class="name">Draw</span></h4>
+              <pre class="sig"><code>public override void Draw(SKCanvas canvas, SKRect rect, SKRect borderRect, SKColor backgroundColor);</code></pre>
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.Image.MicroQRCodeImageBuilder" data-name="skiasharp.qrcode.image.microqrcodeimagebuilder" data-text="skiasharp.qrcode.image.microqrcodeimagebuilder public class microqrcodeimagebuilder : qrcodeimagebuilderbase&lt;microqrcodeimagebuilder&gt; high-level builder for creating micro qr code images with fluent configuration and static methods. this builder mirrors qrcodeimagebuilder for the micro qr symbology (iso/iec 18004, versions m1-m4). version and error correction use the micro qr-typed microqrversion / microqrecclevel , and the default quiet zone is the 2 modules the specification requires (standard qr uses 4). micro qr has a single finder pattern and no high error-correction headroom, so the standard qr styling options that depend on those (icon overlays and custom finder pattern shapes) are intentionally not offered. public microqrcodeimagebuilder(microqrcodedata microqrcodedata); starts a builder that draws a micro qr code you have already generated. the symbol is used exactly as given, so only the appearance options apply. every encoding option throws invalidoperationexception on a builder created this way.  public microqrcodeimagebuilder(string content); starts a builder that will encode content when you ask for an image. error correction, version and every other option keep their defaults until you set them.  public microqrcodeimagebuilder witherrorcorrection(microqrecclevel ecclevel); configure the error correction level for the micro qr code. legal combinations are version-dependent: m1 supports errordetectiononly only, m2/m3 support l and m, m4 supports l, m, and q. illegal combinations throw when the symbol is generated. public microqrcodeimagebuilder withmaskpattern(int? maskpattern); pin one of the four micro qr data mask patterns (0-3) instead of the automatic edge-score selection; see maskpattern .  public microqrcodeimagebuilder withsegmentation(microqrsegmentation segmentation); split the content into mixed-mode segments when that lowers the version (see microqrsegmentation ). defaults to single . never selects a larger version, and produces the identical symbol when a split would not shrink it.  public microqrcodeimagebuilder withversion(microqrversion version); configure the micro qr version to generate. the pinned-version case of the withversion overload. public microqrcodeimagebuilder withversion(microqrversionrange versionrange); configure the versions the generator may choose from, rather than a single one. see microqrversionrange for which empty ranges throw and which are a poor fit. public static byte[] getimagebytes(microqrcodedata microqrcodedata, skencodedimageformat format, int size = 512, int quality = 100); generate a micro qr code as image byte array with specified format.  public static byte[] getimagebytes(string content, skencodedimageformat format, microqrecclevel ecclevel = 2, int size = 512, int quality = 100); generate a micro qr code as image byte array with specified format.  public static byte[] getpngbytes(microqrcodedata microqrcodedata, int size = 512); generate a micro qr code as png byte array with default settings.  public static byte[] getpngbytes(string content, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code as png byte array with default settings.  public static byte[] getsvgbytes(microqrcodedata microqrcodedata, int size = 512); generate a micro qr code as svg (utf-8 encoded) byte array with default settings.  public static byte[] getsvgbytes(string content, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code as svg (utf-8 encoded) byte array with default settings.  public static string getsvgstring(microqrcodedata microqrcodedata, int size = 512); generate a micro qr code as svg document string with default settings.  public static string getsvgstring(string content, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code as svg document string with default settings.  public static void savepng(microqrcodedata microqrcodedata, stream output, int size = 512); generate a micro qr code and save to stream with default png settings.  public static void savepng(string content, stream output, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code and save to stream with default png settings.  public static void savesvg(microqrcodedata microqrcodedata, stream output, int size = 512); generate a micro qr code and save as svg to stream with default settings.  public static void savesvg(string content, stream output, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code and save as svg to stream with default settings.  public static void writeimage(microqrcodedata microqrcodedata, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, int size = 512, int quality = 100); generate a micro qr code and write to an ibufferwriter with specified format.  public static void writeimage(string content, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, microqrecclevel ecclevel = 2, int size = 512, int quality = 100); generate a micro qr code and write to an ibufferwriter with specified format.  public static void writepng(microqrcodedata microqrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate a micro qr code and write to an ibufferwriter with default png settings.  public static void writepng(string content, ibufferwriter&lt;byte&gt; writer, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code and write to an ibufferwriter with default png settings.  public static void writesvg(microqrcodedata microqrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate a micro qr code and write as svg (utf-8 encoded) to an ibufferwriter with default settings.  public static void writesvg(string content, ibufferwriter&lt;byte&gt; writer, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code and write as svg (utf-8 encoded) to an ibufferwriter with default settings. ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.MicroQRCodeImageBuilder" aria-label="Link to SkiaSharp.QrCode.Image.MicroQRCodeImageBuilder">#</a><code>public class MicroQRCodeImageBuilder : QRCodeImageBuilderBase&lt;MicroQRCodeImageBuilder&gt;</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.Image.MicroQRCodeImageBuilder" data-name="skiasharp.qrcode.image.microqrcodeimagebuilder" data-text="skiasharp.qrcode.image.microqrcodeimagebuilder public class microqrcodeimagebuilder : qrcodeimagebuilderbase&lt;microqrcodeimagebuilder&gt; high-level builder for creating micro qr code images with fluent configuration and static methods. this builder mirrors qrcodeimagebuilder for the micro qr symbology (iso/iec 18004, versions m1-m4). version and error correction use the micro qr-typed microqrversion / microqrecclevel , and the default quiet zone is the 2 modules the specification requires (standard qr uses 4). micro qr has a single finder pattern and no high error-correction headroom, so the standard qr styling options that depend on those (icon overlays and custom finder pattern shapes) are intentionally not offered. constructor public microqrcodeimagebuilder(microqrcodedata microqrcodedata); starts a builder that draws a micro qr code you have already generated. the symbol is used exactly as given, so only the appearance options apply. every encoding option throws invalidoperationexception on a builder created this way.  constructor public microqrcodeimagebuilder(string content); starts a builder that will encode content when you ask for an image. error correction, version and every other option keep their defaults until you set them.  method public microqrcodeimagebuilder witherrorcorrection(microqrecclevel ecclevel); configure the error correction level for the micro qr code. legal combinations are version-dependent: m1 supports errordetectiononly only, m2/m3 support l and m, m4 supports l, m, and q. illegal combinations throw when the symbol is generated. method public microqrcodeimagebuilder withmaskpattern(int? maskpattern); pin one of the four micro qr data mask patterns (0-3) instead of the automatic edge-score selection; see maskpattern .  method public microqrcodeimagebuilder withsegmentation(microqrsegmentation segmentation); split the content into mixed-mode segments when that lowers the version (see microqrsegmentation ). defaults to single . never selects a larger version, and produces the identical symbol when a split would not shrink it.  method public microqrcodeimagebuilder withversion(microqrversion version); configure the micro qr version to generate. the pinned-version case of the withversion overload. method public microqrcodeimagebuilder withversion(microqrversionrange versionrange); configure the versions the generator may choose from, rather than a single one. see microqrversionrange for which empty ranges throw and which are a poor fit. method public static byte[] getimagebytes(microqrcodedata microqrcodedata, skencodedimageformat format, int size = 512, int quality = 100); generate a micro qr code as image byte array with specified format.  method public static byte[] getimagebytes(string content, skencodedimageformat format, microqrecclevel ecclevel = 2, int size = 512, int quality = 100); generate a micro qr code as image byte array with specified format.  method public static byte[] getpngbytes(microqrcodedata microqrcodedata, int size = 512); generate a micro qr code as png byte array with default settings.  method public static byte[] getpngbytes(string content, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code as png byte array with default settings.  method public static byte[] getsvgbytes(microqrcodedata microqrcodedata, int size = 512); generate a micro qr code as svg (utf-8 encoded) byte array with default settings.  method public static byte[] getsvgbytes(string content, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code as svg (utf-8 encoded) byte array with default settings.  method public static string getsvgstring(microqrcodedata microqrcodedata, int size = 512); generate a micro qr code as svg document string with default settings.  method public static string getsvgstring(string content, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code as svg document string with default settings.  method public static void savepng(microqrcodedata microqrcodedata, stream output, int size = 512); generate a micro qr code and save to stream with default png settings.  method public static void savepng(string content, stream output, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code and save to stream with default png settings.  method public static void savesvg(microqrcodedata microqrcodedata, stream output, int size = 512); generate a micro qr code and save as svg to stream with default settings.  method public static void savesvg(string content, stream output, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code and save as svg to stream with default settings.  method public static void writeimage(microqrcodedata microqrcodedata, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, int size = 512, int quality = 100); generate a micro qr code and write to an ibufferwriter with specified format.  method public static void writeimage(string content, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, microqrecclevel ecclevel = 2, int size = 512, int quality = 100); generate a micro qr code and write to an ibufferwriter with specified format.  method public static void writepng(microqrcodedata microqrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate a micro qr code and write to an ibufferwriter with default png settings.  method public static void writepng(string content, ibufferwriter&lt;byte&gt; writer, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code and write to an ibufferwriter with default png settings.  method public static void writesvg(microqrcodedata microqrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate a micro qr code and write as svg (utf-8 encoded) to an ibufferwriter with default settings.  method public static void writesvg(string content, ibufferwriter&lt;byte&gt; writer, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code and write as svg (utf-8 encoded) to an ibufferwriter with default settings. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.MicroQRCodeImageBuilder" aria-label="Link to SkiaSharp.QrCode.Image.MicroQRCodeImageBuilder">#</a><span class="kind">class</span> <span class="name">MicroQRCodeImageBuilder</span></h3>
+          <pre class="sig"><code>public class MicroQRCodeImageBuilder : QRCodeImageBuilderBase&lt;MicroQRCodeImageBuilder&gt;</code></pre>
           <p class="doc">High-level builder for creating Micro QR code images with fluent configuration and static methods.</p>
           <details class="notes" data-text="this builder mirrors qrcodeimagebuilder for the micro qr symbology (iso/iec 18004, versions m1-m4). version and error correction use the micro qr-typed microqrversion / microqrecclevel , and the default quiet zone is the 2 modules the specification requires (standard qr uses 4). micro qr has a single finder pattern and no high error-correction headroom, so the standard qr styling options that depend on those (icon overlays and custom finder pattern shapes) are intentionally not offered.">
             <summary>Notes</summary>
             <p class="doc remarks">This builder mirrors QRCodeImageBuilder for the Micro QR symbology (ISO/IEC 18004, versions M1-M4). Version and error correction use the Micro QR-typed MicroQRVersion / MicroQREccLevel , and the default quiet zone is the 2 modules the specification requires (Standard QR uses 4). Micro QR has a single finder pattern and no high error-correction headroom, so the Standard QR styling options that depend on those (icon overlays and custom finder pattern shapes) are intentionally not offered.</p>
           </details>
           <div class="members">
-            <div class="member" data-text="public microqrcodeimagebuilder(microqrcodedata microqrcodedata); starts a builder that draws a micro qr code you have already generated. the symbol is used exactly as given, so only the appearance options apply. every encoding option throws invalidoperationexception on a builder created this way. ">
-              <code>public MicroQRCodeImageBuilder(MicroQRCodeData microQrCodeData);</code>
+            <div class="member" data-text="constructor public microqrcodeimagebuilder(microqrcodedata microqrcodedata); starts a builder that draws a micro qr code you have already generated. the symbol is used exactly as given, so only the appearance options apply. every encoding option throws invalidoperationexception on a builder created this way. ">
+              <h4><span class="kind">constructor</span> <span class="name">MicroQRCodeImageBuilder</span></h4>
+              <pre class="sig"><code>public MicroQRCodeImageBuilder(MicroQRCodeData microQrCodeData);</code></pre>
               <p class="doc">Starts a builder that draws a Micro QR code you have already generated. The symbol is used exactly as given, so only the appearance options apply. Every encoding option throws InvalidOperationException on a builder created this way.</p>
             </div>
-            <div class="member" data-text="public microqrcodeimagebuilder(string content); starts a builder that will encode content when you ask for an image. error correction, version and every other option keep their defaults until you set them. ">
-              <code>public MicroQRCodeImageBuilder(string content);</code>
+            <div class="member" data-text="constructor public microqrcodeimagebuilder(string content); starts a builder that will encode content when you ask for an image. error correction, version and every other option keep their defaults until you set them. ">
+              <h4><span class="kind">constructor</span> <span class="name">MicroQRCodeImageBuilder</span></h4>
+              <pre class="sig"><code>public MicroQRCodeImageBuilder(string content);</code></pre>
               <p class="doc">Starts a builder that will encode content when you ask for an image. Error correction, version and every other option keep their defaults until you set them.</p>
             </div>
-            <div class="member" data-text="public microqrcodeimagebuilder witherrorcorrection(microqrecclevel ecclevel); configure the error correction level for the micro qr code. legal combinations are version-dependent: m1 supports errordetectiononly only, m2/m3 support l and m, m4 supports l, m, and q. illegal combinations throw when the symbol is generated.">
-              <code>public MicroQRCodeImageBuilder WithErrorCorrection(MicroQREccLevel eccLevel);</code>
+            <div class="member" data-text="method public microqrcodeimagebuilder witherrorcorrection(microqrecclevel ecclevel); configure the error correction level for the micro qr code. legal combinations are version-dependent: m1 supports errordetectiononly only, m2/m3 support l and m, m4 supports l, m, and q. illegal combinations throw when the symbol is generated.">
+              <h4><span class="kind">method</span> <span class="name">WithErrorCorrection</span></h4>
+              <pre class="sig"><code>public MicroQRCodeImageBuilder WithErrorCorrection(MicroQREccLevel eccLevel);</code></pre>
               <p class="doc">Configure the error correction level for the Micro QR code.</p>
               <details class="notes" data-text="legal combinations are version-dependent: m1 supports errordetectiononly only, m2/m3 support l and m, m4 supports l, m, and q. illegal combinations throw when the symbol is generated.">
                 <summary>Notes</summary>
                 <p class="doc remarks">Legal combinations are version-dependent: M1 supports ErrorDetectionOnly only, M2/M3 support L and M, M4 supports L, M, and Q. Illegal combinations throw when the symbol is generated.</p>
               </details>
             </div>
-            <div class="member" data-text="public microqrcodeimagebuilder withmaskpattern(int? maskpattern); pin one of the four micro qr data mask patterns (0-3) instead of the automatic edge-score selection; see maskpattern . ">
-              <code>public MicroQRCodeImageBuilder WithMaskPattern(int? maskPattern);</code>
+            <div class="member" data-text="method public microqrcodeimagebuilder withmaskpattern(int? maskpattern); pin one of the four micro qr data mask patterns (0-3) instead of the automatic edge-score selection; see maskpattern . ">
+              <h4><span class="kind">method</span> <span class="name">WithMaskPattern</span></h4>
+              <pre class="sig"><code>public MicroQRCodeImageBuilder WithMaskPattern(int? maskPattern);</code></pre>
               <p class="doc">Pin one of the four Micro QR data mask patterns (0-3) instead of the automatic edge-score selection; see MaskPattern .</p>
             </div>
-            <div class="member" data-text="public microqrcodeimagebuilder withsegmentation(microqrsegmentation segmentation); split the content into mixed-mode segments when that lowers the version (see microqrsegmentation ). defaults to single . never selects a larger version, and produces the identical symbol when a split would not shrink it. ">
-              <code>public MicroQRCodeImageBuilder WithSegmentation(MicroQRSegmentation segmentation);</code>
+            <div class="member" data-text="method public microqrcodeimagebuilder withsegmentation(microqrsegmentation segmentation); split the content into mixed-mode segments when that lowers the version (see microqrsegmentation ). defaults to single . never selects a larger version, and produces the identical symbol when a split would not shrink it. ">
+              <h4><span class="kind">method</span> <span class="name">WithSegmentation</span></h4>
+              <pre class="sig"><code>public MicroQRCodeImageBuilder WithSegmentation(MicroQRSegmentation segmentation);</code></pre>
               <p class="doc">Split the content into mixed-mode segments when that lowers the version (see MicroQRSegmentation ). Defaults to Single . Never selects a larger version, and produces the identical symbol when a split would not shrink it.</p>
             </div>
-            <div class="member" data-text="public microqrcodeimagebuilder withversion(microqrversion version); configure the micro qr version to generate. the pinned-version case of the withversion overload.">
-              <code>public MicroQRCodeImageBuilder WithVersion(MicroQRVersion version);</code>
+            <div class="member" data-text="method public microqrcodeimagebuilder withversion(microqrversion version); configure the micro qr version to generate. the pinned-version case of the withversion overload.">
+              <h4><span class="kind">method</span> <span class="name">WithVersion</span></h4>
+              <pre class="sig"><code>public MicroQRCodeImageBuilder WithVersion(MicroQRVersion version);</code></pre>
               <p class="doc">Configure the Micro QR version to generate.</p>
               <details class="notes" data-text="the pinned-version case of the withversion overload.">
                 <summary>Notes</summary>
                 <p class="doc remarks">The pinned-version case of the WithVersion overload.</p>
               </details>
             </div>
-            <div class="member" data-text="public microqrcodeimagebuilder withversion(microqrversionrange versionrange); configure the versions the generator may choose from, rather than a single one. see microqrversionrange for which empty ranges throw and which are a poor fit.">
-              <code>public MicroQRCodeImageBuilder WithVersion(MicroQRVersionRange versionRange);</code>
+            <div class="member" data-text="method public microqrcodeimagebuilder withversion(microqrversionrange versionrange); configure the versions the generator may choose from, rather than a single one. see microqrversionrange for which empty ranges throw and which are a poor fit.">
+              <h4><span class="kind">method</span> <span class="name">WithVersion</span></h4>
+              <pre class="sig"><code>public MicroQRCodeImageBuilder WithVersion(MicroQRVersionRange versionRange);</code></pre>
               <p class="doc">Configure the versions the generator may choose from, rather than a single one.</p>
               <details class="notes" data-text="see microqrversionrange for which empty ranges throw and which are a poor fit.">
                 <summary>Notes</summary>
                 <p class="doc remarks">See MicroQRVersionRange for which empty ranges throw and which are a poor fit.</p>
               </details>
             </div>
-            <div class="member" data-text="public static byte[] getimagebytes(microqrcodedata microqrcodedata, skencodedimageformat format, int size = 512, int quality = 100); generate a micro qr code as image byte array with specified format. ">
-              <code>public static byte[] GetImageBytes(MicroQRCodeData microQrCodeData, SKEncodedImageFormat format, int size = 512, int quality = 100);</code>
+            <div class="member" data-text="method public static byte[] getimagebytes(microqrcodedata microqrcodedata, skencodedimageformat format, int size = 512, int quality = 100); generate a micro qr code as image byte array with specified format. ">
+              <h4><span class="kind">method</span> <span class="name">GetImageBytes</span></h4>
+              <pre class="sig"><code>public static byte[] GetImageBytes(MicroQRCodeData microQrCodeData, SKEncodedImageFormat format, int size = 512, int quality = 100);</code></pre>
               <p class="doc">Generate a Micro QR code as image byte array with specified format.</p>
             </div>
-            <div class="member" data-text="public static byte[] getimagebytes(string content, skencodedimageformat format, microqrecclevel ecclevel = 2, int size = 512, int quality = 100); generate a micro qr code as image byte array with specified format. ">
-              <code>public static byte[] GetImageBytes(string content, SKEncodedImageFormat format, MicroQREccLevel eccLevel = 2, int size = 512, int quality = 100);</code>
+            <div class="member" data-text="method public static byte[] getimagebytes(string content, skencodedimageformat format, microqrecclevel ecclevel = 2, int size = 512, int quality = 100); generate a micro qr code as image byte array with specified format. ">
+              <h4><span class="kind">method</span> <span class="name">GetImageBytes</span></h4>
+              <pre class="sig"><code>public static byte[] GetImageBytes(string content, SKEncodedImageFormat format, MicroQREccLevel eccLevel = 2, int size = 512, int quality = 100);</code></pre>
               <p class="doc">Generate a Micro QR code as image byte array with specified format.</p>
             </div>
-            <div class="member" data-text="public static byte[] getpngbytes(microqrcodedata microqrcodedata, int size = 512); generate a micro qr code as png byte array with default settings. ">
-              <code>public static byte[] GetPngBytes(MicroQRCodeData microQrCodeData, int size = 512);</code>
+            <div class="member" data-text="method public static byte[] getpngbytes(microqrcodedata microqrcodedata, int size = 512); generate a micro qr code as png byte array with default settings. ">
+              <h4><span class="kind">method</span> <span class="name">GetPngBytes</span></h4>
+              <pre class="sig"><code>public static byte[] GetPngBytes(MicroQRCodeData microQrCodeData, int size = 512);</code></pre>
               <p class="doc">Generate a Micro QR code as PNG byte array with default settings.</p>
             </div>
-            <div class="member" data-text="public static byte[] getpngbytes(string content, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code as png byte array with default settings. ">
-              <code>public static byte[] GetPngBytes(string content, MicroQREccLevel eccLevel = 2, int size = 512);</code>
+            <div class="member" data-text="method public static byte[] getpngbytes(string content, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code as png byte array with default settings. ">
+              <h4><span class="kind">method</span> <span class="name">GetPngBytes</span></h4>
+              <pre class="sig"><code>public static byte[] GetPngBytes(string content, MicroQREccLevel eccLevel = 2, int size = 512);</code></pre>
               <p class="doc">Generate a Micro QR code as PNG byte array with default settings.</p>
             </div>
-            <div class="member" data-text="public static byte[] getsvgbytes(microqrcodedata microqrcodedata, int size = 512); generate a micro qr code as svg (utf-8 encoded) byte array with default settings. ">
-              <code>public static byte[] GetSvgBytes(MicroQRCodeData microQrCodeData, int size = 512);</code>
+            <div class="member" data-text="method public static byte[] getsvgbytes(microqrcodedata microqrcodedata, int size = 512); generate a micro qr code as svg (utf-8 encoded) byte array with default settings. ">
+              <h4><span class="kind">method</span> <span class="name">GetSvgBytes</span></h4>
+              <pre class="sig"><code>public static byte[] GetSvgBytes(MicroQRCodeData microQrCodeData, int size = 512);</code></pre>
               <p class="doc">Generate a Micro QR code as SVG (UTF-8 encoded) byte array with default settings.</p>
             </div>
-            <div class="member" data-text="public static byte[] getsvgbytes(string content, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code as svg (utf-8 encoded) byte array with default settings. ">
-              <code>public static byte[] GetSvgBytes(string content, MicroQREccLevel eccLevel = 2, int size = 512);</code>
+            <div class="member" data-text="method public static byte[] getsvgbytes(string content, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code as svg (utf-8 encoded) byte array with default settings. ">
+              <h4><span class="kind">method</span> <span class="name">GetSvgBytes</span></h4>
+              <pre class="sig"><code>public static byte[] GetSvgBytes(string content, MicroQREccLevel eccLevel = 2, int size = 512);</code></pre>
               <p class="doc">Generate a Micro QR code as SVG (UTF-8 encoded) byte array with default settings.</p>
             </div>
-            <div class="member" data-text="public static string getsvgstring(microqrcodedata microqrcodedata, int size = 512); generate a micro qr code as svg document string with default settings. ">
-              <code>public static string GetSvgString(MicroQRCodeData microQrCodeData, int size = 512);</code>
+            <div class="member" data-text="method public static string getsvgstring(microqrcodedata microqrcodedata, int size = 512); generate a micro qr code as svg document string with default settings. ">
+              <h4><span class="kind">method</span> <span class="name">GetSvgString</span></h4>
+              <pre class="sig"><code>public static string GetSvgString(MicroQRCodeData microQrCodeData, int size = 512);</code></pre>
               <p class="doc">Generate a Micro QR code as SVG document string with default settings.</p>
             </div>
-            <div class="member" data-text="public static string getsvgstring(string content, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code as svg document string with default settings. ">
-              <code>public static string GetSvgString(string content, MicroQREccLevel eccLevel = 2, int size = 512);</code>
+            <div class="member" data-text="method public static string getsvgstring(string content, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code as svg document string with default settings. ">
+              <h4><span class="kind">method</span> <span class="name">GetSvgString</span></h4>
+              <pre class="sig"><code>public static string GetSvgString(string content, MicroQREccLevel eccLevel = 2, int size = 512);</code></pre>
               <p class="doc">Generate a Micro QR code as SVG document string with default settings.</p>
             </div>
-            <div class="member" data-text="public static void savepng(microqrcodedata microqrcodedata, stream output, int size = 512); generate a micro qr code and save to stream with default png settings. ">
-              <code>public static void SavePng(MicroQRCodeData microQrCodeData, Stream output, int size = 512);</code>
+            <div class="member" data-text="method public static void savepng(microqrcodedata microqrcodedata, stream output, int size = 512); generate a micro qr code and save to stream with default png settings. ">
+              <h4><span class="kind">method</span> <span class="name">SavePng</span></h4>
+              <pre class="sig"><code>public static void SavePng(MicroQRCodeData microQrCodeData, Stream output, int size = 512);</code></pre>
               <p class="doc">Generate a Micro QR code and save to stream with default PNG settings.</p>
             </div>
-            <div class="member" data-text="public static void savepng(string content, stream output, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code and save to stream with default png settings. ">
-              <code>public static void SavePng(string content, Stream output, MicroQREccLevel eccLevel = 2, int size = 512);</code>
+            <div class="member" data-text="method public static void savepng(string content, stream output, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code and save to stream with default png settings. ">
+              <h4><span class="kind">method</span> <span class="name">SavePng</span></h4>
+              <pre class="sig"><code>public static void SavePng(string content, Stream output, MicroQREccLevel eccLevel = 2, int size = 512);</code></pre>
               <p class="doc">Generate a Micro QR code and save to stream with default PNG settings.</p>
             </div>
-            <div class="member" data-text="public static void savesvg(microqrcodedata microqrcodedata, stream output, int size = 512); generate a micro qr code and save as svg to stream with default settings. ">
-              <code>public static void SaveSvg(MicroQRCodeData microQrCodeData, Stream output, int size = 512);</code>
+            <div class="member" data-text="method public static void savesvg(microqrcodedata microqrcodedata, stream output, int size = 512); generate a micro qr code and save as svg to stream with default settings. ">
+              <h4><span class="kind">method</span> <span class="name">SaveSvg</span></h4>
+              <pre class="sig"><code>public static void SaveSvg(MicroQRCodeData microQrCodeData, Stream output, int size = 512);</code></pre>
               <p class="doc">Generate a Micro QR code and save as SVG to stream with default settings.</p>
             </div>
-            <div class="member" data-text="public static void savesvg(string content, stream output, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code and save as svg to stream with default settings. ">
-              <code>public static void SaveSvg(string content, Stream output, MicroQREccLevel eccLevel = 2, int size = 512);</code>
+            <div class="member" data-text="method public static void savesvg(string content, stream output, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code and save as svg to stream with default settings. ">
+              <h4><span class="kind">method</span> <span class="name">SaveSvg</span></h4>
+              <pre class="sig"><code>public static void SaveSvg(string content, Stream output, MicroQREccLevel eccLevel = 2, int size = 512);</code></pre>
               <p class="doc">Generate a Micro QR code and save as SVG to stream with default settings.</p>
             </div>
-            <div class="member" data-text="public static void writeimage(microqrcodedata microqrcodedata, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, int size = 512, int quality = 100); generate a micro qr code and write to an ibufferwriter with specified format. ">
-              <code>public static void WriteImage(MicroQRCodeData microQrCodeData, IBufferWriter&lt;byte&gt; writer, SKEncodedImageFormat format, int size = 512, int quality = 100);</code>
+            <div class="member" data-text="method public static void writeimage(microqrcodedata microqrcodedata, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, int size = 512, int quality = 100); generate a micro qr code and write to an ibufferwriter with specified format. ">
+              <h4><span class="kind">method</span> <span class="name">WriteImage</span></h4>
+              <pre class="sig"><code>public static void WriteImage(MicroQRCodeData microQrCodeData, IBufferWriter&lt;byte&gt; writer, SKEncodedImageFormat format, int size = 512, int quality = 100);</code></pre>
               <p class="doc">Generate a Micro QR code and write to an IBufferWriter with specified format.</p>
             </div>
-            <div class="member" data-text="public static void writeimage(string content, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, microqrecclevel ecclevel = 2, int size = 512, int quality = 100); generate a micro qr code and write to an ibufferwriter with specified format. ">
-              <code>public static void WriteImage(string content, IBufferWriter&lt;byte&gt; writer, SKEncodedImageFormat format, MicroQREccLevel eccLevel = 2, int size = 512, int quality = 100);</code>
+            <div class="member" data-text="method public static void writeimage(string content, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, microqrecclevel ecclevel = 2, int size = 512, int quality = 100); generate a micro qr code and write to an ibufferwriter with specified format. ">
+              <h4><span class="kind">method</span> <span class="name">WriteImage</span></h4>
+              <pre class="sig"><code>public static void WriteImage(string content, IBufferWriter&lt;byte&gt; writer, SKEncodedImageFormat format, MicroQREccLevel eccLevel = 2, int size = 512, int quality = 100);</code></pre>
               <p class="doc">Generate a Micro QR code and write to an IBufferWriter with specified format.</p>
             </div>
-            <div class="member" data-text="public static void writepng(microqrcodedata microqrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate a micro qr code and write to an ibufferwriter with default png settings. ">
-              <code>public static void WritePng(MicroQRCodeData microQrCodeData, IBufferWriter&lt;byte&gt; writer, int size = 512);</code>
+            <div class="member" data-text="method public static void writepng(microqrcodedata microqrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate a micro qr code and write to an ibufferwriter with default png settings. ">
+              <h4><span class="kind">method</span> <span class="name">WritePng</span></h4>
+              <pre class="sig"><code>public static void WritePng(MicroQRCodeData microQrCodeData, IBufferWriter&lt;byte&gt; writer, int size = 512);</code></pre>
               <p class="doc">Generate a Micro QR code and write to an IBufferWriter with default PNG settings.</p>
             </div>
-            <div class="member" data-text="public static void writepng(string content, ibufferwriter&lt;byte&gt; writer, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code and write to an ibufferwriter with default png settings. ">
-              <code>public static void WritePng(string content, IBufferWriter&lt;byte&gt; writer, MicroQREccLevel eccLevel = 2, int size = 512);</code>
+            <div class="member" data-text="method public static void writepng(string content, ibufferwriter&lt;byte&gt; writer, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code and write to an ibufferwriter with default png settings. ">
+              <h4><span class="kind">method</span> <span class="name">WritePng</span></h4>
+              <pre class="sig"><code>public static void WritePng(string content, IBufferWriter&lt;byte&gt; writer, MicroQREccLevel eccLevel = 2, int size = 512);</code></pre>
               <p class="doc">Generate a Micro QR code and write to an IBufferWriter with default PNG settings.</p>
             </div>
-            <div class="member" data-text="public static void writesvg(microqrcodedata microqrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate a micro qr code and write as svg (utf-8 encoded) to an ibufferwriter with default settings. ">
-              <code>public static void WriteSvg(MicroQRCodeData microQrCodeData, IBufferWriter&lt;byte&gt; writer, int size = 512);</code>
+            <div class="member" data-text="method public static void writesvg(microqrcodedata microqrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate a micro qr code and write as svg (utf-8 encoded) to an ibufferwriter with default settings. ">
+              <h4><span class="kind">method</span> <span class="name">WriteSvg</span></h4>
+              <pre class="sig"><code>public static void WriteSvg(MicroQRCodeData microQrCodeData, IBufferWriter&lt;byte&gt; writer, int size = 512);</code></pre>
               <p class="doc">Generate a Micro QR code and write as SVG (UTF-8 encoded) to an IBufferWriter with default settings.</p>
             </div>
-            <div class="member" data-text="public static void writesvg(string content, ibufferwriter&lt;byte&gt; writer, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code and write as svg (utf-8 encoded) to an ibufferwriter with default settings. ">
-              <code>public static void WriteSvg(string content, IBufferWriter&lt;byte&gt; writer, MicroQREccLevel eccLevel = 2, int size = 512);</code>
+            <div class="member" data-text="method public static void writesvg(string content, ibufferwriter&lt;byte&gt; writer, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code and write as svg (utf-8 encoded) to an ibufferwriter with default settings. ">
+              <h4><span class="kind">method</span> <span class="name">WriteSvg</span></h4>
+              <pre class="sig"><code>public static void WriteSvg(string content, IBufferWriter&lt;byte&gt; writer, MicroQREccLevel eccLevel = 2, int size = 512);</code></pre>
               <p class="doc">Generate a Micro QR code and write as SVG (UTF-8 encoded) to an IBufferWriter with default settings.</p>
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.Image.ModuleShape" data-name="skiasharp.qrcode.image.moduleshape" data-text="skiasharp.qrcode.image.moduleshape public abstract class moduleshape defines the shape of qr code modules  protected moduleshape();  public bool requiresantialiasing { get; } gets whether this shape requires antialiasing for smooth rendering.  public abstract void draw(skcanvas canvas, skrect rect, skpaint paint); draw a module at the specified location. ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.ModuleShape" aria-label="Link to SkiaSharp.QrCode.Image.ModuleShape">#</a><code>public abstract class ModuleShape</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.Image.ModuleShape" data-name="skiasharp.qrcode.image.moduleshape" data-text="skiasharp.qrcode.image.moduleshape public abstract class moduleshape defines the shape of qr code modules  constructor protected moduleshape();  property public bool requiresantialiasing { get; } gets whether this shape requires antialiasing for smooth rendering.  method public abstract void draw(skcanvas canvas, skrect rect, skpaint paint); draw a module at the specified location. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.ModuleShape" aria-label="Link to SkiaSharp.QrCode.Image.ModuleShape">#</a><span class="kind">class</span> <span class="name">ModuleShape</span></h3>
+          <pre class="sig"><code>public abstract class ModuleShape</code></pre>
           <p class="doc">Defines the shape of QR code modules</p>
           <div class="members">
-            <div class="member" data-text="protected moduleshape(); ">
-              <code>protected ModuleShape();</code>
+            <div class="member" data-text="constructor protected moduleshape(); ">
+              <h4><span class="kind">constructor</span> <span class="name">ModuleShape</span></h4>
+              <pre class="sig"><code>protected ModuleShape();</code></pre>
             </div>
-            <div class="member" data-text="public bool requiresantialiasing { get; } gets whether this shape requires antialiasing for smooth rendering. ">
-              <code>public bool RequiresAntialiasing { get; }</code>
+            <div class="member" data-text="property public bool requiresantialiasing { get; } gets whether this shape requires antialiasing for smooth rendering. ">
+              <h4><span class="kind">property</span> <span class="name">RequiresAntialiasing</span></h4>
+              <pre class="sig"><code>public bool RequiresAntialiasing { get; }</code></pre>
               <p class="doc">Gets whether this shape requires antialiasing for smooth rendering.</p>
             </div>
-            <div class="member" data-text="public abstract void draw(skcanvas canvas, skrect rect, skpaint paint); draw a module at the specified location. ">
-              <code>public abstract void Draw(SKCanvas canvas, SKRect rect, SKPaint paint);</code>
+            <div class="member" data-text="method public abstract void draw(skcanvas canvas, skrect rect, skpaint paint); draw a module at the specified location. ">
+              <h4><span class="kind">method</span> <span class="name">Draw</span></h4>
+              <pre class="sig"><code>public abstract void Draw(SKCanvas canvas, SKRect rect, SKPaint paint);</code></pre>
               <p class="doc">Draw a module at the specified location.</p>
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.Image.QRCodeImageBuilder" data-name="skiasharp.qrcode.image.qrcodeimagebuilder" data-text="skiasharp.qrcode.image.qrcodeimagebuilder public class qrcodeimagebuilder : qrcodeimagebuilderbase&lt;qrcodeimagebuilder&gt; high-level builder for creating qr code images with fluent configuration and static methods. this builder provides both simple static methods for quick qr code generation and a fluent api for advanced customization. quick generation (static methods): use static methods like getpngbytes for one-liner qr code creation with default settings. advanced configuration (fluent api): chain the shared options ( qrcodeimagebuilderbase , qrcodeimagebuilderbase , qrcodeimagebuilderbase , qrcodeimagebuilderbase , qrcodeimagebuilderbase ) with the standard qr-specific options ( witherrorcorrection , withversion , withicon , withfinderpatternshape ) to customize appearance. public qrcodeimagebuilder(qrcodedata qrcodedata); starts a builder that draws a qr code you have already generated. the symbol is used exactly as given, so only the appearance options apply. most encoding options throw invalidoperationexception on a builder created this way; witherrorcorrection and withecimode are accepted and then ignored, because they shipped that way in 1.1.1.  public qrcodeimagebuilder(string content); starts a builder that will encode content when you ask for an image. error correction, version and every other option keep their defaults until you set them.  public qrcodeimagebuilder withecimode(ecimode ecimode); configure the eci (extended channel interpretation) mode for character encoding.  public qrcodeimagebuilder witherrorcorrection(ecclevel ecclevel); configure the error correction level for the qr code.  public qrcodeimagebuilder witherrorcorrectionboost(bool boostecclevel = true); raise the error correction level above the one configured with witherrorcorrection when the chosen version's capacity allows it, without changing the version or the symbol size. recommended together with withicon : the spare capacity absorbs the modules the icon covers.  public qrcodeimagebuilder withfinderpatternshape(finderpatternshape? finderpatternshape); configure the shape of the finder patterns.  public qrcodeimagebuilder withicon(icondata? icondata); configure an icon to overlay on the center of the qr code.  public qrcodeimagebuilder withmaskpattern(int? maskpattern); pin one of the eight data mask patterns (0-7) instead of the automatic penalty-scored selection; see maskpattern .  public qrcodeimagebuilder withsegmentation(qrcodesegmentation segmentation); split the content into mixed-mode segments when that lowers the version (see qrcodesegmentation ). defaults to single . never selects a larger version, and produces the identical symbol when a split would not shrink it.  public qrcodeimagebuilder withversion(qrcodeversionrange versionrange); configure the versions the generator may choose from, rather than a single one. for a symbol that must reach, or not exceed, a physical size. an int? converts implicitly, so an optional version needs no branch. public qrcodeimagebuilder withversion(int version); configure the qr code version to generate. the pinned case of withversion ; -1 is any . public static byte[] getimagebytes(qrcodedata qrcodedata, skencodedimageformat format, int size = 512, int quality = 100); generate a qr code as image byte array with specified format.  public static byte[] getimagebytes(string content, skencodedimageformat format, ecclevel ecclevel = 1, int size = 512, int quality = 100); generate a qr code as image byte array with specified format.  public static byte[] getpngbytes(qrcodedata qrcodedata, int size = 512); generate a qr code as png byte array with default settings.  public static byte[] getpngbytes(string content, ecclevel ecclevel = 1, int size = 512); generate a qr code as png byte array with default settings.  public static byte[] getsvgbytes(qrcodedata qrcodedata, int size = 512); generate a qr code as svg (utf-8 encoded) byte array with default settings.  public static byte[] getsvgbytes(string content, ecclevel ecclevel = 1, int size = 512); generate a qr code as svg (utf-8 encoded) byte array with default settings.  public static string getsvgstring(qrcodedata qrcodedata, int size = 512); generate a qr code as svg document string with default settings.  public static string getsvgstring(string content, ecclevel ecclevel = 1, int size = 512); generate a qr code as svg document string with default settings.  public static void savepng(qrcodedata qrcodedata, stream output, int size = 512); generate a qr code and save to stream with default png settings.  public static void savepng(string content, stream output, ecclevel ecclevel = 1, int size = 512); generate a qr code and save to stream with default png settings.  public static void savesvg(qrcodedata qrcodedata, stream output, int size = 512); generate a qr code and save as svg to stream with default settings.  public static void savesvg(string content, stream output, ecclevel ecclevel = 1, int size = 512); generate a qr code and save as svg to stream with default settings.  public static void writeimage(qrcodedata qrcodedata, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, int size = 512, int quality = 100); generate a qr code and write to an ibufferwriter with specified format.  public static void writeimage(string content, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, ecclevel ecclevel = 1, int size = 512, int quality = 100); generate a qr code and write to an ibufferwriter with specified format.  public static void writepng(qrcodedata qrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate a qr code and write to an ibufferwriter with default png settings.  public static void writepng(string content, ibufferwriter&lt;byte&gt; writer, ecclevel ecclevel = 1, int size = 512); generate a qr code and write to an ibufferwriter with default png settings.  public static void writesvg(qrcodedata qrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate a qr code and write as svg (utf-8 encoded) to an ibufferwriter with default settings.  public static void writesvg(string content, ibufferwriter&lt;byte&gt; writer, ecclevel ecclevel = 1, int size = 512); generate a qr code and write as svg (utf-8 encoded) to an ibufferwriter with default settings. ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.QRCodeImageBuilder" aria-label="Link to SkiaSharp.QrCode.Image.QRCodeImageBuilder">#</a><code>public class QRCodeImageBuilder : QRCodeImageBuilderBase&lt;QRCodeImageBuilder&gt;</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.Image.QRCodeImageBuilder" data-name="skiasharp.qrcode.image.qrcodeimagebuilder" data-text="skiasharp.qrcode.image.qrcodeimagebuilder public class qrcodeimagebuilder : qrcodeimagebuilderbase&lt;qrcodeimagebuilder&gt; high-level builder for creating qr code images with fluent configuration and static methods. this builder provides both simple static methods for quick qr code generation and a fluent api for advanced customization. quick generation (static methods): use static methods like getpngbytes for one-liner qr code creation with default settings. advanced configuration (fluent api): chain the shared options ( qrcodeimagebuilderbase , qrcodeimagebuilderbase , qrcodeimagebuilderbase , qrcodeimagebuilderbase , qrcodeimagebuilderbase ) with the standard qr-specific options ( witherrorcorrection , withversion , withicon , withfinderpatternshape ) to customize appearance. constructor public qrcodeimagebuilder(qrcodedata qrcodedata); starts a builder that draws a qr code you have already generated. the symbol is used exactly as given, so only the appearance options apply. most encoding options throw invalidoperationexception on a builder created this way; witherrorcorrection and withecimode are accepted and then ignored, because they shipped that way in 1.1.1.  constructor public qrcodeimagebuilder(string content); starts a builder that will encode content when you ask for an image. error correction, version and every other option keep their defaults until you set them.  method public qrcodeimagebuilder withecimode(ecimode ecimode); configure the eci (extended channel interpretation) mode for character encoding.  method public qrcodeimagebuilder witherrorcorrection(ecclevel ecclevel); configure the error correction level for the qr code.  method public qrcodeimagebuilder witherrorcorrectionboost(bool boostecclevel = true); raise the error correction level above the one configured with witherrorcorrection when the chosen version's capacity allows it, without changing the version or the symbol size. recommended together with withicon : the spare capacity absorbs the modules the icon covers.  method public qrcodeimagebuilder withfinderpatternshape(finderpatternshape? finderpatternshape); configure the shape of the finder patterns.  method public qrcodeimagebuilder withicon(icondata? icondata); configure an icon to overlay on the center of the qr code.  method public qrcodeimagebuilder withmaskpattern(int? maskpattern); pin one of the eight data mask patterns (0-7) instead of the automatic penalty-scored selection; see maskpattern .  method public qrcodeimagebuilder withsegmentation(qrcodesegmentation segmentation); split the content into mixed-mode segments when that lowers the version (see qrcodesegmentation ). defaults to single . never selects a larger version, and produces the identical symbol when a split would not shrink it.  method public qrcodeimagebuilder withversion(qrcodeversionrange versionrange); configure the versions the generator may choose from, rather than a single one. for a symbol that must reach, or not exceed, a physical size. an int? converts implicitly, so an optional version needs no branch. method public qrcodeimagebuilder withversion(int version); configure the qr code version to generate. the pinned case of withversion ; -1 is any . method public static byte[] getimagebytes(qrcodedata qrcodedata, skencodedimageformat format, int size = 512, int quality = 100); generate a qr code as image byte array with specified format.  method public static byte[] getimagebytes(string content, skencodedimageformat format, ecclevel ecclevel = 1, int size = 512, int quality = 100); generate a qr code as image byte array with specified format.  method public static byte[] getpngbytes(qrcodedata qrcodedata, int size = 512); generate a qr code as png byte array with default settings.  method public static byte[] getpngbytes(string content, ecclevel ecclevel = 1, int size = 512); generate a qr code as png byte array with default settings.  method public static byte[] getsvgbytes(qrcodedata qrcodedata, int size = 512); generate a qr code as svg (utf-8 encoded) byte array with default settings.  method public static byte[] getsvgbytes(string content, ecclevel ecclevel = 1, int size = 512); generate a qr code as svg (utf-8 encoded) byte array with default settings.  method public static string getsvgstring(qrcodedata qrcodedata, int size = 512); generate a qr code as svg document string with default settings.  method public static string getsvgstring(string content, ecclevel ecclevel = 1, int size = 512); generate a qr code as svg document string with default settings.  method public static void savepng(qrcodedata qrcodedata, stream output, int size = 512); generate a qr code and save to stream with default png settings.  method public static void savepng(string content, stream output, ecclevel ecclevel = 1, int size = 512); generate a qr code and save to stream with default png settings.  method public static void savesvg(qrcodedata qrcodedata, stream output, int size = 512); generate a qr code and save as svg to stream with default settings.  method public static void savesvg(string content, stream output, ecclevel ecclevel = 1, int size = 512); generate a qr code and save as svg to stream with default settings.  method public static void writeimage(qrcodedata qrcodedata, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, int size = 512, int quality = 100); generate a qr code and write to an ibufferwriter with specified format.  method public static void writeimage(string content, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, ecclevel ecclevel = 1, int size = 512, int quality = 100); generate a qr code and write to an ibufferwriter with specified format.  method public static void writepng(qrcodedata qrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate a qr code and write to an ibufferwriter with default png settings.  method public static void writepng(string content, ibufferwriter&lt;byte&gt; writer, ecclevel ecclevel = 1, int size = 512); generate a qr code and write to an ibufferwriter with default png settings.  method public static void writesvg(qrcodedata qrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate a qr code and write as svg (utf-8 encoded) to an ibufferwriter with default settings.  method public static void writesvg(string content, ibufferwriter&lt;byte&gt; writer, ecclevel ecclevel = 1, int size = 512); generate a qr code and write as svg (utf-8 encoded) to an ibufferwriter with default settings. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.QRCodeImageBuilder" aria-label="Link to SkiaSharp.QrCode.Image.QRCodeImageBuilder">#</a><span class="kind">class</span> <span class="name">QRCodeImageBuilder</span></h3>
+          <pre class="sig"><code>public class QRCodeImageBuilder : QRCodeImageBuilderBase&lt;QRCodeImageBuilder&gt;</code></pre>
           <p class="doc">High-level builder for creating QR code images with fluent configuration and static methods.</p>
           <details class="notes" data-text="this builder provides both simple static methods for quick qr code generation and a fluent api for advanced customization. quick generation (static methods): use static methods like getpngbytes for one-liner qr code creation with default settings. advanced configuration (fluent api): chain the shared options ( qrcodeimagebuilderbase , qrcodeimagebuilderbase , qrcodeimagebuilderbase , qrcodeimagebuilderbase , qrcodeimagebuilderbase ) with the standard qr-specific options ( witherrorcorrection , withversion , withicon , withfinderpatternshape ) to customize appearance.">
             <summary>Notes</summary>
             <p class="doc remarks">This builder provides both simple static methods for quick QR code generation and a fluent API for advanced customization. Quick Generation (Static Methods): Use static methods like GetPngBytes for one-liner QR code creation with default settings. Advanced Configuration (Fluent API): Chain the shared options ( QRCodeImageBuilderBase , QRCodeImageBuilderBase , QRCodeImageBuilderBase , QRCodeImageBuilderBase , QRCodeImageBuilderBase ) with the Standard QR-specific options ( WithErrorCorrection , WithVersion , WithIcon , WithFinderPatternShape ) to customize appearance.</p>
           </details>
           <div class="members">
-            <div class="member" data-text="public qrcodeimagebuilder(qrcodedata qrcodedata); starts a builder that draws a qr code you have already generated. the symbol is used exactly as given, so only the appearance options apply. most encoding options throw invalidoperationexception on a builder created this way; witherrorcorrection and withecimode are accepted and then ignored, because they shipped that way in 1.1.1. ">
-              <code>public QRCodeImageBuilder(QRCodeData qrCodeData);</code>
+            <div class="member" data-text="constructor public qrcodeimagebuilder(qrcodedata qrcodedata); starts a builder that draws a qr code you have already generated. the symbol is used exactly as given, so only the appearance options apply. most encoding options throw invalidoperationexception on a builder created this way; witherrorcorrection and withecimode are accepted and then ignored, because they shipped that way in 1.1.1. ">
+              <h4><span class="kind">constructor</span> <span class="name">QRCodeImageBuilder</span></h4>
+              <pre class="sig"><code>public QRCodeImageBuilder(QRCodeData qrCodeData);</code></pre>
               <p class="doc">Starts a builder that draws a QR code you have already generated. The symbol is used exactly as given, so only the appearance options apply. Most encoding options throw InvalidOperationException on a builder created this way; WithErrorCorrection and WithEciMode are accepted and then ignored, because they shipped that way in 1.1.1.</p>
             </div>
-            <div class="member" data-text="public qrcodeimagebuilder(string content); starts a builder that will encode content when you ask for an image. error correction, version and every other option keep their defaults until you set them. ">
-              <code>public QRCodeImageBuilder(string content);</code>
+            <div class="member" data-text="constructor public qrcodeimagebuilder(string content); starts a builder that will encode content when you ask for an image. error correction, version and every other option keep their defaults until you set them. ">
+              <h4><span class="kind">constructor</span> <span class="name">QRCodeImageBuilder</span></h4>
+              <pre class="sig"><code>public QRCodeImageBuilder(string content);</code></pre>
               <p class="doc">Starts a builder that will encode content when you ask for an image. Error correction, version and every other option keep their defaults until you set them.</p>
             </div>
-            <div class="member" data-text="public qrcodeimagebuilder withecimode(ecimode ecimode); configure the eci (extended channel interpretation) mode for character encoding. ">
-              <code>public QRCodeImageBuilder WithEciMode(EciMode eciMode);</code>
+            <div class="member" data-text="method public qrcodeimagebuilder withecimode(ecimode ecimode); configure the eci (extended channel interpretation) mode for character encoding. ">
+              <h4><span class="kind">method</span> <span class="name">WithEciMode</span></h4>
+              <pre class="sig"><code>public QRCodeImageBuilder WithEciMode(EciMode eciMode);</code></pre>
               <p class="doc">Configure the ECI (Extended Channel Interpretation) mode for character encoding.</p>
             </div>
-            <div class="member" data-text="public qrcodeimagebuilder witherrorcorrection(ecclevel ecclevel); configure the error correction level for the qr code. ">
-              <code>public QRCodeImageBuilder WithErrorCorrection(ECCLevel eccLevel);</code>
+            <div class="member" data-text="method public qrcodeimagebuilder witherrorcorrection(ecclevel ecclevel); configure the error correction level for the qr code. ">
+              <h4><span class="kind">method</span> <span class="name">WithErrorCorrection</span></h4>
+              <pre class="sig"><code>public QRCodeImageBuilder WithErrorCorrection(ECCLevel eccLevel);</code></pre>
               <p class="doc">Configure the error correction level for the QR code.</p>
             </div>
-            <div class="member" data-text="public qrcodeimagebuilder witherrorcorrectionboost(bool boostecclevel = true); raise the error correction level above the one configured with witherrorcorrection when the chosen version's capacity allows it, without changing the version or the symbol size. recommended together with withicon : the spare capacity absorbs the modules the icon covers. ">
-              <code>public QRCodeImageBuilder WithErrorCorrectionBoost(bool boostEccLevel = true);</code>
+            <div class="member" data-text="method public qrcodeimagebuilder witherrorcorrectionboost(bool boostecclevel = true); raise the error correction level above the one configured with witherrorcorrection when the chosen version's capacity allows it, without changing the version or the symbol size. recommended together with withicon : the spare capacity absorbs the modules the icon covers. ">
+              <h4><span class="kind">method</span> <span class="name">WithErrorCorrectionBoost</span></h4>
+              <pre class="sig"><code>public QRCodeImageBuilder WithErrorCorrectionBoost(bool boostEccLevel = true);</code></pre>
               <p class="doc">Raise the error correction level above the one configured with WithErrorCorrection when the chosen version's capacity allows it, without changing the version or the symbol size. Recommended together with WithIcon : the spare capacity absorbs the modules the icon covers.</p>
             </div>
-            <div class="member" data-text="public qrcodeimagebuilder withfinderpatternshape(finderpatternshape? finderpatternshape); configure the shape of the finder patterns. ">
-              <code>public QRCodeImageBuilder WithFinderPatternShape(FinderPatternShape? finderPatternShape);</code>
+            <div class="member" data-text="method public qrcodeimagebuilder withfinderpatternshape(finderpatternshape? finderpatternshape); configure the shape of the finder patterns. ">
+              <h4><span class="kind">method</span> <span class="name">WithFinderPatternShape</span></h4>
+              <pre class="sig"><code>public QRCodeImageBuilder WithFinderPatternShape(FinderPatternShape? finderPatternShape);</code></pre>
               <p class="doc">Configure the shape of the finder patterns.</p>
             </div>
-            <div class="member" data-text="public qrcodeimagebuilder withicon(icondata? icondata); configure an icon to overlay on the center of the qr code. ">
-              <code>public QRCodeImageBuilder WithIcon(IconData? iconData);</code>
+            <div class="member" data-text="method public qrcodeimagebuilder withicon(icondata? icondata); configure an icon to overlay on the center of the qr code. ">
+              <h4><span class="kind">method</span> <span class="name">WithIcon</span></h4>
+              <pre class="sig"><code>public QRCodeImageBuilder WithIcon(IconData? iconData);</code></pre>
               <p class="doc">Configure an icon to overlay on the center of the QR code.</p>
             </div>
-            <div class="member" data-text="public qrcodeimagebuilder withmaskpattern(int? maskpattern); pin one of the eight data mask patterns (0-7) instead of the automatic penalty-scored selection; see maskpattern . ">
-              <code>public QRCodeImageBuilder WithMaskPattern(int? maskPattern);</code>
+            <div class="member" data-text="method public qrcodeimagebuilder withmaskpattern(int? maskpattern); pin one of the eight data mask patterns (0-7) instead of the automatic penalty-scored selection; see maskpattern . ">
+              <h4><span class="kind">method</span> <span class="name">WithMaskPattern</span></h4>
+              <pre class="sig"><code>public QRCodeImageBuilder WithMaskPattern(int? maskPattern);</code></pre>
               <p class="doc">Pin one of the eight data mask patterns (0-7) instead of the automatic penalty-scored selection; see MaskPattern .</p>
             </div>
-            <div class="member" data-text="public qrcodeimagebuilder withsegmentation(qrcodesegmentation segmentation); split the content into mixed-mode segments when that lowers the version (see qrcodesegmentation ). defaults to single . never selects a larger version, and produces the identical symbol when a split would not shrink it. ">
-              <code>public QRCodeImageBuilder WithSegmentation(QRCodeSegmentation segmentation);</code>
+            <div class="member" data-text="method public qrcodeimagebuilder withsegmentation(qrcodesegmentation segmentation); split the content into mixed-mode segments when that lowers the version (see qrcodesegmentation ). defaults to single . never selects a larger version, and produces the identical symbol when a split would not shrink it. ">
+              <h4><span class="kind">method</span> <span class="name">WithSegmentation</span></h4>
+              <pre class="sig"><code>public QRCodeImageBuilder WithSegmentation(QRCodeSegmentation segmentation);</code></pre>
               <p class="doc">Split the content into mixed-mode segments when that lowers the version (see QRCodeSegmentation ). Defaults to Single . Never selects a larger version, and produces the identical symbol when a split would not shrink it.</p>
             </div>
-            <div class="member" data-text="public qrcodeimagebuilder withversion(qrcodeversionrange versionrange); configure the versions the generator may choose from, rather than a single one. for a symbol that must reach, or not exceed, a physical size. an int? converts implicitly, so an optional version needs no branch.">
-              <code>public QRCodeImageBuilder WithVersion(QRCodeVersionRange versionRange);</code>
+            <div class="member" data-text="method public qrcodeimagebuilder withversion(qrcodeversionrange versionrange); configure the versions the generator may choose from, rather than a single one. for a symbol that must reach, or not exceed, a physical size. an int? converts implicitly, so an optional version needs no branch.">
+              <h4><span class="kind">method</span> <span class="name">WithVersion</span></h4>
+              <pre class="sig"><code>public QRCodeImageBuilder WithVersion(QRCodeVersionRange versionRange);</code></pre>
               <p class="doc">Configure the versions the generator may choose from, rather than a single one.</p>
               <details class="notes" data-text="for a symbol that must reach, or not exceed, a physical size. an int? converts implicitly, so an optional version needs no branch.">
                 <summary>Notes</summary>
                 <p class="doc remarks">For a symbol that must reach, or not exceed, a physical size. An int? converts implicitly, so an optional version needs no branch.</p>
               </details>
             </div>
-            <div class="member" data-text="public qrcodeimagebuilder withversion(int version); configure the qr code version to generate. the pinned case of withversion ; -1 is any .">
-              <code>public QRCodeImageBuilder WithVersion(int version);</code>
+            <div class="member" data-text="method public qrcodeimagebuilder withversion(int version); configure the qr code version to generate. the pinned case of withversion ; -1 is any .">
+              <h4><span class="kind">method</span> <span class="name">WithVersion</span></h4>
+              <pre class="sig"><code>public QRCodeImageBuilder WithVersion(int version);</code></pre>
               <p class="doc">Configure the QR code version to generate.</p>
               <details class="notes" data-text="the pinned case of withversion ; -1 is any .">
                 <summary>Notes</summary>
                 <p class="doc remarks">The pinned case of WithVersion ; -1 is Any .</p>
               </details>
             </div>
-            <div class="member" data-text="public static byte[] getimagebytes(qrcodedata qrcodedata, skencodedimageformat format, int size = 512, int quality = 100); generate a qr code as image byte array with specified format. ">
-              <code>public static byte[] GetImageBytes(QRCodeData qrCodeData, SKEncodedImageFormat format, int size = 512, int quality = 100);</code>
+            <div class="member" data-text="method public static byte[] getimagebytes(qrcodedata qrcodedata, skencodedimageformat format, int size = 512, int quality = 100); generate a qr code as image byte array with specified format. ">
+              <h4><span class="kind">method</span> <span class="name">GetImageBytes</span></h4>
+              <pre class="sig"><code>public static byte[] GetImageBytes(QRCodeData qrCodeData, SKEncodedImageFormat format, int size = 512, int quality = 100);</code></pre>
               <p class="doc">Generate a QR code as image byte array with specified format.</p>
             </div>
-            <div class="member" data-text="public static byte[] getimagebytes(string content, skencodedimageformat format, ecclevel ecclevel = 1, int size = 512, int quality = 100); generate a qr code as image byte array with specified format. ">
-              <code>public static byte[] GetImageBytes(string content, SKEncodedImageFormat format, ECCLevel eccLevel = 1, int size = 512, int quality = 100);</code>
+            <div class="member" data-text="method public static byte[] getimagebytes(string content, skencodedimageformat format, ecclevel ecclevel = 1, int size = 512, int quality = 100); generate a qr code as image byte array with specified format. ">
+              <h4><span class="kind">method</span> <span class="name">GetImageBytes</span></h4>
+              <pre class="sig"><code>public static byte[] GetImageBytes(string content, SKEncodedImageFormat format, ECCLevel eccLevel = 1, int size = 512, int quality = 100);</code></pre>
               <p class="doc">Generate a QR code as image byte array with specified format.</p>
             </div>
-            <div class="member" data-text="public static byte[] getpngbytes(qrcodedata qrcodedata, int size = 512); generate a qr code as png byte array with default settings. ">
-              <code>public static byte[] GetPngBytes(QRCodeData qrCodeData, int size = 512);</code>
+            <div class="member" data-text="method public static byte[] getpngbytes(qrcodedata qrcodedata, int size = 512); generate a qr code as png byte array with default settings. ">
+              <h4><span class="kind">method</span> <span class="name">GetPngBytes</span></h4>
+              <pre class="sig"><code>public static byte[] GetPngBytes(QRCodeData qrCodeData, int size = 512);</code></pre>
               <p class="doc">Generate a QR code as PNG byte array with default settings.</p>
             </div>
-            <div class="member" data-text="public static byte[] getpngbytes(string content, ecclevel ecclevel = 1, int size = 512); generate a qr code as png byte array with default settings. ">
-              <code>public static byte[] GetPngBytes(string content, ECCLevel eccLevel = 1, int size = 512);</code>
+            <div class="member" data-text="method public static byte[] getpngbytes(string content, ecclevel ecclevel = 1, int size = 512); generate a qr code as png byte array with default settings. ">
+              <h4><span class="kind">method</span> <span class="name">GetPngBytes</span></h4>
+              <pre class="sig"><code>public static byte[] GetPngBytes(string content, ECCLevel eccLevel = 1, int size = 512);</code></pre>
               <p class="doc">Generate a QR code as PNG byte array with default settings.</p>
             </div>
-            <div class="member" data-text="public static byte[] getsvgbytes(qrcodedata qrcodedata, int size = 512); generate a qr code as svg (utf-8 encoded) byte array with default settings. ">
-              <code>public static byte[] GetSvgBytes(QRCodeData qrCodeData, int size = 512);</code>
+            <div class="member" data-text="method public static byte[] getsvgbytes(qrcodedata qrcodedata, int size = 512); generate a qr code as svg (utf-8 encoded) byte array with default settings. ">
+              <h4><span class="kind">method</span> <span class="name">GetSvgBytes</span></h4>
+              <pre class="sig"><code>public static byte[] GetSvgBytes(QRCodeData qrCodeData, int size = 512);</code></pre>
               <p class="doc">Generate a QR code as SVG (UTF-8 encoded) byte array with default settings.</p>
             </div>
-            <div class="member" data-text="public static byte[] getsvgbytes(string content, ecclevel ecclevel = 1, int size = 512); generate a qr code as svg (utf-8 encoded) byte array with default settings. ">
-              <code>public static byte[] GetSvgBytes(string content, ECCLevel eccLevel = 1, int size = 512);</code>
+            <div class="member" data-text="method public static byte[] getsvgbytes(string content, ecclevel ecclevel = 1, int size = 512); generate a qr code as svg (utf-8 encoded) byte array with default settings. ">
+              <h4><span class="kind">method</span> <span class="name">GetSvgBytes</span></h4>
+              <pre class="sig"><code>public static byte[] GetSvgBytes(string content, ECCLevel eccLevel = 1, int size = 512);</code></pre>
               <p class="doc">Generate a QR code as SVG (UTF-8 encoded) byte array with default settings.</p>
             </div>
-            <div class="member" data-text="public static string getsvgstring(qrcodedata qrcodedata, int size = 512); generate a qr code as svg document string with default settings. ">
-              <code>public static string GetSvgString(QRCodeData qrCodeData, int size = 512);</code>
+            <div class="member" data-text="method public static string getsvgstring(qrcodedata qrcodedata, int size = 512); generate a qr code as svg document string with default settings. ">
+              <h4><span class="kind">method</span> <span class="name">GetSvgString</span></h4>
+              <pre class="sig"><code>public static string GetSvgString(QRCodeData qrCodeData, int size = 512);</code></pre>
               <p class="doc">Generate a QR code as SVG document string with default settings.</p>
             </div>
-            <div class="member" data-text="public static string getsvgstring(string content, ecclevel ecclevel = 1, int size = 512); generate a qr code as svg document string with default settings. ">
-              <code>public static string GetSvgString(string content, ECCLevel eccLevel = 1, int size = 512);</code>
+            <div class="member" data-text="method public static string getsvgstring(string content, ecclevel ecclevel = 1, int size = 512); generate a qr code as svg document string with default settings. ">
+              <h4><span class="kind">method</span> <span class="name">GetSvgString</span></h4>
+              <pre class="sig"><code>public static string GetSvgString(string content, ECCLevel eccLevel = 1, int size = 512);</code></pre>
               <p class="doc">Generate a QR code as SVG document string with default settings.</p>
             </div>
-            <div class="member" data-text="public static void savepng(qrcodedata qrcodedata, stream output, int size = 512); generate a qr code and save to stream with default png settings. ">
-              <code>public static void SavePng(QRCodeData qrCodeData, Stream output, int size = 512);</code>
+            <div class="member" data-text="method public static void savepng(qrcodedata qrcodedata, stream output, int size = 512); generate a qr code and save to stream with default png settings. ">
+              <h4><span class="kind">method</span> <span class="name">SavePng</span></h4>
+              <pre class="sig"><code>public static void SavePng(QRCodeData qrCodeData, Stream output, int size = 512);</code></pre>
               <p class="doc">Generate a QR code and save to stream with default PNG settings.</p>
             </div>
-            <div class="member" data-text="public static void savepng(string content, stream output, ecclevel ecclevel = 1, int size = 512); generate a qr code and save to stream with default png settings. ">
-              <code>public static void SavePng(string content, Stream output, ECCLevel eccLevel = 1, int size = 512);</code>
+            <div class="member" data-text="method public static void savepng(string content, stream output, ecclevel ecclevel = 1, int size = 512); generate a qr code and save to stream with default png settings. ">
+              <h4><span class="kind">method</span> <span class="name">SavePng</span></h4>
+              <pre class="sig"><code>public static void SavePng(string content, Stream output, ECCLevel eccLevel = 1, int size = 512);</code></pre>
               <p class="doc">Generate a QR code and save to stream with default PNG settings.</p>
             </div>
-            <div class="member" data-text="public static void savesvg(qrcodedata qrcodedata, stream output, int size = 512); generate a qr code and save as svg to stream with default settings. ">
-              <code>public static void SaveSvg(QRCodeData qrCodeData, Stream output, int size = 512);</code>
+            <div class="member" data-text="method public static void savesvg(qrcodedata qrcodedata, stream output, int size = 512); generate a qr code and save as svg to stream with default settings. ">
+              <h4><span class="kind">method</span> <span class="name">SaveSvg</span></h4>
+              <pre class="sig"><code>public static void SaveSvg(QRCodeData qrCodeData, Stream output, int size = 512);</code></pre>
               <p class="doc">Generate a QR code and save as SVG to stream with default settings.</p>
             </div>
-            <div class="member" data-text="public static void savesvg(string content, stream output, ecclevel ecclevel = 1, int size = 512); generate a qr code and save as svg to stream with default settings. ">
-              <code>public static void SaveSvg(string content, Stream output, ECCLevel eccLevel = 1, int size = 512);</code>
+            <div class="member" data-text="method public static void savesvg(string content, stream output, ecclevel ecclevel = 1, int size = 512); generate a qr code and save as svg to stream with default settings. ">
+              <h4><span class="kind">method</span> <span class="name">SaveSvg</span></h4>
+              <pre class="sig"><code>public static void SaveSvg(string content, Stream output, ECCLevel eccLevel = 1, int size = 512);</code></pre>
               <p class="doc">Generate a QR code and save as SVG to stream with default settings.</p>
             </div>
-            <div class="member" data-text="public static void writeimage(qrcodedata qrcodedata, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, int size = 512, int quality = 100); generate a qr code and write to an ibufferwriter with specified format. ">
-              <code>public static void WriteImage(QRCodeData qrCodeData, IBufferWriter&lt;byte&gt; writer, SKEncodedImageFormat format, int size = 512, int quality = 100);</code>
+            <div class="member" data-text="method public static void writeimage(qrcodedata qrcodedata, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, int size = 512, int quality = 100); generate a qr code and write to an ibufferwriter with specified format. ">
+              <h4><span class="kind">method</span> <span class="name">WriteImage</span></h4>
+              <pre class="sig"><code>public static void WriteImage(QRCodeData qrCodeData, IBufferWriter&lt;byte&gt; writer, SKEncodedImageFormat format, int size = 512, int quality = 100);</code></pre>
               <p class="doc">Generate a QR code and write to an IBufferWriter with specified format.</p>
             </div>
-            <div class="member" data-text="public static void writeimage(string content, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, ecclevel ecclevel = 1, int size = 512, int quality = 100); generate a qr code and write to an ibufferwriter with specified format. ">
-              <code>public static void WriteImage(string content, IBufferWriter&lt;byte&gt; writer, SKEncodedImageFormat format, ECCLevel eccLevel = 1, int size = 512, int quality = 100);</code>
+            <div class="member" data-text="method public static void writeimage(string content, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, ecclevel ecclevel = 1, int size = 512, int quality = 100); generate a qr code and write to an ibufferwriter with specified format. ">
+              <h4><span class="kind">method</span> <span class="name">WriteImage</span></h4>
+              <pre class="sig"><code>public static void WriteImage(string content, IBufferWriter&lt;byte&gt; writer, SKEncodedImageFormat format, ECCLevel eccLevel = 1, int size = 512, int quality = 100);</code></pre>
               <p class="doc">Generate a QR code and write to an IBufferWriter with specified format.</p>
             </div>
-            <div class="member" data-text="public static void writepng(qrcodedata qrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate a qr code and write to an ibufferwriter with default png settings. ">
-              <code>public static void WritePng(QRCodeData qrCodeData, IBufferWriter&lt;byte&gt; writer, int size = 512);</code>
+            <div class="member" data-text="method public static void writepng(qrcodedata qrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate a qr code and write to an ibufferwriter with default png settings. ">
+              <h4><span class="kind">method</span> <span class="name">WritePng</span></h4>
+              <pre class="sig"><code>public static void WritePng(QRCodeData qrCodeData, IBufferWriter&lt;byte&gt; writer, int size = 512);</code></pre>
               <p class="doc">Generate a QR code and write to an IBufferWriter with default PNG settings.</p>
             </div>
-            <div class="member" data-text="public static void writepng(string content, ibufferwriter&lt;byte&gt; writer, ecclevel ecclevel = 1, int size = 512); generate a qr code and write to an ibufferwriter with default png settings. ">
-              <code>public static void WritePng(string content, IBufferWriter&lt;byte&gt; writer, ECCLevel eccLevel = 1, int size = 512);</code>
+            <div class="member" data-text="method public static void writepng(string content, ibufferwriter&lt;byte&gt; writer, ecclevel ecclevel = 1, int size = 512); generate a qr code and write to an ibufferwriter with default png settings. ">
+              <h4><span class="kind">method</span> <span class="name">WritePng</span></h4>
+              <pre class="sig"><code>public static void WritePng(string content, IBufferWriter&lt;byte&gt; writer, ECCLevel eccLevel = 1, int size = 512);</code></pre>
               <p class="doc">Generate a QR code and write to an IBufferWriter with default PNG settings.</p>
             </div>
-            <div class="member" data-text="public static void writesvg(qrcodedata qrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate a qr code and write as svg (utf-8 encoded) to an ibufferwriter with default settings. ">
-              <code>public static void WriteSvg(QRCodeData qrCodeData, IBufferWriter&lt;byte&gt; writer, int size = 512);</code>
+            <div class="member" data-text="method public static void writesvg(qrcodedata qrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate a qr code and write as svg (utf-8 encoded) to an ibufferwriter with default settings. ">
+              <h4><span class="kind">method</span> <span class="name">WriteSvg</span></h4>
+              <pre class="sig"><code>public static void WriteSvg(QRCodeData qrCodeData, IBufferWriter&lt;byte&gt; writer, int size = 512);</code></pre>
               <p class="doc">Generate a QR code and write as SVG (UTF-8 encoded) to an IBufferWriter with default settings.</p>
             </div>
-            <div class="member" data-text="public static void writesvg(string content, ibufferwriter&lt;byte&gt; writer, ecclevel ecclevel = 1, int size = 512); generate a qr code and write as svg (utf-8 encoded) to an ibufferwriter with default settings. ">
-              <code>public static void WriteSvg(string content, IBufferWriter&lt;byte&gt; writer, ECCLevel eccLevel = 1, int size = 512);</code>
+            <div class="member" data-text="method public static void writesvg(string content, ibufferwriter&lt;byte&gt; writer, ecclevel ecclevel = 1, int size = 512); generate a qr code and write as svg (utf-8 encoded) to an ibufferwriter with default settings. ">
+              <h4><span class="kind">method</span> <span class="name">WriteSvg</span></h4>
+              <pre class="sig"><code>public static void WriteSvg(string content, IBufferWriter&lt;byte&gt; writer, ECCLevel eccLevel = 1, int size = 512);</code></pre>
               <p class="doc">Generate a QR code and write as SVG (UTF-8 encoded) to an IBufferWriter with default settings.</p>
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.Image.QRCodeImageBuilderBase" data-name="skiasharp.qrcode.image.qrcodeimagebuilderbase" data-text="skiasharp.qrcode.image.qrcodeimagebuilderbase public abstract class qrcodeimagebuilderbase&lt;tself&gt; shared implementation for the symbology-specific qr image builders ( qrcodeimagebuilder , microqrcodeimagebuilder ): the fluent options every symbology supports, canvas layout, and the complete raster/svg output surface. symbology-specific concerns, error correction and version types, icon overlays, finder pattern styling, live on the derived builders. the self-referential type parameter keeps fluent chains typed to the concrete builder, so shared and symbology-specific options mix freely without casts: new microqrcodeimagebuilder(&quot;...&quot;).withsize(256, 256).withversion(microqrversion.m4). deriving from this class outside the library is not supported: the abstract hooks that connect a symbology's data model to the shared output pipeline are private protected. public qrcodeimagebuilderbase.tself withcolors(skcolor? codecolor = null, skcolor? backgroundcolor = null, skcolor? clearcolor = null); configure the colors used in the image.  public qrcodeimagebuilderbase.tself withformat(skencodedimageformat format, int quality = 100); configure the output image format and quality.  public qrcodeimagebuilderbase.tself withgradient(gradientoptions? gradientoptions); configure gradient options for the modules.  public qrcodeimagebuilderbase.tself withmodulepixelsize(int modulepixelsize); configure content size from pixels-per-module. sets each module to an exact integer pixel size. content side length is matrixsize * modulepixelsize. used alone, the output image matches the content size. used with qrcodeimagebuilderbase , the content is centered on the larger canvas and padded with clearcolor. if the canvas is smaller than the content, rendering throws. public qrcodeimagebuilderbase.tself withmoduleshape(moduleshape? moduleshape, float sizepercent = 1); configure the shape of the modules. note: custom module shapes reduce scan margin; sizes below 0.8 may affect readability. on standard qr they also affect finder patterns unless a custom finder pattern shape is explicitly set via its withfinderpatternshape option. public qrcodeimagebuilderbase.tself withquietzone(int size); configure the quiet zone size (light border) around the symbol. when not called, the builder uses its symbology's specification default: 4 modules for standard qr, 2 for micro qr and rmqr. ignored when the builder was given pre-built symbol data (the data already carries its quiet zone). public qrcodeimagebuilderbase.tself withsize(int width, int height); configure the output image size in absolute pixels. used alone, this sets an exact canvas size. for the square symbologies the module pixel size then becomes imagesize / matrixsize, which may be fractional and can change when the version changes; the rectangular rmqr builder fits the symbol into the canvas with a uniform module scale instead (letterbox, the leftover pad keeps clearcolor). used with qrcodeimagebuilderbase , this sets the canvas size while module pixels define the content size (matrixsize * modulepixelsize). the canvas must be at least as large as the content on both sides; extra space is padded and the content is centered. padding uses clearcolor from qrcodeimagebuilderbase . public skbitmap tobitmap(); generate the symbol image and return as skbitmap.  public skimage toimage(); generate the symbol image and return as skimage.  public byte[] tobytearray(); generate the symbol image and return as byte array.  public string tosvgstring(); generate the symbol and return as svg document string. see qrcodeimagebuilderbase for rendering behavior. public void saveto(ibufferwriter&lt;byte&gt; writer); generate the symbol image and write to an ibufferwriter. this is more efficient than saveto(stream) as it avoids intermediate buffering.  public void saveto(stream output); generate the symbol image and save to stream.  public void savetosvg(ibufferwriter&lt;byte&gt; writer); generate the symbol and write as svg document to an ibufferwriter. see qrcodeimagebuilderbase for rendering behavior. data is written in writer-provided segments, so segmented writers (e.g. pipewriter) work without a single contiguous buffer for the whole document. public void savetosvg(stream output); generate the symbol and save as svg document to stream. the symbol is drawn as vector shapes via sksvgcanvas , so the output scales without quality loss. all builder options apply. the root element carries a viewbox, so the document scales its content when embedded at a different size (img element, css). for plain rectangular modules, shape-rendering=&quot;crispedges&quot; is added to avoid antialiasing seams between modules; custom shapes keep antialiasing for smooth curves. qrcodeimagebuilderbase is ignored, svg is a vector format, not an skencodedimageformat . size options ( qrcodeimagebuilderbase , qrcodeimagebuilderbase , or the symbology's default canvas) define the svg viewport in units. the stream is left open after writing.">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.QRCodeImageBuilderBase" aria-label="Link to SkiaSharp.QrCode.Image.QRCodeImageBuilderBase">#</a><code>public abstract class QRCodeImageBuilderBase&lt;TSelf&gt;</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.Image.QRCodeImageBuilderBase" data-name="skiasharp.qrcode.image.qrcodeimagebuilderbase" data-text="skiasharp.qrcode.image.qrcodeimagebuilderbase public abstract class qrcodeimagebuilderbase&lt;tself&gt; shared implementation for the symbology-specific qr image builders ( qrcodeimagebuilder , microqrcodeimagebuilder ): the fluent options every symbology supports, canvas layout, and the complete raster/svg output surface. symbology-specific concerns, error correction and version types, icon overlays, finder pattern styling, live on the derived builders. the self-referential type parameter keeps fluent chains typed to the concrete builder, so shared and symbology-specific options mix freely without casts: new microqrcodeimagebuilder(&quot;...&quot;).withsize(256, 256).withversion(microqrversion.m4). deriving from this class outside the library is not supported: the abstract hooks that connect a symbology's data model to the shared output pipeline are private protected. method public qrcodeimagebuilderbase.tself withcolors(skcolor? codecolor = null, skcolor? backgroundcolor = null, skcolor? clearcolor = null); configure the colors used in the image.  method public qrcodeimagebuilderbase.tself withformat(skencodedimageformat format, int quality = 100); configure the output image format and quality.  method public qrcodeimagebuilderbase.tself withgradient(gradientoptions? gradientoptions); configure gradient options for the modules.  method public qrcodeimagebuilderbase.tself withmodulepixelsize(int modulepixelsize); configure content size from pixels-per-module. sets each module to an exact integer pixel size. content side length is matrixsize * modulepixelsize. used alone, the output image matches the content size. used with qrcodeimagebuilderbase , the content is centered on the larger canvas and padded with clearcolor. if the canvas is smaller than the content, rendering throws. method public qrcodeimagebuilderbase.tself withmoduleshape(moduleshape? moduleshape, float sizepercent = 1); configure the shape of the modules. note: custom module shapes reduce scan margin; sizes below 0.8 may affect readability. on standard qr they also affect finder patterns unless a custom finder pattern shape is explicitly set via its withfinderpatternshape option. method public qrcodeimagebuilderbase.tself withquietzone(int size); configure the quiet zone size (light border) around the symbol. when not called, the builder uses its symbology's specification default: 4 modules for standard qr, 2 for micro qr and rmqr. ignored when the builder was given pre-built symbol data (the data already carries its quiet zone). method public qrcodeimagebuilderbase.tself withsize(int width, int height); configure the output image size in absolute pixels. used alone, this sets an exact canvas size. for the square symbologies the module pixel size then becomes imagesize / matrixsize, which may be fractional and can change when the version changes; the rectangular rmqr builder fits the symbol into the canvas with a uniform module scale instead (letterbox, the leftover pad keeps clearcolor). used with qrcodeimagebuilderbase , this sets the canvas size while module pixels define the content size (matrixsize * modulepixelsize). the canvas must be at least as large as the content on both sides; extra space is padded and the content is centered. padding uses clearcolor from qrcodeimagebuilderbase . method public skbitmap tobitmap(); generate the symbol image and return as skbitmap.  method public skimage toimage(); generate the symbol image and return as skimage.  method public byte[] tobytearray(); generate the symbol image and return as byte array.  method public string tosvgstring(); generate the symbol and return as svg document string. see qrcodeimagebuilderbase for rendering behavior. method public void saveto(ibufferwriter&lt;byte&gt; writer); generate the symbol image and write to an ibufferwriter. this is more efficient than saveto(stream) as it avoids intermediate buffering.  method public void saveto(stream output); generate the symbol image and save to stream.  method public void savetosvg(ibufferwriter&lt;byte&gt; writer); generate the symbol and write as svg document to an ibufferwriter. see qrcodeimagebuilderbase for rendering behavior. data is written in writer-provided segments, so segmented writers (e.g. pipewriter) work without a single contiguous buffer for the whole document. method public void savetosvg(stream output); generate the symbol and save as svg document to stream. the symbol is drawn as vector shapes via sksvgcanvas , so the output scales without quality loss. all builder options apply. the root element carries a viewbox, so the document scales its content when embedded at a different size (img element, css). for plain rectangular modules, shape-rendering=&quot;crispedges&quot; is added to avoid antialiasing seams between modules; custom shapes keep antialiasing for smooth curves. qrcodeimagebuilderbase is ignored, svg is a vector format, not an skencodedimageformat . size options ( qrcodeimagebuilderbase , qrcodeimagebuilderbase , or the symbology's default canvas) define the svg viewport in units. the stream is left open after writing.">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.QRCodeImageBuilderBase" aria-label="Link to SkiaSharp.QrCode.Image.QRCodeImageBuilderBase">#</a><span class="kind">class</span> <span class="name">QRCodeImageBuilderBase</span></h3>
+          <pre class="sig"><code>public abstract class QRCodeImageBuilderBase&lt;TSelf&gt;</code></pre>
           <p class="doc">Shared implementation for the symbology-specific QR image builders ( QRCodeImageBuilder , MicroQRCodeImageBuilder ): the fluent options every symbology supports, canvas layout, and the complete raster/SVG output surface. Symbology-specific concerns, error correction and version types, icon overlays, finder pattern styling, live on the derived builders.</p>
           <details class="notes" data-text="the self-referential type parameter keeps fluent chains typed to the concrete builder, so shared and symbology-specific options mix freely without casts: new microqrcodeimagebuilder(&quot;...&quot;).withsize(256, 256).withversion(microqrversion.m4). deriving from this class outside the library is not supported: the abstract hooks that connect a symbology's data model to the shared output pipeline are private protected.">
             <summary>Notes</summary>
             <p class="doc remarks">The self-referential type parameter keeps fluent chains typed to the concrete builder, so shared and symbology-specific options mix freely without casts: new MicroQRCodeImageBuilder(&quot;...&quot;).WithSize(256, 256).WithVersion(MicroQRVersion.M4). Deriving from this class outside the library is not supported: the abstract hooks that connect a symbology's data model to the shared output pipeline are private protected.</p>
           </details>
           <div class="members">
-            <div class="member" data-text="public qrcodeimagebuilderbase.tself withcolors(skcolor? codecolor = null, skcolor? backgroundcolor = null, skcolor? clearcolor = null); configure the colors used in the image. ">
-              <code>public QRCodeImageBuilderBase.TSelf WithColors(SKColor? codeColor = null, SKColor? backgroundColor = null, SKColor? clearColor = null);</code>
+            <div class="member" data-text="method public qrcodeimagebuilderbase.tself withcolors(skcolor? codecolor = null, skcolor? backgroundcolor = null, skcolor? clearcolor = null); configure the colors used in the image. ">
+              <h4><span class="kind">method</span> <span class="name">WithColors</span></h4>
+              <pre class="sig"><code>public QRCodeImageBuilderBase.TSelf WithColors(SKColor? codeColor = null, SKColor? backgroundColor = null, SKColor? clearColor = null);</code></pre>
               <p class="doc">Configure the colors used in the image.</p>
             </div>
-            <div class="member" data-text="public qrcodeimagebuilderbase.tself withformat(skencodedimageformat format, int quality = 100); configure the output image format and quality. ">
-              <code>public QRCodeImageBuilderBase.TSelf WithFormat(SKEncodedImageFormat format, int quality = 100);</code>
+            <div class="member" data-text="method public qrcodeimagebuilderbase.tself withformat(skencodedimageformat format, int quality = 100); configure the output image format and quality. ">
+              <h4><span class="kind">method</span> <span class="name">WithFormat</span></h4>
+              <pre class="sig"><code>public QRCodeImageBuilderBase.TSelf WithFormat(SKEncodedImageFormat format, int quality = 100);</code></pre>
               <p class="doc">Configure the output image format and quality.</p>
             </div>
-            <div class="member" data-text="public qrcodeimagebuilderbase.tself withgradient(gradientoptions? gradientoptions); configure gradient options for the modules. ">
-              <code>public QRCodeImageBuilderBase.TSelf WithGradient(GradientOptions? gradientOptions);</code>
+            <div class="member" data-text="method public qrcodeimagebuilderbase.tself withgradient(gradientoptions? gradientoptions); configure gradient options for the modules. ">
+              <h4><span class="kind">method</span> <span class="name">WithGradient</span></h4>
+              <pre class="sig"><code>public QRCodeImageBuilderBase.TSelf WithGradient(GradientOptions? gradientOptions);</code></pre>
               <p class="doc">Configure gradient options for the modules.</p>
             </div>
-            <div class="member" data-text="public qrcodeimagebuilderbase.tself withmodulepixelsize(int modulepixelsize); configure content size from pixels-per-module. sets each module to an exact integer pixel size. content side length is matrixsize * modulepixelsize. used alone, the output image matches the content size. used with qrcodeimagebuilderbase , the content is centered on the larger canvas and padded with clearcolor. if the canvas is smaller than the content, rendering throws.">
-              <code>public QRCodeImageBuilderBase.TSelf WithModulePixelSize(int modulePixelSize);</code>
+            <div class="member" data-text="method public qrcodeimagebuilderbase.tself withmodulepixelsize(int modulepixelsize); configure content size from pixels-per-module. sets each module to an exact integer pixel size. content side length is matrixsize * modulepixelsize. used alone, the output image matches the content size. used with qrcodeimagebuilderbase , the content is centered on the larger canvas and padded with clearcolor. if the canvas is smaller than the content, rendering throws.">
+              <h4><span class="kind">method</span> <span class="name">WithModulePixelSize</span></h4>
+              <pre class="sig"><code>public QRCodeImageBuilderBase.TSelf WithModulePixelSize(int modulePixelSize);</code></pre>
               <p class="doc">Configure content size from pixels-per-module.</p>
               <details class="notes" data-text="sets each module to an exact integer pixel size. content side length is matrixsize * modulepixelsize. used alone, the output image matches the content size. used with qrcodeimagebuilderbase , the content is centered on the larger canvas and padded with clearcolor. if the canvas is smaller than the content, rendering throws.">
                 <summary>Notes</summary>
                 <p class="doc remarks">Sets each module to an exact integer pixel size. Content side length is matrixSize * modulePixelSize. Used alone, the output image matches the content size. Used with QRCodeImageBuilderBase , the content is centered on the larger canvas and padded with clearColor. If the canvas is smaller than the content, rendering throws.</p>
               </details>
             </div>
-            <div class="member" data-text="public qrcodeimagebuilderbase.tself withmoduleshape(moduleshape? moduleshape, float sizepercent = 1); configure the shape of the modules. note: custom module shapes reduce scan margin; sizes below 0.8 may affect readability. on standard qr they also affect finder patterns unless a custom finder pattern shape is explicitly set via its withfinderpatternshape option.">
-              <code>public QRCodeImageBuilderBase.TSelf WithModuleShape(ModuleShape? moduleShape, float sizePercent = 1);</code>
+            <div class="member" data-text="method public qrcodeimagebuilderbase.tself withmoduleshape(moduleshape? moduleshape, float sizepercent = 1); configure the shape of the modules. note: custom module shapes reduce scan margin; sizes below 0.8 may affect readability. on standard qr they also affect finder patterns unless a custom finder pattern shape is explicitly set via its withfinderpatternshape option.">
+              <h4><span class="kind">method</span> <span class="name">WithModuleShape</span></h4>
+              <pre class="sig"><code>public QRCodeImageBuilderBase.TSelf WithModuleShape(ModuleShape? moduleShape, float sizePercent = 1);</code></pre>
               <p class="doc">Configure the shape of the modules.</p>
               <details class="notes" data-text="note: custom module shapes reduce scan margin; sizes below 0.8 may affect readability. on standard qr they also affect finder patterns unless a custom finder pattern shape is explicitly set via its withfinderpatternshape option.">
                 <summary>Notes</summary>
                 <p class="doc remarks">Note: Custom module shapes reduce scan margin; sizes below 0.8 may affect readability. On Standard QR they also affect finder patterns unless a custom finder pattern shape is explicitly set via its WithFinderPatternShape option.</p>
               </details>
             </div>
-            <div class="member" data-text="public qrcodeimagebuilderbase.tself withquietzone(int size); configure the quiet zone size (light border) around the symbol. when not called, the builder uses its symbology's specification default: 4 modules for standard qr, 2 for micro qr and rmqr. ignored when the builder was given pre-built symbol data (the data already carries its quiet zone).">
-              <code>public QRCodeImageBuilderBase.TSelf WithQuietZone(int size);</code>
+            <div class="member" data-text="method public qrcodeimagebuilderbase.tself withquietzone(int size); configure the quiet zone size (light border) around the symbol. when not called, the builder uses its symbology's specification default: 4 modules for standard qr, 2 for micro qr and rmqr. ignored when the builder was given pre-built symbol data (the data already carries its quiet zone).">
+              <h4><span class="kind">method</span> <span class="name">WithQuietZone</span></h4>
+              <pre class="sig"><code>public QRCodeImageBuilderBase.TSelf WithQuietZone(int size);</code></pre>
               <p class="doc">Configure the quiet zone size (light border) around the symbol.</p>
               <details class="notes" data-text="when not called, the builder uses its symbology's specification default: 4 modules for standard qr, 2 for micro qr and rmqr. ignored when the builder was given pre-built symbol data (the data already carries its quiet zone).">
                 <summary>Notes</summary>
                 <p class="doc remarks">When not called, the builder uses its symbology's specification default: 4 modules for Standard QR, 2 for Micro QR and rMQR. Ignored when the builder was given pre-built symbol data (the data already carries its quiet zone).</p>
               </details>
             </div>
-            <div class="member" data-text="public qrcodeimagebuilderbase.tself withsize(int width, int height); configure the output image size in absolute pixels. used alone, this sets an exact canvas size. for the square symbologies the module pixel size then becomes imagesize / matrixsize, which may be fractional and can change when the version changes; the rectangular rmqr builder fits the symbol into the canvas with a uniform module scale instead (letterbox, the leftover pad keeps clearcolor). used with qrcodeimagebuilderbase , this sets the canvas size while module pixels define the content size (matrixsize * modulepixelsize). the canvas must be at least as large as the content on both sides; extra space is padded and the content is centered. padding uses clearcolor from qrcodeimagebuilderbase .">
-              <code>public QRCodeImageBuilderBase.TSelf WithSize(int width, int height);</code>
+            <div class="member" data-text="method public qrcodeimagebuilderbase.tself withsize(int width, int height); configure the output image size in absolute pixels. used alone, this sets an exact canvas size. for the square symbologies the module pixel size then becomes imagesize / matrixsize, which may be fractional and can change when the version changes; the rectangular rmqr builder fits the symbol into the canvas with a uniform module scale instead (letterbox, the leftover pad keeps clearcolor). used with qrcodeimagebuilderbase , this sets the canvas size while module pixels define the content size (matrixsize * modulepixelsize). the canvas must be at least as large as the content on both sides; extra space is padded and the content is centered. padding uses clearcolor from qrcodeimagebuilderbase .">
+              <h4><span class="kind">method</span> <span class="name">WithSize</span></h4>
+              <pre class="sig"><code>public QRCodeImageBuilderBase.TSelf WithSize(int width, int height);</code></pre>
               <p class="doc">Configure the output image size in absolute pixels.</p>
               <details class="notes" data-text="used alone, this sets an exact canvas size. for the square symbologies the module pixel size then becomes imagesize / matrixsize, which may be fractional and can change when the version changes; the rectangular rmqr builder fits the symbol into the canvas with a uniform module scale instead (letterbox, the leftover pad keeps clearcolor). used with qrcodeimagebuilderbase , this sets the canvas size while module pixels define the content size (matrixsize * modulepixelsize). the canvas must be at least as large as the content on both sides; extra space is padded and the content is centered. padding uses clearcolor from qrcodeimagebuilderbase .">
                 <summary>Notes</summary>
                 <p class="doc remarks">Used alone, this sets an exact canvas size. For the square symbologies the module pixel size then becomes imageSize / matrixSize, which may be fractional and can change when the version changes; the rectangular rMQR builder fits the symbol into the canvas with a uniform module scale instead (letterbox, the leftover pad keeps clearColor). Used with QRCodeImageBuilderBase , this sets the canvas size while module pixels define the content size (matrixSize * modulePixelSize). The canvas must be at least as large as the content on both sides; extra space is padded and the content is centered. Padding uses clearColor from QRCodeImageBuilderBase .</p>
               </details>
             </div>
-            <div class="member" data-text="public skbitmap tobitmap(); generate the symbol image and return as skbitmap. ">
-              <code>public SKBitmap ToBitmap();</code>
+            <div class="member" data-text="method public skbitmap tobitmap(); generate the symbol image and return as skbitmap. ">
+              <h4><span class="kind">method</span> <span class="name">ToBitmap</span></h4>
+              <pre class="sig"><code>public SKBitmap ToBitmap();</code></pre>
               <p class="doc">Generate the symbol image and return as SKBitmap.</p>
             </div>
-            <div class="member" data-text="public skimage toimage(); generate the symbol image and return as skimage. ">
-              <code>public SKImage ToImage();</code>
+            <div class="member" data-text="method public skimage toimage(); generate the symbol image and return as skimage. ">
+              <h4><span class="kind">method</span> <span class="name">ToImage</span></h4>
+              <pre class="sig"><code>public SKImage ToImage();</code></pre>
               <p class="doc">Generate the symbol image and return as SKImage.</p>
             </div>
-            <div class="member" data-text="public byte[] tobytearray(); generate the symbol image and return as byte array. ">
-              <code>public byte[] ToByteArray();</code>
+            <div class="member" data-text="method public byte[] tobytearray(); generate the symbol image and return as byte array. ">
+              <h4><span class="kind">method</span> <span class="name">ToByteArray</span></h4>
+              <pre class="sig"><code>public byte[] ToByteArray();</code></pre>
               <p class="doc">Generate the symbol image and return as byte array.</p>
             </div>
-            <div class="member" data-text="public string tosvgstring(); generate the symbol and return as svg document string. see qrcodeimagebuilderbase for rendering behavior.">
-              <code>public string ToSvgString();</code>
+            <div class="member" data-text="method public string tosvgstring(); generate the symbol and return as svg document string. see qrcodeimagebuilderbase for rendering behavior.">
+              <h4><span class="kind">method</span> <span class="name">ToSvgString</span></h4>
+              <pre class="sig"><code>public string ToSvgString();</code></pre>
               <p class="doc">Generate the symbol and return as SVG document string.</p>
               <details class="notes" data-text="see qrcodeimagebuilderbase for rendering behavior.">
                 <summary>Notes</summary>
                 <p class="doc remarks">See QRCodeImageBuilderBase for rendering behavior.</p>
               </details>
             </div>
-            <div class="member" data-text="public void saveto(ibufferwriter&lt;byte&gt; writer); generate the symbol image and write to an ibufferwriter. this is more efficient than saveto(stream) as it avoids intermediate buffering. ">
-              <code>public void SaveTo(IBufferWriter&lt;byte&gt; writer);</code>
+            <div class="member" data-text="method public void saveto(ibufferwriter&lt;byte&gt; writer); generate the symbol image and write to an ibufferwriter. this is more efficient than saveto(stream) as it avoids intermediate buffering. ">
+              <h4><span class="kind">method</span> <span class="name">SaveTo</span></h4>
+              <pre class="sig"><code>public void SaveTo(IBufferWriter&lt;byte&gt; writer);</code></pre>
               <p class="doc">Generate the symbol image and write to an IBufferWriter. This is more efficient than SaveTo(Stream) as it avoids intermediate buffering.</p>
             </div>
-            <div class="member" data-text="public void saveto(stream output); generate the symbol image and save to stream. ">
-              <code>public void SaveTo(Stream output);</code>
+            <div class="member" data-text="method public void saveto(stream output); generate the symbol image and save to stream. ">
+              <h4><span class="kind">method</span> <span class="name">SaveTo</span></h4>
+              <pre class="sig"><code>public void SaveTo(Stream output);</code></pre>
               <p class="doc">Generate the symbol image and save to stream.</p>
             </div>
-            <div class="member" data-text="public void savetosvg(ibufferwriter&lt;byte&gt; writer); generate the symbol and write as svg document to an ibufferwriter. see qrcodeimagebuilderbase for rendering behavior. data is written in writer-provided segments, so segmented writers (e.g. pipewriter) work without a single contiguous buffer for the whole document.">
-              <code>public void SaveToSvg(IBufferWriter&lt;byte&gt; writer);</code>
+            <div class="member" data-text="method public void savetosvg(ibufferwriter&lt;byte&gt; writer); generate the symbol and write as svg document to an ibufferwriter. see qrcodeimagebuilderbase for rendering behavior. data is written in writer-provided segments, so segmented writers (e.g. pipewriter) work without a single contiguous buffer for the whole document.">
+              <h4><span class="kind">method</span> <span class="name">SaveToSvg</span></h4>
+              <pre class="sig"><code>public void SaveToSvg(IBufferWriter&lt;byte&gt; writer);</code></pre>
               <p class="doc">Generate the symbol and write as SVG document to an IBufferWriter.</p>
               <details class="notes" data-text="see qrcodeimagebuilderbase for rendering behavior. data is written in writer-provided segments, so segmented writers (e.g. pipewriter) work without a single contiguous buffer for the whole document.">
                 <summary>Notes</summary>
                 <p class="doc remarks">See QRCodeImageBuilderBase for rendering behavior. Data is written in writer-provided segments, so segmented writers (e.g. PipeWriter) work without a single contiguous buffer for the whole document.</p>
               </details>
             </div>
-            <div class="member" data-text="public void savetosvg(stream output); generate the symbol and save as svg document to stream. the symbol is drawn as vector shapes via sksvgcanvas , so the output scales without quality loss. all builder options apply. the root element carries a viewbox, so the document scales its content when embedded at a different size (img element, css). for plain rectangular modules, shape-rendering=&quot;crispedges&quot; is added to avoid antialiasing seams between modules; custom shapes keep antialiasing for smooth curves. qrcodeimagebuilderbase is ignored, svg is a vector format, not an skencodedimageformat . size options ( qrcodeimagebuilderbase , qrcodeimagebuilderbase , or the symbology's default canvas) define the svg viewport in units. the stream is left open after writing.">
-              <code>public void SaveToSvg(Stream output);</code>
+            <div class="member" data-text="method public void savetosvg(stream output); generate the symbol and save as svg document to stream. the symbol is drawn as vector shapes via sksvgcanvas , so the output scales without quality loss. all builder options apply. the root element carries a viewbox, so the document scales its content when embedded at a different size (img element, css). for plain rectangular modules, shape-rendering=&quot;crispedges&quot; is added to avoid antialiasing seams between modules; custom shapes keep antialiasing for smooth curves. qrcodeimagebuilderbase is ignored, svg is a vector format, not an skencodedimageformat . size options ( qrcodeimagebuilderbase , qrcodeimagebuilderbase , or the symbology's default canvas) define the svg viewport in units. the stream is left open after writing.">
+              <h4><span class="kind">method</span> <span class="name">SaveToSvg</span></h4>
+              <pre class="sig"><code>public void SaveToSvg(Stream output);</code></pre>
               <p class="doc">Generate the symbol and save as SVG document to stream.</p>
               <details class="notes" data-text="the symbol is drawn as vector shapes via sksvgcanvas , so the output scales without quality loss. all builder options apply. the root element carries a viewbox, so the document scales its content when embedded at a different size (img element, css). for plain rectangular modules, shape-rendering=&quot;crispedges&quot; is added to avoid antialiasing seams between modules; custom shapes keep antialiasing for smooth curves. qrcodeimagebuilderbase is ignored, svg is a vector format, not an skencodedimageformat . size options ( qrcodeimagebuilderbase , qrcodeimagebuilderbase , or the symbology's default canvas) define the svg viewport in units. the stream is left open after writing.">
                 <summary>Notes</summary>
@@ -2437,311 +2782,382 @@
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.Image.RectangleFinderPatternShape" data-name="skiasharp.qrcode.image.rectanglefinderpatternshape" data-text="skiasharp.qrcode.image.rectanglefinderpatternshape public sealed class rectanglefinderpatternshape : finderpatternshape standard qr code finder pattern (three nested squares, 7x7, 5x5, 3x3).  public static readonly rectanglefinderpatternshape default; gets the default instance.  public bool requiresantialiasing { get; } antialiasing disabled; straight-edged rectangles render cleanly without it.  public override void draw(skcanvas canvas, skrect rect, skpaint paint);  public override void draw(skcanvas canvas, skrect rect, skpaint paint, skcolor backgroundcolor);  public override void draw(skcanvas canvas, skrect rect, skpaint paint, skpaint backgroundpaint); ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.RectangleFinderPatternShape" aria-label="Link to SkiaSharp.QrCode.Image.RectangleFinderPatternShape">#</a><code>public sealed class RectangleFinderPatternShape : FinderPatternShape</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.Image.RectangleFinderPatternShape" data-name="skiasharp.qrcode.image.rectanglefinderpatternshape" data-text="skiasharp.qrcode.image.rectanglefinderpatternshape public sealed class rectanglefinderpatternshape : finderpatternshape standard qr code finder pattern (three nested squares, 7x7, 5x5, 3x3).  field public static readonly rectanglefinderpatternshape default; gets the default instance.  property public bool requiresantialiasing { get; } antialiasing disabled; straight-edged rectangles render cleanly without it.  method public override void draw(skcanvas canvas, skrect rect, skpaint paint);  method public override void draw(skcanvas canvas, skrect rect, skpaint paint, skcolor backgroundcolor);  method public override void draw(skcanvas canvas, skrect rect, skpaint paint, skpaint backgroundpaint); ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.RectangleFinderPatternShape" aria-label="Link to SkiaSharp.QrCode.Image.RectangleFinderPatternShape">#</a><span class="kind">class</span> <span class="name">RectangleFinderPatternShape</span></h3>
+          <pre class="sig"><code>public sealed class RectangleFinderPatternShape : FinderPatternShape</code></pre>
           <p class="doc">Standard QR code finder pattern (three nested squares, 7x7, 5x5, 3x3).</p>
           <div class="members">
-            <div class="member" data-text="public static readonly rectanglefinderpatternshape default; gets the default instance. ">
-              <code>public static readonly RectangleFinderPatternShape Default;</code>
+            <div class="member" data-text="field public static readonly rectanglefinderpatternshape default; gets the default instance. ">
+              <h4><span class="kind">field</span> <span class="name">Default</span></h4>
+              <pre class="sig"><code>public static readonly RectangleFinderPatternShape Default;</code></pre>
               <p class="doc">Gets the default instance.</p>
             </div>
-            <div class="member" data-text="public bool requiresantialiasing { get; } antialiasing disabled; straight-edged rectangles render cleanly without it. ">
-              <code>public bool RequiresAntialiasing { get; }</code>
+            <div class="member" data-text="property public bool requiresantialiasing { get; } antialiasing disabled; straight-edged rectangles render cleanly without it. ">
+              <h4><span class="kind">property</span> <span class="name">RequiresAntialiasing</span></h4>
+              <pre class="sig"><code>public bool RequiresAntialiasing { get; }</code></pre>
               <p class="doc">Antialiasing disabled; straight-edged rectangles render cleanly without it.</p>
             </div>
-            <div class="member" data-text="public override void draw(skcanvas canvas, skrect rect, skpaint paint); ">
-              <code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint);</code>
+            <div class="member" data-text="method public override void draw(skcanvas canvas, skrect rect, skpaint paint); ">
+              <h4><span class="kind">method</span> <span class="name">Draw</span></h4>
+              <pre class="sig"><code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint);</code></pre>
             </div>
-            <div class="member" data-text="public override void draw(skcanvas canvas, skrect rect, skpaint paint, skcolor backgroundcolor); ">
-              <code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint, SKColor backgroundColor);</code>
+            <div class="member" data-text="method public override void draw(skcanvas canvas, skrect rect, skpaint paint, skcolor backgroundcolor); ">
+              <h4><span class="kind">method</span> <span class="name">Draw</span></h4>
+              <pre class="sig"><code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint, SKColor backgroundColor);</code></pre>
             </div>
-            <div class="member" data-text="public override void draw(skcanvas canvas, skrect rect, skpaint paint, skpaint backgroundpaint); ">
-              <code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint, SKPaint backgroundPaint);</code>
+            <div class="member" data-text="method public override void draw(skcanvas canvas, skrect rect, skpaint paint, skpaint backgroundpaint); ">
+              <h4><span class="kind">method</span> <span class="name">Draw</span></h4>
+              <pre class="sig"><code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint, SKPaint backgroundPaint);</code></pre>
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.Image.RectangleModuleShape" data-name="skiasharp.qrcode.image.rectanglemoduleshape" data-text="skiasharp.qrcode.image.rectanglemoduleshape public sealed class rectanglemoduleshape : moduleshape draw modules as rectangles.  public static readonly rectanglemoduleshape default; gets the default instance.  public bool requiresantialiasing { get; } antialiasing disabled to prevent gray borders between modules.  public override void draw(skcanvas canvas, skrect rect, skpaint paint); ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.RectangleModuleShape" aria-label="Link to SkiaSharp.QrCode.Image.RectangleModuleShape">#</a><code>public sealed class RectangleModuleShape : ModuleShape</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.Image.RectangleModuleShape" data-name="skiasharp.qrcode.image.rectanglemoduleshape" data-text="skiasharp.qrcode.image.rectanglemoduleshape public sealed class rectanglemoduleshape : moduleshape draw modules as rectangles.  field public static readonly rectanglemoduleshape default; gets the default instance.  property public bool requiresantialiasing { get; } antialiasing disabled to prevent gray borders between modules.  method public override void draw(skcanvas canvas, skrect rect, skpaint paint); ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.RectangleModuleShape" aria-label="Link to SkiaSharp.QrCode.Image.RectangleModuleShape">#</a><span class="kind">class</span> <span class="name">RectangleModuleShape</span></h3>
+          <pre class="sig"><code>public sealed class RectangleModuleShape : ModuleShape</code></pre>
           <p class="doc">Draw modules as rectangles.</p>
           <div class="members">
-            <div class="member" data-text="public static readonly rectanglemoduleshape default; gets the default instance. ">
-              <code>public static readonly RectangleModuleShape Default;</code>
+            <div class="member" data-text="field public static readonly rectanglemoduleshape default; gets the default instance. ">
+              <h4><span class="kind">field</span> <span class="name">Default</span></h4>
+              <pre class="sig"><code>public static readonly RectangleModuleShape Default;</code></pre>
               <p class="doc">Gets the default instance.</p>
             </div>
-            <div class="member" data-text="public bool requiresantialiasing { get; } antialiasing disabled to prevent gray borders between modules. ">
-              <code>public bool RequiresAntialiasing { get; }</code>
+            <div class="member" data-text="property public bool requiresantialiasing { get; } antialiasing disabled to prevent gray borders between modules. ">
+              <h4><span class="kind">property</span> <span class="name">RequiresAntialiasing</span></h4>
+              <pre class="sig"><code>public bool RequiresAntialiasing { get; }</code></pre>
               <p class="doc">Antialiasing disabled to prevent gray borders between modules.</p>
             </div>
-            <div class="member" data-text="public override void draw(skcanvas canvas, skrect rect, skpaint paint); ">
-              <code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint);</code>
+            <div class="member" data-text="method public override void draw(skcanvas canvas, skrect rect, skpaint paint); ">
+              <h4><span class="kind">method</span> <span class="name">Draw</span></h4>
+              <pre class="sig"><code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint);</code></pre>
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.Image.RmQRCodeImageBuilder" data-name="skiasharp.qrcode.image.rmqrcodeimagebuilder" data-text="skiasharp.qrcode.image.rmqrcodeimagebuilder public class rmqrcodeimagebuilder : qrcodeimagebuilderbase&lt;rmqrcodeimagebuilder&gt; high-level builder for creating rmqr code images with fluent configuration and static methods. this builder mirrors qrcodeimagebuilder / microqrcodeimagebuilder for the rmqr symbology (iso/iec 23941, r7x43-r17x139). version, error correction and fit use the rmqr-typed rmqrversion / rmqrecclevel / rmqrfitstrategy / rmqrheight , and the default quiet zone is the 2 modules the specification requires. rmqr symbols are rectangular. with qrcodeimagebuilderbase the image is exactly the matrix at that scale; with qrcodeimagebuilderbase the symbol is fitted into the canvas with a uniform module scale and centered (letterbox, never stretched); with withwidth (the static helpers' size, and the 512-pixel default when nothing is configured) the image is that wide, the height follows the symbol aspect ratio rounded to whole pixels, the background covers the whole image and the symbol is drawn at a uniform module scale inside it (the height rounding can leave a few pixels of background at the sides on the widest versions; there is no clear-colour pad, so an opaque background gives an opaque image). rmqr has a single finder pattern and no error-correction headroom for overlays, so the standard qr styling options that depend on those (icon overlays and custom finder pattern shapes) are intentionally not offered. public rmqrcodeimagebuilder(rmqrcodedata rmqrcodedata); starts a builder that draws an rmqr code you have already generated. the symbol is used exactly as given, so only the appearance options apply. every encoding option throws invalidoperationexception on a builder created this way.  public rmqrcodeimagebuilder(string content); starts a builder that will encode content when you ask for an image. error correction, version and fit keep their defaults until you set them.  public rmqrcodeimagebuilder withecimode(ecimode ecimode); configure the eci character encoding declaration.  public rmqrcodeimagebuilder witherrorcorrection(rmqrecclevel ecclevel); configure the error correction level (m or h).  public rmqrcodeimagebuilder withfitstrategy(rmqrfitstrategy fitstrategy); configure how the version is chosen among those that hold the content (default minimizearea , fewest modules; note it may prefer a taller, narrower symbol, use minimizeheight or withheight for the flattest fit).  public rmqrcodeimagebuilder withheight(rmqrheight height); restrict automatic version selection to one symbol height (fixed height, automatic width). must agree with withversion when both are used.  public rmqrcodeimagebuilder withsegmentation(rmqrsegmentation segmentation); split the content into mixed-mode segments when that lowers the module count (see rmqrsegmentation ). defaults to single . fewer modules is not the same as a smaller image: a flatter, wider symbol can render onto a larger grid.  public rmqrcodeimagebuilder withversion(rmqrversion version); configure the exact rmqr version to generate.  public rmqrcodeimagebuilder withwidth(int width); configure the image width in pixels; the height follows the symbol aspect ratio (rounded to whole pixels), the background covers the whole image and the symbol is drawn at a uniform module scale inside it. this is the static helpers' sizing rule and the default (512) when no size is configured. qrcodeimagebuilderbase (letterbox into an exact canvas) or qrcodeimagebuilderbase (exact matrix) take precedence when also called.  public static byte[] getimagebytes(rmqrcodedata rmqrcodedata, skencodedimageformat format, int size = 512, int quality = 100); generate an rmqr code as image byte array with specified format.  public static byte[] getimagebytes(string content, skencodedimageformat format, rmqrecclevel ecclevel = 0, int size = 512, int quality = 100); generate an rmqr code as image byte array with specified format.  public static byte[] getpngbytes(rmqrcodedata rmqrcodedata, int size = 512); generate an rmqr code as png byte array with default settings.  public static byte[] getpngbytes(string content, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code as png byte array with default settings.  public static byte[] getsvgbytes(rmqrcodedata rmqrcodedata, int size = 512); generate an rmqr code as svg byte array.  public static byte[] getsvgbytes(string content, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code as svg byte array.  public static string getsvgstring(rmqrcodedata rmqrcodedata, int size = 512); generate an rmqr code as svg string.  public static string getsvgstring(string content, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code as svg string.  public static void savepng(rmqrcodedata rmqrcodedata, stream output, int size = 512); generate an rmqr code and save as png to stream.  public static void savepng(string content, stream output, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code and save as png to stream.  public static void savesvg(rmqrcodedata rmqrcodedata, stream output, int size = 512); generate an rmqr code and save as svg to stream.  public static void savesvg(string content, stream output, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code and save as svg to stream.  public static void writeimage(rmqrcodedata rmqrcodedata, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, int size = 512, int quality = 100); generate an rmqr code and write encoded image bytes to a buffer writer.  public static void writeimage(string content, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, rmqrecclevel ecclevel = 0, int size = 512, int quality = 100); generate an rmqr code and write encoded image bytes to a buffer writer.  public static void writepng(rmqrcodedata rmqrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate an rmqr code and write png bytes to a buffer writer.  public static void writepng(string content, ibufferwriter&lt;byte&gt; writer, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code and write png bytes to a buffer writer.  public static void writesvg(rmqrcodedata rmqrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate an rmqr code and write the svg document to a buffer writer.  public static void writesvg(string content, ibufferwriter&lt;byte&gt; writer, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code and write the svg document to a buffer writer. ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.RmQRCodeImageBuilder" aria-label="Link to SkiaSharp.QrCode.Image.RmQRCodeImageBuilder">#</a><code>public class RmQRCodeImageBuilder : QRCodeImageBuilderBase&lt;RmQRCodeImageBuilder&gt;</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.Image.RmQRCodeImageBuilder" data-name="skiasharp.qrcode.image.rmqrcodeimagebuilder" data-text="skiasharp.qrcode.image.rmqrcodeimagebuilder public class rmqrcodeimagebuilder : qrcodeimagebuilderbase&lt;rmqrcodeimagebuilder&gt; high-level builder for creating rmqr code images with fluent configuration and static methods. this builder mirrors qrcodeimagebuilder / microqrcodeimagebuilder for the rmqr symbology (iso/iec 23941, r7x43-r17x139). version, error correction and fit use the rmqr-typed rmqrversion / rmqrecclevel / rmqrfitstrategy / rmqrheight , and the default quiet zone is the 2 modules the specification requires. rmqr symbols are rectangular. with qrcodeimagebuilderbase the image is exactly the matrix at that scale; with qrcodeimagebuilderbase the symbol is fitted into the canvas with a uniform module scale and centered (letterbox, never stretched); with withwidth (the static helpers' size, and the 512-pixel default when nothing is configured) the image is that wide, the height follows the symbol aspect ratio rounded to whole pixels, the background covers the whole image and the symbol is drawn at a uniform module scale inside it (the height rounding can leave a few pixels of background at the sides on the widest versions; there is no clear-colour pad, so an opaque background gives an opaque image). rmqr has a single finder pattern and no error-correction headroom for overlays, so the standard qr styling options that depend on those (icon overlays and custom finder pattern shapes) are intentionally not offered. constructor public rmqrcodeimagebuilder(rmqrcodedata rmqrcodedata); starts a builder that draws an rmqr code you have already generated. the symbol is used exactly as given, so only the appearance options apply. every encoding option throws invalidoperationexception on a builder created this way.  constructor public rmqrcodeimagebuilder(string content); starts a builder that will encode content when you ask for an image. error correction, version and fit keep their defaults until you set them.  method public rmqrcodeimagebuilder withecimode(ecimode ecimode); configure the eci character encoding declaration.  method public rmqrcodeimagebuilder witherrorcorrection(rmqrecclevel ecclevel); configure the error correction level (m or h).  method public rmqrcodeimagebuilder withfitstrategy(rmqrfitstrategy fitstrategy); configure how the version is chosen among those that hold the content (default minimizearea , fewest modules; note it may prefer a taller, narrower symbol, use minimizeheight or withheight for the flattest fit).  method public rmqrcodeimagebuilder withheight(rmqrheight height); restrict automatic version selection to one symbol height (fixed height, automatic width). must agree with withversion when both are used.  method public rmqrcodeimagebuilder withsegmentation(rmqrsegmentation segmentation); split the content into mixed-mode segments when that lowers the module count (see rmqrsegmentation ). defaults to single . fewer modules is not the same as a smaller image: a flatter, wider symbol can render onto a larger grid.  method public rmqrcodeimagebuilder withversion(rmqrversion version); configure the exact rmqr version to generate.  method public rmqrcodeimagebuilder withwidth(int width); configure the image width in pixels; the height follows the symbol aspect ratio (rounded to whole pixels), the background covers the whole image and the symbol is drawn at a uniform module scale inside it. this is the static helpers' sizing rule and the default (512) when no size is configured. qrcodeimagebuilderbase (letterbox into an exact canvas) or qrcodeimagebuilderbase (exact matrix) take precedence when also called.  method public static byte[] getimagebytes(rmqrcodedata rmqrcodedata, skencodedimageformat format, int size = 512, int quality = 100); generate an rmqr code as image byte array with specified format.  method public static byte[] getimagebytes(string content, skencodedimageformat format, rmqrecclevel ecclevel = 0, int size = 512, int quality = 100); generate an rmqr code as image byte array with specified format.  method public static byte[] getpngbytes(rmqrcodedata rmqrcodedata, int size = 512); generate an rmqr code as png byte array with default settings.  method public static byte[] getpngbytes(string content, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code as png byte array with default settings.  method public static byte[] getsvgbytes(rmqrcodedata rmqrcodedata, int size = 512); generate an rmqr code as svg byte array.  method public static byte[] getsvgbytes(string content, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code as svg byte array.  method public static string getsvgstring(rmqrcodedata rmqrcodedata, int size = 512); generate an rmqr code as svg string.  method public static string getsvgstring(string content, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code as svg string.  method public static void savepng(rmqrcodedata rmqrcodedata, stream output, int size = 512); generate an rmqr code and save as png to stream.  method public static void savepng(string content, stream output, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code and save as png to stream.  method public static void savesvg(rmqrcodedata rmqrcodedata, stream output, int size = 512); generate an rmqr code and save as svg to stream.  method public static void savesvg(string content, stream output, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code and save as svg to stream.  method public static void writeimage(rmqrcodedata rmqrcodedata, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, int size = 512, int quality = 100); generate an rmqr code and write encoded image bytes to a buffer writer.  method public static void writeimage(string content, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, rmqrecclevel ecclevel = 0, int size = 512, int quality = 100); generate an rmqr code and write encoded image bytes to a buffer writer.  method public static void writepng(rmqrcodedata rmqrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate an rmqr code and write png bytes to a buffer writer.  method public static void writepng(string content, ibufferwriter&lt;byte&gt; writer, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code and write png bytes to a buffer writer.  method public static void writesvg(rmqrcodedata rmqrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate an rmqr code and write the svg document to a buffer writer.  method public static void writesvg(string content, ibufferwriter&lt;byte&gt; writer, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code and write the svg document to a buffer writer. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.RmQRCodeImageBuilder" aria-label="Link to SkiaSharp.QrCode.Image.RmQRCodeImageBuilder">#</a><span class="kind">class</span> <span class="name">RmQRCodeImageBuilder</span></h3>
+          <pre class="sig"><code>public class RmQRCodeImageBuilder : QRCodeImageBuilderBase&lt;RmQRCodeImageBuilder&gt;</code></pre>
           <p class="doc">High-level builder for creating rMQR code images with fluent configuration and static methods.</p>
           <details class="notes" data-text="this builder mirrors qrcodeimagebuilder / microqrcodeimagebuilder for the rmqr symbology (iso/iec 23941, r7x43-r17x139). version, error correction and fit use the rmqr-typed rmqrversion / rmqrecclevel / rmqrfitstrategy / rmqrheight , and the default quiet zone is the 2 modules the specification requires. rmqr symbols are rectangular. with qrcodeimagebuilderbase the image is exactly the matrix at that scale; with qrcodeimagebuilderbase the symbol is fitted into the canvas with a uniform module scale and centered (letterbox, never stretched); with withwidth (the static helpers' size, and the 512-pixel default when nothing is configured) the image is that wide, the height follows the symbol aspect ratio rounded to whole pixels, the background covers the whole image and the symbol is drawn at a uniform module scale inside it (the height rounding can leave a few pixels of background at the sides on the widest versions; there is no clear-colour pad, so an opaque background gives an opaque image). rmqr has a single finder pattern and no error-correction headroom for overlays, so the standard qr styling options that depend on those (icon overlays and custom finder pattern shapes) are intentionally not offered.">
             <summary>Notes</summary>
             <p class="doc remarks">This builder mirrors QRCodeImageBuilder / MicroQRCodeImageBuilder for the rMQR symbology (ISO/IEC 23941, R7x43-R17x139). Version, error correction and fit use the rMQR-typed RmQRVersion / RmQREccLevel / RmQRFitStrategy / RmQRHeight , and the default quiet zone is the 2 modules the specification requires. rMQR symbols are rectangular. With QRCodeImageBuilderBase the image is exactly the matrix at that scale; with QRCodeImageBuilderBase the symbol is fitted into the canvas with a uniform module scale and centered (letterbox, never stretched); with WithWidth (the static helpers' size, and the 512-pixel default when nothing is configured) the image is that wide, the height follows the symbol aspect ratio rounded to whole pixels, the background covers the whole image and the symbol is drawn at a uniform module scale inside it (the height rounding can leave a few pixels of background at the sides on the widest versions; there is no clear-colour pad, so an opaque background gives an opaque image). rMQR has a single finder pattern and no error-correction headroom for overlays, so the Standard QR styling options that depend on those (icon overlays and custom finder pattern shapes) are intentionally not offered.</p>
           </details>
           <div class="members">
-            <div class="member" data-text="public rmqrcodeimagebuilder(rmqrcodedata rmqrcodedata); starts a builder that draws an rmqr code you have already generated. the symbol is used exactly as given, so only the appearance options apply. every encoding option throws invalidoperationexception on a builder created this way. ">
-              <code>public RmQRCodeImageBuilder(RmQRCodeData rmQrCodeData);</code>
+            <div class="member" data-text="constructor public rmqrcodeimagebuilder(rmqrcodedata rmqrcodedata); starts a builder that draws an rmqr code you have already generated. the symbol is used exactly as given, so only the appearance options apply. every encoding option throws invalidoperationexception on a builder created this way. ">
+              <h4><span class="kind">constructor</span> <span class="name">RmQRCodeImageBuilder</span></h4>
+              <pre class="sig"><code>public RmQRCodeImageBuilder(RmQRCodeData rmQrCodeData);</code></pre>
               <p class="doc">Starts a builder that draws an rMQR code you have already generated. The symbol is used exactly as given, so only the appearance options apply. Every encoding option throws InvalidOperationException on a builder created this way.</p>
             </div>
-            <div class="member" data-text="public rmqrcodeimagebuilder(string content); starts a builder that will encode content when you ask for an image. error correction, version and fit keep their defaults until you set them. ">
-              <code>public RmQRCodeImageBuilder(string content);</code>
+            <div class="member" data-text="constructor public rmqrcodeimagebuilder(string content); starts a builder that will encode content when you ask for an image. error correction, version and fit keep their defaults until you set them. ">
+              <h4><span class="kind">constructor</span> <span class="name">RmQRCodeImageBuilder</span></h4>
+              <pre class="sig"><code>public RmQRCodeImageBuilder(string content);</code></pre>
               <p class="doc">Starts a builder that will encode content when you ask for an image. Error correction, version and fit keep their defaults until you set them.</p>
             </div>
-            <div class="member" data-text="public rmqrcodeimagebuilder withecimode(ecimode ecimode); configure the eci character encoding declaration. ">
-              <code>public RmQRCodeImageBuilder WithEciMode(EciMode eciMode);</code>
+            <div class="member" data-text="method public rmqrcodeimagebuilder withecimode(ecimode ecimode); configure the eci character encoding declaration. ">
+              <h4><span class="kind">method</span> <span class="name">WithEciMode</span></h4>
+              <pre class="sig"><code>public RmQRCodeImageBuilder WithEciMode(EciMode eciMode);</code></pre>
               <p class="doc">Configure the ECI character encoding declaration.</p>
             </div>
-            <div class="member" data-text="public rmqrcodeimagebuilder witherrorcorrection(rmqrecclevel ecclevel); configure the error correction level (m or h). ">
-              <code>public RmQRCodeImageBuilder WithErrorCorrection(RmQREccLevel eccLevel);</code>
+            <div class="member" data-text="method public rmqrcodeimagebuilder witherrorcorrection(rmqrecclevel ecclevel); configure the error correction level (m or h). ">
+              <h4><span class="kind">method</span> <span class="name">WithErrorCorrection</span></h4>
+              <pre class="sig"><code>public RmQRCodeImageBuilder WithErrorCorrection(RmQREccLevel eccLevel);</code></pre>
               <p class="doc">Configure the error correction level (M or H).</p>
             </div>
-            <div class="member" data-text="public rmqrcodeimagebuilder withfitstrategy(rmqrfitstrategy fitstrategy); configure how the version is chosen among those that hold the content (default minimizearea , fewest modules; note it may prefer a taller, narrower symbol, use minimizeheight or withheight for the flattest fit). ">
-              <code>public RmQRCodeImageBuilder WithFitStrategy(RmQRFitStrategy fitStrategy);</code>
+            <div class="member" data-text="method public rmqrcodeimagebuilder withfitstrategy(rmqrfitstrategy fitstrategy); configure how the version is chosen among those that hold the content (default minimizearea , fewest modules; note it may prefer a taller, narrower symbol, use minimizeheight or withheight for the flattest fit). ">
+              <h4><span class="kind">method</span> <span class="name">WithFitStrategy</span></h4>
+              <pre class="sig"><code>public RmQRCodeImageBuilder WithFitStrategy(RmQRFitStrategy fitStrategy);</code></pre>
               <p class="doc">Configure how the version is chosen among those that hold the content (default MinimizeArea , fewest modules; note it may prefer a taller, narrower symbol, use MinimizeHeight or WithHeight for the flattest fit).</p>
             </div>
-            <div class="member" data-text="public rmqrcodeimagebuilder withheight(rmqrheight height); restrict automatic version selection to one symbol height (fixed height, automatic width). must agree with withversion when both are used. ">
-              <code>public RmQRCodeImageBuilder WithHeight(RmQRHeight height);</code>
+            <div class="member" data-text="method public rmqrcodeimagebuilder withheight(rmqrheight height); restrict automatic version selection to one symbol height (fixed height, automatic width). must agree with withversion when both are used. ">
+              <h4><span class="kind">method</span> <span class="name">WithHeight</span></h4>
+              <pre class="sig"><code>public RmQRCodeImageBuilder WithHeight(RmQRHeight height);</code></pre>
               <p class="doc">Restrict automatic version selection to one symbol height (fixed height, automatic width). Must agree with WithVersion when both are used.</p>
             </div>
-            <div class="member" data-text="public rmqrcodeimagebuilder withsegmentation(rmqrsegmentation segmentation); split the content into mixed-mode segments when that lowers the module count (see rmqrsegmentation ). defaults to single . fewer modules is not the same as a smaller image: a flatter, wider symbol can render onto a larger grid. ">
-              <code>public RmQRCodeImageBuilder WithSegmentation(RmQRSegmentation segmentation);</code>
+            <div class="member" data-text="method public rmqrcodeimagebuilder withsegmentation(rmqrsegmentation segmentation); split the content into mixed-mode segments when that lowers the module count (see rmqrsegmentation ). defaults to single . fewer modules is not the same as a smaller image: a flatter, wider symbol can render onto a larger grid. ">
+              <h4><span class="kind">method</span> <span class="name">WithSegmentation</span></h4>
+              <pre class="sig"><code>public RmQRCodeImageBuilder WithSegmentation(RmQRSegmentation segmentation);</code></pre>
               <p class="doc">Split the content into mixed-mode segments when that lowers the module count (see RmQRSegmentation ). Defaults to Single . Fewer modules is not the same as a smaller image: a flatter, wider symbol can render onto a larger grid.</p>
             </div>
-            <div class="member" data-text="public rmqrcodeimagebuilder withversion(rmqrversion version); configure the exact rmqr version to generate. ">
-              <code>public RmQRCodeImageBuilder WithVersion(RmQRVersion version);</code>
+            <div class="member" data-text="method public rmqrcodeimagebuilder withversion(rmqrversion version); configure the exact rmqr version to generate. ">
+              <h4><span class="kind">method</span> <span class="name">WithVersion</span></h4>
+              <pre class="sig"><code>public RmQRCodeImageBuilder WithVersion(RmQRVersion version);</code></pre>
               <p class="doc">Configure the exact rMQR version to generate.</p>
             </div>
-            <div class="member" data-text="public rmqrcodeimagebuilder withwidth(int width); configure the image width in pixels; the height follows the symbol aspect ratio (rounded to whole pixels), the background covers the whole image and the symbol is drawn at a uniform module scale inside it. this is the static helpers' sizing rule and the default (512) when no size is configured. qrcodeimagebuilderbase (letterbox into an exact canvas) or qrcodeimagebuilderbase (exact matrix) take precedence when also called. ">
-              <code>public RmQRCodeImageBuilder WithWidth(int width);</code>
+            <div class="member" data-text="method public rmqrcodeimagebuilder withwidth(int width); configure the image width in pixels; the height follows the symbol aspect ratio (rounded to whole pixels), the background covers the whole image and the symbol is drawn at a uniform module scale inside it. this is the static helpers' sizing rule and the default (512) when no size is configured. qrcodeimagebuilderbase (letterbox into an exact canvas) or qrcodeimagebuilderbase (exact matrix) take precedence when also called. ">
+              <h4><span class="kind">method</span> <span class="name">WithWidth</span></h4>
+              <pre class="sig"><code>public RmQRCodeImageBuilder WithWidth(int width);</code></pre>
               <p class="doc">Configure the image width in pixels; the height follows the symbol aspect ratio (rounded to whole pixels), the background covers the whole image and the symbol is drawn at a uniform module scale inside it. This is the static helpers' sizing rule and the default (512) when no size is configured. QRCodeImageBuilderBase (letterbox into an exact canvas) or QRCodeImageBuilderBase (exact matrix) take precedence when also called.</p>
             </div>
-            <div class="member" data-text="public static byte[] getimagebytes(rmqrcodedata rmqrcodedata, skencodedimageformat format, int size = 512, int quality = 100); generate an rmqr code as image byte array with specified format. ">
-              <code>public static byte[] GetImageBytes(RmQRCodeData rmQrCodeData, SKEncodedImageFormat format, int size = 512, int quality = 100);</code>
+            <div class="member" data-text="method public static byte[] getimagebytes(rmqrcodedata rmqrcodedata, skencodedimageformat format, int size = 512, int quality = 100); generate an rmqr code as image byte array with specified format. ">
+              <h4><span class="kind">method</span> <span class="name">GetImageBytes</span></h4>
+              <pre class="sig"><code>public static byte[] GetImageBytes(RmQRCodeData rmQrCodeData, SKEncodedImageFormat format, int size = 512, int quality = 100);</code></pre>
               <p class="doc">Generate an rMQR code as image byte array with specified format.</p>
             </div>
-            <div class="member" data-text="public static byte[] getimagebytes(string content, skencodedimageformat format, rmqrecclevel ecclevel = 0, int size = 512, int quality = 100); generate an rmqr code as image byte array with specified format. ">
-              <code>public static byte[] GetImageBytes(string content, SKEncodedImageFormat format, RmQREccLevel eccLevel = 0, int size = 512, int quality = 100);</code>
+            <div class="member" data-text="method public static byte[] getimagebytes(string content, skencodedimageformat format, rmqrecclevel ecclevel = 0, int size = 512, int quality = 100); generate an rmqr code as image byte array with specified format. ">
+              <h4><span class="kind">method</span> <span class="name">GetImageBytes</span></h4>
+              <pre class="sig"><code>public static byte[] GetImageBytes(string content, SKEncodedImageFormat format, RmQREccLevel eccLevel = 0, int size = 512, int quality = 100);</code></pre>
               <p class="doc">Generate an rMQR code as image byte array with specified format.</p>
             </div>
-            <div class="member" data-text="public static byte[] getpngbytes(rmqrcodedata rmqrcodedata, int size = 512); generate an rmqr code as png byte array with default settings. ">
-              <code>public static byte[] GetPngBytes(RmQRCodeData rmQrCodeData, int size = 512);</code>
+            <div class="member" data-text="method public static byte[] getpngbytes(rmqrcodedata rmqrcodedata, int size = 512); generate an rmqr code as png byte array with default settings. ">
+              <h4><span class="kind">method</span> <span class="name">GetPngBytes</span></h4>
+              <pre class="sig"><code>public static byte[] GetPngBytes(RmQRCodeData rmQrCodeData, int size = 512);</code></pre>
               <p class="doc">Generate an rMQR code as PNG byte array with default settings.</p>
             </div>
-            <div class="member" data-text="public static byte[] getpngbytes(string content, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code as png byte array with default settings. ">
-              <code>public static byte[] GetPngBytes(string content, RmQREccLevel eccLevel = 0, int size = 512);</code>
+            <div class="member" data-text="method public static byte[] getpngbytes(string content, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code as png byte array with default settings. ">
+              <h4><span class="kind">method</span> <span class="name">GetPngBytes</span></h4>
+              <pre class="sig"><code>public static byte[] GetPngBytes(string content, RmQREccLevel eccLevel = 0, int size = 512);</code></pre>
               <p class="doc">Generate an rMQR code as PNG byte array with default settings.</p>
             </div>
-            <div class="member" data-text="public static byte[] getsvgbytes(rmqrcodedata rmqrcodedata, int size = 512); generate an rmqr code as svg byte array. ">
-              <code>public static byte[] GetSvgBytes(RmQRCodeData rmQrCodeData, int size = 512);</code>
+            <div class="member" data-text="method public static byte[] getsvgbytes(rmqrcodedata rmqrcodedata, int size = 512); generate an rmqr code as svg byte array. ">
+              <h4><span class="kind">method</span> <span class="name">GetSvgBytes</span></h4>
+              <pre class="sig"><code>public static byte[] GetSvgBytes(RmQRCodeData rmQrCodeData, int size = 512);</code></pre>
               <p class="doc">Generate an rMQR code as SVG byte array.</p>
             </div>
-            <div class="member" data-text="public static byte[] getsvgbytes(string content, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code as svg byte array. ">
-              <code>public static byte[] GetSvgBytes(string content, RmQREccLevel eccLevel = 0, int size = 512);</code>
+            <div class="member" data-text="method public static byte[] getsvgbytes(string content, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code as svg byte array. ">
+              <h4><span class="kind">method</span> <span class="name">GetSvgBytes</span></h4>
+              <pre class="sig"><code>public static byte[] GetSvgBytes(string content, RmQREccLevel eccLevel = 0, int size = 512);</code></pre>
               <p class="doc">Generate an rMQR code as SVG byte array.</p>
             </div>
-            <div class="member" data-text="public static string getsvgstring(rmqrcodedata rmqrcodedata, int size = 512); generate an rmqr code as svg string. ">
-              <code>public static string GetSvgString(RmQRCodeData rmQrCodeData, int size = 512);</code>
+            <div class="member" data-text="method public static string getsvgstring(rmqrcodedata rmqrcodedata, int size = 512); generate an rmqr code as svg string. ">
+              <h4><span class="kind">method</span> <span class="name">GetSvgString</span></h4>
+              <pre class="sig"><code>public static string GetSvgString(RmQRCodeData rmQrCodeData, int size = 512);</code></pre>
               <p class="doc">Generate an rMQR code as SVG string.</p>
             </div>
-            <div class="member" data-text="public static string getsvgstring(string content, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code as svg string. ">
-              <code>public static string GetSvgString(string content, RmQREccLevel eccLevel = 0, int size = 512);</code>
+            <div class="member" data-text="method public static string getsvgstring(string content, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code as svg string. ">
+              <h4><span class="kind">method</span> <span class="name">GetSvgString</span></h4>
+              <pre class="sig"><code>public static string GetSvgString(string content, RmQREccLevel eccLevel = 0, int size = 512);</code></pre>
               <p class="doc">Generate an rMQR code as SVG string.</p>
             </div>
-            <div class="member" data-text="public static void savepng(rmqrcodedata rmqrcodedata, stream output, int size = 512); generate an rmqr code and save as png to stream. ">
-              <code>public static void SavePng(RmQRCodeData rmQrCodeData, Stream output, int size = 512);</code>
+            <div class="member" data-text="method public static void savepng(rmqrcodedata rmqrcodedata, stream output, int size = 512); generate an rmqr code and save as png to stream. ">
+              <h4><span class="kind">method</span> <span class="name">SavePng</span></h4>
+              <pre class="sig"><code>public static void SavePng(RmQRCodeData rmQrCodeData, Stream output, int size = 512);</code></pre>
               <p class="doc">Generate an rMQR code and save as PNG to stream.</p>
             </div>
-            <div class="member" data-text="public static void savepng(string content, stream output, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code and save as png to stream. ">
-              <code>public static void SavePng(string content, Stream output, RmQREccLevel eccLevel = 0, int size = 512);</code>
+            <div class="member" data-text="method public static void savepng(string content, stream output, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code and save as png to stream. ">
+              <h4><span class="kind">method</span> <span class="name">SavePng</span></h4>
+              <pre class="sig"><code>public static void SavePng(string content, Stream output, RmQREccLevel eccLevel = 0, int size = 512);</code></pre>
               <p class="doc">Generate an rMQR code and save as PNG to stream.</p>
             </div>
-            <div class="member" data-text="public static void savesvg(rmqrcodedata rmqrcodedata, stream output, int size = 512); generate an rmqr code and save as svg to stream. ">
-              <code>public static void SaveSvg(RmQRCodeData rmQrCodeData, Stream output, int size = 512);</code>
+            <div class="member" data-text="method public static void savesvg(rmqrcodedata rmqrcodedata, stream output, int size = 512); generate an rmqr code and save as svg to stream. ">
+              <h4><span class="kind">method</span> <span class="name">SaveSvg</span></h4>
+              <pre class="sig"><code>public static void SaveSvg(RmQRCodeData rmQrCodeData, Stream output, int size = 512);</code></pre>
               <p class="doc">Generate an rMQR code and save as SVG to stream.</p>
             </div>
-            <div class="member" data-text="public static void savesvg(string content, stream output, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code and save as svg to stream. ">
-              <code>public static void SaveSvg(string content, Stream output, RmQREccLevel eccLevel = 0, int size = 512);</code>
+            <div class="member" data-text="method public static void savesvg(string content, stream output, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code and save as svg to stream. ">
+              <h4><span class="kind">method</span> <span class="name">SaveSvg</span></h4>
+              <pre class="sig"><code>public static void SaveSvg(string content, Stream output, RmQREccLevel eccLevel = 0, int size = 512);</code></pre>
               <p class="doc">Generate an rMQR code and save as SVG to stream.</p>
             </div>
-            <div class="member" data-text="public static void writeimage(rmqrcodedata rmqrcodedata, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, int size = 512, int quality = 100); generate an rmqr code and write encoded image bytes to a buffer writer. ">
-              <code>public static void WriteImage(RmQRCodeData rmQrCodeData, IBufferWriter&lt;byte&gt; writer, SKEncodedImageFormat format, int size = 512, int quality = 100);</code>
+            <div class="member" data-text="method public static void writeimage(rmqrcodedata rmqrcodedata, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, int size = 512, int quality = 100); generate an rmqr code and write encoded image bytes to a buffer writer. ">
+              <h4><span class="kind">method</span> <span class="name">WriteImage</span></h4>
+              <pre class="sig"><code>public static void WriteImage(RmQRCodeData rmQrCodeData, IBufferWriter&lt;byte&gt; writer, SKEncodedImageFormat format, int size = 512, int quality = 100);</code></pre>
               <p class="doc">Generate an rMQR code and write encoded image bytes to a buffer writer.</p>
             </div>
-            <div class="member" data-text="public static void writeimage(string content, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, rmqrecclevel ecclevel = 0, int size = 512, int quality = 100); generate an rmqr code and write encoded image bytes to a buffer writer. ">
-              <code>public static void WriteImage(string content, IBufferWriter&lt;byte&gt; writer, SKEncodedImageFormat format, RmQREccLevel eccLevel = 0, int size = 512, int quality = 100);</code>
+            <div class="member" data-text="method public static void writeimage(string content, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, rmqrecclevel ecclevel = 0, int size = 512, int quality = 100); generate an rmqr code and write encoded image bytes to a buffer writer. ">
+              <h4><span class="kind">method</span> <span class="name">WriteImage</span></h4>
+              <pre class="sig"><code>public static void WriteImage(string content, IBufferWriter&lt;byte&gt; writer, SKEncodedImageFormat format, RmQREccLevel eccLevel = 0, int size = 512, int quality = 100);</code></pre>
               <p class="doc">Generate an rMQR code and write encoded image bytes to a buffer writer.</p>
             </div>
-            <div class="member" data-text="public static void writepng(rmqrcodedata rmqrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate an rmqr code and write png bytes to a buffer writer. ">
-              <code>public static void WritePng(RmQRCodeData rmQrCodeData, IBufferWriter&lt;byte&gt; writer, int size = 512);</code>
+            <div class="member" data-text="method public static void writepng(rmqrcodedata rmqrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate an rmqr code and write png bytes to a buffer writer. ">
+              <h4><span class="kind">method</span> <span class="name">WritePng</span></h4>
+              <pre class="sig"><code>public static void WritePng(RmQRCodeData rmQrCodeData, IBufferWriter&lt;byte&gt; writer, int size = 512);</code></pre>
               <p class="doc">Generate an rMQR code and write PNG bytes to a buffer writer.</p>
             </div>
-            <div class="member" data-text="public static void writepng(string content, ibufferwriter&lt;byte&gt; writer, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code and write png bytes to a buffer writer. ">
-              <code>public static void WritePng(string content, IBufferWriter&lt;byte&gt; writer, RmQREccLevel eccLevel = 0, int size = 512);</code>
+            <div class="member" data-text="method public static void writepng(string content, ibufferwriter&lt;byte&gt; writer, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code and write png bytes to a buffer writer. ">
+              <h4><span class="kind">method</span> <span class="name">WritePng</span></h4>
+              <pre class="sig"><code>public static void WritePng(string content, IBufferWriter&lt;byte&gt; writer, RmQREccLevel eccLevel = 0, int size = 512);</code></pre>
               <p class="doc">Generate an rMQR code and write PNG bytes to a buffer writer.</p>
             </div>
-            <div class="member" data-text="public static void writesvg(rmqrcodedata rmqrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate an rmqr code and write the svg document to a buffer writer. ">
-              <code>public static void WriteSvg(RmQRCodeData rmQrCodeData, IBufferWriter&lt;byte&gt; writer, int size = 512);</code>
+            <div class="member" data-text="method public static void writesvg(rmqrcodedata rmqrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate an rmqr code and write the svg document to a buffer writer. ">
+              <h4><span class="kind">method</span> <span class="name">WriteSvg</span></h4>
+              <pre class="sig"><code>public static void WriteSvg(RmQRCodeData rmQrCodeData, IBufferWriter&lt;byte&gt; writer, int size = 512);</code></pre>
               <p class="doc">Generate an rMQR code and write the SVG document to a buffer writer.</p>
             </div>
-            <div class="member" data-text="public static void writesvg(string content, ibufferwriter&lt;byte&gt; writer, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code and write the svg document to a buffer writer. ">
-              <code>public static void WriteSvg(string content, IBufferWriter&lt;byte&gt; writer, RmQREccLevel eccLevel = 0, int size = 512);</code>
+            <div class="member" data-text="method public static void writesvg(string content, ibufferwriter&lt;byte&gt; writer, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code and write the svg document to a buffer writer. ">
+              <h4><span class="kind">method</span> <span class="name">WriteSvg</span></h4>
+              <pre class="sig"><code>public static void WriteSvg(string content, IBufferWriter&lt;byte&gt; writer, RmQREccLevel eccLevel = 0, int size = 512);</code></pre>
               <p class="doc">Generate an rMQR code and write the SVG document to a buffer writer.</p>
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.Image.RoundedRectangleCircleFinderPatternShape" data-name="skiasharp.qrcode.image.roundedrectanglecirclefinderpatternshape" data-text="skiasharp.qrcode.image.roundedrectanglecirclefinderpatternshape public sealed class roundedrectanglecirclefinderpatternshape : finderpatternshape rounded rectangle outer with circular center finder pattern. three nested shapes: outer rounded rectangle (7×7), middle rounded rectangle (5×5), inner circle (3×3).  public static readonly roundedrectanglecirclefinderpatternshape default; gets the default instance.  public roundedrectanglecirclefinderpatternshape(float cornerradiuspercent = 0.3); initializes a new instance with the specified corner radius.  public bool requiresantialiasing { get; } requires antialiasing to prevent jagged edges on curves.  public override void draw(skcanvas canvas, skrect rect, skpaint paint);  public override void draw(skcanvas canvas, skrect rect, skpaint paint, skcolor backgroundcolor);  public override void draw(skcanvas canvas, skrect rect, skpaint paint, skpaint backgroundpaint); ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.RoundedRectangleCircleFinderPatternShape" aria-label="Link to SkiaSharp.QrCode.Image.RoundedRectangleCircleFinderPatternShape">#</a><code>public sealed class RoundedRectangleCircleFinderPatternShape : FinderPatternShape</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.Image.RoundedRectangleCircleFinderPatternShape" data-name="skiasharp.qrcode.image.roundedrectanglecirclefinderpatternshape" data-text="skiasharp.qrcode.image.roundedrectanglecirclefinderpatternshape public sealed class roundedrectanglecirclefinderpatternshape : finderpatternshape rounded rectangle outer with circular center finder pattern. three nested shapes: outer rounded rectangle (7×7), middle rounded rectangle (5×5), inner circle (3×3).  field public static readonly roundedrectanglecirclefinderpatternshape default; gets the default instance.  constructor public roundedrectanglecirclefinderpatternshape(float cornerradiuspercent = 0.3); initializes a new instance with the specified corner radius.  property public bool requiresantialiasing { get; } requires antialiasing to prevent jagged edges on curves.  method public override void draw(skcanvas canvas, skrect rect, skpaint paint);  method public override void draw(skcanvas canvas, skrect rect, skpaint paint, skcolor backgroundcolor);  method public override void draw(skcanvas canvas, skrect rect, skpaint paint, skpaint backgroundpaint); ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.RoundedRectangleCircleFinderPatternShape" aria-label="Link to SkiaSharp.QrCode.Image.RoundedRectangleCircleFinderPatternShape">#</a><span class="kind">class</span> <span class="name">RoundedRectangleCircleFinderPatternShape</span></h3>
+          <pre class="sig"><code>public sealed class RoundedRectangleCircleFinderPatternShape : FinderPatternShape</code></pre>
           <p class="doc">Rounded rectangle outer with circular center finder pattern. Three nested shapes: outer rounded rectangle (7×7), middle rounded rectangle (5×5), inner circle (3×3).</p>
           <div class="members">
-            <div class="member" data-text="public static readonly roundedrectanglecirclefinderpatternshape default; gets the default instance. ">
-              <code>public static readonly RoundedRectangleCircleFinderPatternShape Default;</code>
+            <div class="member" data-text="field public static readonly roundedrectanglecirclefinderpatternshape default; gets the default instance. ">
+              <h4><span class="kind">field</span> <span class="name">Default</span></h4>
+              <pre class="sig"><code>public static readonly RoundedRectangleCircleFinderPatternShape Default;</code></pre>
               <p class="doc">Gets the default instance.</p>
             </div>
-            <div class="member" data-text="public roundedrectanglecirclefinderpatternshape(float cornerradiuspercent = 0.3); initializes a new instance with the specified corner radius. ">
-              <code>public RoundedRectangleCircleFinderPatternShape(float cornerRadiusPercent = 0.3);</code>
+            <div class="member" data-text="constructor public roundedrectanglecirclefinderpatternshape(float cornerradiuspercent = 0.3); initializes a new instance with the specified corner radius. ">
+              <h4><span class="kind">constructor</span> <span class="name">RoundedRectangleCircleFinderPatternShape</span></h4>
+              <pre class="sig"><code>public RoundedRectangleCircleFinderPatternShape(float cornerRadiusPercent = 0.3);</code></pre>
               <p class="doc">Initializes a new instance with the specified corner radius.</p>
             </div>
-            <div class="member" data-text="public bool requiresantialiasing { get; } requires antialiasing to prevent jagged edges on curves. ">
-              <code>public bool RequiresAntialiasing { get; }</code>
+            <div class="member" data-text="property public bool requiresantialiasing { get; } requires antialiasing to prevent jagged edges on curves. ">
+              <h4><span class="kind">property</span> <span class="name">RequiresAntialiasing</span></h4>
+              <pre class="sig"><code>public bool RequiresAntialiasing { get; }</code></pre>
               <p class="doc">Requires antialiasing to prevent jagged edges on curves.</p>
             </div>
-            <div class="member" data-text="public override void draw(skcanvas canvas, skrect rect, skpaint paint); ">
-              <code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint);</code>
+            <div class="member" data-text="method public override void draw(skcanvas canvas, skrect rect, skpaint paint); ">
+              <h4><span class="kind">method</span> <span class="name">Draw</span></h4>
+              <pre class="sig"><code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint);</code></pre>
             </div>
-            <div class="member" data-text="public override void draw(skcanvas canvas, skrect rect, skpaint paint, skcolor backgroundcolor); ">
-              <code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint, SKColor backgroundColor);</code>
+            <div class="member" data-text="method public override void draw(skcanvas canvas, skrect rect, skpaint paint, skcolor backgroundcolor); ">
+              <h4><span class="kind">method</span> <span class="name">Draw</span></h4>
+              <pre class="sig"><code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint, SKColor backgroundColor);</code></pre>
             </div>
-            <div class="member" data-text="public override void draw(skcanvas canvas, skrect rect, skpaint paint, skpaint backgroundpaint); ">
-              <code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint, SKPaint backgroundPaint);</code>
+            <div class="member" data-text="method public override void draw(skcanvas canvas, skrect rect, skpaint paint, skpaint backgroundpaint); ">
+              <h4><span class="kind">method</span> <span class="name">Draw</span></h4>
+              <pre class="sig"><code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint, SKPaint backgroundPaint);</code></pre>
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.Image.RoundedRectangleFinderPatternShape" data-name="skiasharp.qrcode.image.roundedrectanglefinderpatternshape" data-text="skiasharp.qrcode.image.roundedrectanglefinderpatternshape public sealed class roundedrectanglefinderpatternshape : finderpatternshape rounded rectangle outer with circular center finder pattern. three nested shapes: outer rounded rectangle (7×7), middle rounded rectangle (5×5), inner rounded rectangle (3×3).  public static readonly roundedrectanglefinderpatternshape default; gets the default instance.  public roundedrectanglefinderpatternshape(float cornerradiuspercent = 0.2); initializes a new instance with the specified corner radius.  public bool requiresantialiasing { get; } requires antialiasing to prevent jagged edges on curves.  public override void draw(skcanvas canvas, skrect rect, skpaint paint);  public override void draw(skcanvas canvas, skrect rect, skpaint paint, skcolor backgroundcolor);  public override void draw(skcanvas canvas, skrect rect, skpaint paint, skpaint backgroundpaint); ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.RoundedRectangleFinderPatternShape" aria-label="Link to SkiaSharp.QrCode.Image.RoundedRectangleFinderPatternShape">#</a><code>public sealed class RoundedRectangleFinderPatternShape : FinderPatternShape</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.Image.RoundedRectangleFinderPatternShape" data-name="skiasharp.qrcode.image.roundedrectanglefinderpatternshape" data-text="skiasharp.qrcode.image.roundedrectanglefinderpatternshape public sealed class roundedrectanglefinderpatternshape : finderpatternshape rounded rectangle outer with circular center finder pattern. three nested shapes: outer rounded rectangle (7×7), middle rounded rectangle (5×5), inner rounded rectangle (3×3).  field public static readonly roundedrectanglefinderpatternshape default; gets the default instance.  constructor public roundedrectanglefinderpatternshape(float cornerradiuspercent = 0.2); initializes a new instance with the specified corner radius.  property public bool requiresantialiasing { get; } requires antialiasing to prevent jagged edges on curves.  method public override void draw(skcanvas canvas, skrect rect, skpaint paint);  method public override void draw(skcanvas canvas, skrect rect, skpaint paint, skcolor backgroundcolor);  method public override void draw(skcanvas canvas, skrect rect, skpaint paint, skpaint backgroundpaint); ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.RoundedRectangleFinderPatternShape" aria-label="Link to SkiaSharp.QrCode.Image.RoundedRectangleFinderPatternShape">#</a><span class="kind">class</span> <span class="name">RoundedRectangleFinderPatternShape</span></h3>
+          <pre class="sig"><code>public sealed class RoundedRectangleFinderPatternShape : FinderPatternShape</code></pre>
           <p class="doc">Rounded rectangle outer with circular center finder pattern. Three nested shapes: outer rounded rectangle (7×7), middle rounded rectangle (5×5), inner rounded rectangle (3×3).</p>
           <div class="members">
-            <div class="member" data-text="public static readonly roundedrectanglefinderpatternshape default; gets the default instance. ">
-              <code>public static readonly RoundedRectangleFinderPatternShape Default;</code>
+            <div class="member" data-text="field public static readonly roundedrectanglefinderpatternshape default; gets the default instance. ">
+              <h4><span class="kind">field</span> <span class="name">Default</span></h4>
+              <pre class="sig"><code>public static readonly RoundedRectangleFinderPatternShape Default;</code></pre>
               <p class="doc">Gets the default instance.</p>
             </div>
-            <div class="member" data-text="public roundedrectanglefinderpatternshape(float cornerradiuspercent = 0.2); initializes a new instance with the specified corner radius. ">
-              <code>public RoundedRectangleFinderPatternShape(float cornerRadiusPercent = 0.2);</code>
+            <div class="member" data-text="constructor public roundedrectanglefinderpatternshape(float cornerradiuspercent = 0.2); initializes a new instance with the specified corner radius. ">
+              <h4><span class="kind">constructor</span> <span class="name">RoundedRectangleFinderPatternShape</span></h4>
+              <pre class="sig"><code>public RoundedRectangleFinderPatternShape(float cornerRadiusPercent = 0.2);</code></pre>
               <p class="doc">Initializes a new instance with the specified corner radius.</p>
             </div>
-            <div class="member" data-text="public bool requiresantialiasing { get; } requires antialiasing to prevent jagged edges on curves. ">
-              <code>public bool RequiresAntialiasing { get; }</code>
+            <div class="member" data-text="property public bool requiresantialiasing { get; } requires antialiasing to prevent jagged edges on curves. ">
+              <h4><span class="kind">property</span> <span class="name">RequiresAntialiasing</span></h4>
+              <pre class="sig"><code>public bool RequiresAntialiasing { get; }</code></pre>
               <p class="doc">Requires antialiasing to prevent jagged edges on curves.</p>
             </div>
-            <div class="member" data-text="public override void draw(skcanvas canvas, skrect rect, skpaint paint); ">
-              <code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint);</code>
+            <div class="member" data-text="method public override void draw(skcanvas canvas, skrect rect, skpaint paint); ">
+              <h4><span class="kind">method</span> <span class="name">Draw</span></h4>
+              <pre class="sig"><code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint);</code></pre>
             </div>
-            <div class="member" data-text="public override void draw(skcanvas canvas, skrect rect, skpaint paint, skcolor backgroundcolor); ">
-              <code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint, SKColor backgroundColor);</code>
+            <div class="member" data-text="method public override void draw(skcanvas canvas, skrect rect, skpaint paint, skcolor backgroundcolor); ">
+              <h4><span class="kind">method</span> <span class="name">Draw</span></h4>
+              <pre class="sig"><code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint, SKColor backgroundColor);</code></pre>
             </div>
-            <div class="member" data-text="public override void draw(skcanvas canvas, skrect rect, skpaint paint, skpaint backgroundpaint); ">
-              <code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint, SKPaint backgroundPaint);</code>
+            <div class="member" data-text="method public override void draw(skcanvas canvas, skrect rect, skpaint paint, skpaint backgroundpaint); ">
+              <h4><span class="kind">method</span> <span class="name">Draw</span></h4>
+              <pre class="sig"><code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint, SKPaint backgroundPaint);</code></pre>
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.Image.RoundedRectangleModuleShape" data-name="skiasharp.qrcode.image.roundedrectanglemoduleshape" data-text="skiasharp.qrcode.image.roundedrectanglemoduleshape public sealed class roundedrectanglemoduleshape : moduleshape draws modules as rounded rectangles.  public static readonly roundedrectanglemoduleshape default; gets the default instance.  public roundedrectanglemoduleshape(float cornerradiuspercent = 0.3); initializes a new instance with the specified corner radius.  public bool requiresantialiasing { get; } requires antialiasing to prevent jagged edges on curves.  public override void draw(skcanvas canvas, skrect rect, skpaint paint); ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.RoundedRectangleModuleShape" aria-label="Link to SkiaSharp.QrCode.Image.RoundedRectangleModuleShape">#</a><code>public sealed class RoundedRectangleModuleShape : ModuleShape</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.Image.RoundedRectangleModuleShape" data-name="skiasharp.qrcode.image.roundedrectanglemoduleshape" data-text="skiasharp.qrcode.image.roundedrectanglemoduleshape public sealed class roundedrectanglemoduleshape : moduleshape draws modules as rounded rectangles.  field public static readonly roundedrectanglemoduleshape default; gets the default instance.  constructor public roundedrectanglemoduleshape(float cornerradiuspercent = 0.3); initializes a new instance with the specified corner radius.  property public bool requiresantialiasing { get; } requires antialiasing to prevent jagged edges on curves.  method public override void draw(skcanvas canvas, skrect rect, skpaint paint); ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.RoundedRectangleModuleShape" aria-label="Link to SkiaSharp.QrCode.Image.RoundedRectangleModuleShape">#</a><span class="kind">class</span> <span class="name">RoundedRectangleModuleShape</span></h3>
+          <pre class="sig"><code>public sealed class RoundedRectangleModuleShape : ModuleShape</code></pre>
           <p class="doc">Draws modules as rounded rectangles.</p>
           <div class="members">
-            <div class="member" data-text="public static readonly roundedrectanglemoduleshape default; gets the default instance. ">
-              <code>public static readonly RoundedRectangleModuleShape Default;</code>
+            <div class="member" data-text="field public static readonly roundedrectanglemoduleshape default; gets the default instance. ">
+              <h4><span class="kind">field</span> <span class="name">Default</span></h4>
+              <pre class="sig"><code>public static readonly RoundedRectangleModuleShape Default;</code></pre>
               <p class="doc">Gets the default instance.</p>
             </div>
-            <div class="member" data-text="public roundedrectanglemoduleshape(float cornerradiuspercent = 0.3); initializes a new instance with the specified corner radius. ">
-              <code>public RoundedRectangleModuleShape(float cornerRadiusPercent = 0.3);</code>
+            <div class="member" data-text="constructor public roundedrectanglemoduleshape(float cornerradiuspercent = 0.3); initializes a new instance with the specified corner radius. ">
+              <h4><span class="kind">constructor</span> <span class="name">RoundedRectangleModuleShape</span></h4>
+              <pre class="sig"><code>public RoundedRectangleModuleShape(float cornerRadiusPercent = 0.3);</code></pre>
               <p class="doc">Initializes a new instance with the specified corner radius.</p>
             </div>
-            <div class="member" data-text="public bool requiresantialiasing { get; } requires antialiasing to prevent jagged edges on curves. ">
-              <code>public bool RequiresAntialiasing { get; }</code>
+            <div class="member" data-text="property public bool requiresantialiasing { get; } requires antialiasing to prevent jagged edges on curves. ">
+              <h4><span class="kind">property</span> <span class="name">RequiresAntialiasing</span></h4>
+              <pre class="sig"><code>public bool RequiresAntialiasing { get; }</code></pre>
               <p class="doc">Requires antialiasing to prevent jagged edges on curves.</p>
             </div>
-            <div class="member" data-text="public override void draw(skcanvas canvas, skrect rect, skpaint paint); ">
-              <code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint);</code>
+            <div class="member" data-text="method public override void draw(skcanvas canvas, skrect rect, skpaint paint); ">
+              <h4><span class="kind">method</span> <span class="name">Draw</span></h4>
+              <pre class="sig"><code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint);</code></pre>
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.Image.TextVerticalAlignment" data-name="skiasharp.qrcode.image.textverticalalignment" data-text="skiasharp.qrcode.image.textverticalalignment public enum textverticalalignment : int specifies the vertical alignment of text relative to the icon.  bottom = 0, text is positioned below the icon (default).  center = 1, text is centered vertically with the icon.  top = 2, text is positioned above the icon. ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.TextVerticalAlignment" aria-label="Link to SkiaSharp.QrCode.Image.TextVerticalAlignment">#</a><code>public enum TextVerticalAlignment : int</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.Image.TextVerticalAlignment" data-name="skiasharp.qrcode.image.textverticalalignment" data-text="skiasharp.qrcode.image.textverticalalignment public enum textverticalalignment : int specifies the vertical alignment of text relative to the icon.  value bottom = 0, text is positioned below the icon (default).  value center = 1, text is centered vertically with the icon.  value top = 2, text is positioned above the icon. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.TextVerticalAlignment" aria-label="Link to SkiaSharp.QrCode.Image.TextVerticalAlignment">#</a><span class="kind">enum</span> <span class="name">TextVerticalAlignment</span></h3>
+          <pre class="sig"><code>public enum TextVerticalAlignment : int</code></pre>
           <p class="doc">Specifies the vertical alignment of text relative to the icon.</p>
           <div class="members">
-            <div class="member" data-text="bottom = 0, text is positioned below the icon (default). ">
-              <code>Bottom = 0,</code>
+            <div class="member" data-text="value bottom = 0, text is positioned below the icon (default). ">
+              <pre class="sig"><code>Bottom = 0,</code></pre>
               <p class="doc">Text is positioned below the icon (default).</p>
             </div>
-            <div class="member" data-text="center = 1, text is centered vertically with the icon. ">
-              <code>Center = 1,</code>
+            <div class="member" data-text="value center = 1, text is centered vertically with the icon. ">
+              <pre class="sig"><code>Center = 1,</code></pre>
               <p class="doc">Text is centered vertically with the icon.</p>
             </div>
-            <div class="member" data-text="top = 2, text is positioned above the icon. ">
-              <code>Top = 2,</code>
+            <div class="member" data-text="value top = 2, text is positioned above the icon. ">
+              <pre class="sig"><code>Top = 2,</code></pre>
               <p class="doc">Text is positioned above the icon.</p>
             </div>
           </div>
         </article>
-        <article class="type" id="SkiaSharp.QrCode.Image.Vector2Slim" data-name="skiasharp.qrcode.image.vector2slim" data-text="skiasharp.qrcode.image.vector2slim public readonly struct vector2slim : iequatable&lt;vector2slim&gt; int version of vector2, slim implementation ref: https://github.com/dotnet/corefx/blob/v3.1.32/src/system.numerics.vectors/src/system/numerics/vector2_intrinsics.cs public static readonly vector2slim one; returns the vector (1,1).  public static readonly vector2slim unitx; returns the vector (1,0).  public static readonly vector2slim unity; returns the vector (0,1).  public static readonly vector2slim zero; returns the vector (0,0).  public vector2slim(int value); creates a vector with both components set to the same value.  public vector2slim(int x, int y); creates a vector from its two components.  public int x { get; } the x component of the vector.  public int y { get; } the y component of the vector.  public void copyto(span&lt;int&gt; span); copies the vector elements to the specified span.  public void copyto(span&lt;int&gt; span, int index); copies the vector elements to the specified span starting at the specified index.  public void copyto(int[] array); copies the vector elements to the specified array.  public void copyto(int[] array, int index); copies the vector elements to the specified array starting at the specified index. ">
-          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.Vector2Slim" aria-label="Link to SkiaSharp.QrCode.Image.Vector2Slim">#</a><code>public readonly struct Vector2Slim : IEquatable&lt;Vector2Slim&gt;</code></h3>
+        <article class="type" id="SkiaSharp.QrCode.Image.Vector2Slim" data-name="skiasharp.qrcode.image.vector2slim" data-text="skiasharp.qrcode.image.vector2slim public readonly struct vector2slim : iequatable&lt;vector2slim&gt; int version of vector2, slim implementation ref: https://github.com/dotnet/corefx/blob/v3.1.32/src/system.numerics.vectors/src/system/numerics/vector2_intrinsics.cs field public static readonly vector2slim one; returns the vector (1,1).  field public static readonly vector2slim unitx; returns the vector (1,0).  field public static readonly vector2slim unity; returns the vector (0,1).  field public static readonly vector2slim zero; returns the vector (0,0).  constructor public vector2slim(int value); creates a vector with both components set to the same value.  constructor public vector2slim(int x, int y); creates a vector from its two components.  property public int x { get; } the x component of the vector.  property public int y { get; } the y component of the vector.  method public void copyto(span&lt;int&gt; span); copies the vector elements to the specified span.  method public void copyto(span&lt;int&gt; span, int index); copies the vector elements to the specified span starting at the specified index.  method public void copyto(int[] array); copies the vector elements to the specified array.  method public void copyto(int[] array, int index); copies the vector elements to the specified array starting at the specified index. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.Vector2Slim" aria-label="Link to SkiaSharp.QrCode.Image.Vector2Slim">#</a><span class="kind">struct</span> <span class="name">Vector2Slim</span></h3>
+          <pre class="sig"><code>public readonly struct Vector2Slim : IEquatable&lt;Vector2Slim&gt;</code></pre>
           <p class="doc">int version of Vector2, slim implementation</p>
           <details class="notes" data-text="ref: https://github.com/dotnet/corefx/blob/v3.1.32/src/system.numerics.vectors/src/system/numerics/vector2_intrinsics.cs">
             <summary>Notes</summary>
             <p class="doc remarks">ref: https://github.com/dotnet/corefx/blob/v3.1.32/src/System.Numerics.Vectors/src/System/Numerics/Vector2_Intrinsics.cs</p>
           </details>
           <div class="members">
-            <div class="member" data-text="public static readonly vector2slim one; returns the vector (1,1). ">
-              <code>public static readonly Vector2Slim One;</code>
+            <div class="member" data-text="field public static readonly vector2slim one; returns the vector (1,1). ">
+              <h4><span class="kind">field</span> <span class="name">One</span></h4>
+              <pre class="sig"><code>public static readonly Vector2Slim One;</code></pre>
               <p class="doc">Returns the vector (1,1).</p>
             </div>
-            <div class="member" data-text="public static readonly vector2slim unitx; returns the vector (1,0). ">
-              <code>public static readonly Vector2Slim UnitX;</code>
+            <div class="member" data-text="field public static readonly vector2slim unitx; returns the vector (1,0). ">
+              <h4><span class="kind">field</span> <span class="name">UnitX</span></h4>
+              <pre class="sig"><code>public static readonly Vector2Slim UnitX;</code></pre>
               <p class="doc">Returns the vector (1,0).</p>
             </div>
-            <div class="member" data-text="public static readonly vector2slim unity; returns the vector (0,1). ">
-              <code>public static readonly Vector2Slim UnitY;</code>
+            <div class="member" data-text="field public static readonly vector2slim unity; returns the vector (0,1). ">
+              <h4><span class="kind">field</span> <span class="name">UnitY</span></h4>
+              <pre class="sig"><code>public static readonly Vector2Slim UnitY;</code></pre>
               <p class="doc">Returns the vector (0,1).</p>
             </div>
-            <div class="member" data-text="public static readonly vector2slim zero; returns the vector (0,0). ">
-              <code>public static readonly Vector2Slim Zero;</code>
+            <div class="member" data-text="field public static readonly vector2slim zero; returns the vector (0,0). ">
+              <h4><span class="kind">field</span> <span class="name">Zero</span></h4>
+              <pre class="sig"><code>public static readonly Vector2Slim Zero;</code></pre>
               <p class="doc">Returns the vector (0,0).</p>
             </div>
-            <div class="member" data-text="public vector2slim(int value); creates a vector with both components set to the same value. ">
-              <code>public Vector2Slim(int value);</code>
+            <div class="member" data-text="constructor public vector2slim(int value); creates a vector with both components set to the same value. ">
+              <h4><span class="kind">constructor</span> <span class="name">Vector2Slim</span></h4>
+              <pre class="sig"><code>public Vector2Slim(int value);</code></pre>
               <p class="doc">Creates a vector with both components set to the same value.</p>
             </div>
-            <div class="member" data-text="public vector2slim(int x, int y); creates a vector from its two components. ">
-              <code>public Vector2Slim(int x, int y);</code>
+            <div class="member" data-text="constructor public vector2slim(int x, int y); creates a vector from its two components. ">
+              <h4><span class="kind">constructor</span> <span class="name">Vector2Slim</span></h4>
+              <pre class="sig"><code>public Vector2Slim(int x, int y);</code></pre>
               <p class="doc">Creates a vector from its two components.</p>
             </div>
-            <div class="member" data-text="public int x { get; } the x component of the vector. ">
-              <code>public int X { get; }</code>
+            <div class="member" data-text="property public int x { get; } the x component of the vector. ">
+              <h4><span class="kind">property</span> <span class="name">X</span></h4>
+              <pre class="sig"><code>public int X { get; }</code></pre>
               <p class="doc">The X component of the vector.</p>
             </div>
-            <div class="member" data-text="public int y { get; } the y component of the vector. ">
-              <code>public int Y { get; }</code>
+            <div class="member" data-text="property public int y { get; } the y component of the vector. ">
+              <h4><span class="kind">property</span> <span class="name">Y</span></h4>
+              <pre class="sig"><code>public int Y { get; }</code></pre>
               <p class="doc">The Y component of the vector.</p>
             </div>
-            <div class="member" data-text="public void copyto(span&lt;int&gt; span); copies the vector elements to the specified span. ">
-              <code>public void CopyTo(Span&lt;int&gt; span);</code>
+            <div class="member" data-text="method public void copyto(span&lt;int&gt; span); copies the vector elements to the specified span. ">
+              <h4><span class="kind">method</span> <span class="name">CopyTo</span></h4>
+              <pre class="sig"><code>public void CopyTo(Span&lt;int&gt; span);</code></pre>
               <p class="doc">Copies the vector elements to the specified span.</p>
             </div>
-            <div class="member" data-text="public void copyto(span&lt;int&gt; span, int index); copies the vector elements to the specified span starting at the specified index. ">
-              <code>public void CopyTo(Span&lt;int&gt; span, int index);</code>
+            <div class="member" data-text="method public void copyto(span&lt;int&gt; span, int index); copies the vector elements to the specified span starting at the specified index. ">
+              <h4><span class="kind">method</span> <span class="name">CopyTo</span></h4>
+              <pre class="sig"><code>public void CopyTo(Span&lt;int&gt; span, int index);</code></pre>
               <p class="doc">Copies the vector elements to the specified span starting at the specified index.</p>
             </div>
-            <div class="member" data-text="public void copyto(int[] array); copies the vector elements to the specified array. ">
-              <code>public void CopyTo(int[] array);</code>
+            <div class="member" data-text="method public void copyto(int[] array); copies the vector elements to the specified array. ">
+              <h4><span class="kind">method</span> <span class="name">CopyTo</span></h4>
+              <pre class="sig"><code>public void CopyTo(int[] array);</code></pre>
               <p class="doc">Copies the vector elements to the specified array.</p>
             </div>
-            <div class="member" data-text="public void copyto(int[] array, int index); copies the vector elements to the specified array starting at the specified index. ">
-              <code>public void CopyTo(int[] array, int index);</code>
+            <div class="member" data-text="method public void copyto(int[] array, int index); copies the vector elements to the specified array starting at the specified index. ">
+              <h4><span class="kind">method</span> <span class="name">CopyTo</span></h4>
+              <pre class="sig"><code>public void CopyTo(int[] array, int index);</code></pre>
               <p class="doc">Copies the vector elements to the specified array starting at the specified index.</p>
             </div>
           </div>

--- a/src/SkiaSharp.QrCode.Playground/wwwroot/api/index.html
+++ b/src/SkiaSharp.QrCode.Playground/wwwroot/api/index.html
@@ -1,0 +1,2841 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <title>SkiaSharp.QrCode API</title>
+  <meta name="description" content="Every public type in SkiaSharp.QrCode 1.2.0.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="color-scheme" id="meta-color-scheme" content="light dark" />
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+  <script>
+    (function () {
+      var key = 'skqr-playground-color-mode';
+      var meta = document.getElementById('meta-color-scheme');
+      try {
+        var v = localStorage.getItem(key);
+        if (v === 'light' || v === 'dark') {
+          document.documentElement.setAttribute('data-theme', v);
+          if (meta) meta.setAttribute('content', v);
+        }
+      } catch (e) { /* private mode, cleared storage: the default is fine */ }
+    })();
+  </script>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --accent: #d62976;
+      --bg: #f6f7fb;
+      --panel-bg: #ffffff;
+      --panel-border: #e3e6ee;
+      --text: #1f2430;
+      --text-muted: #5b6474;
+      --input-bg: #ffffff;
+      --input-border: #c9cfdd;
+      --tag-bg: #fbe7f0;
+      --tag-text: #a3306a;
+      --sig-bg: #f0f2f8;
+      --shadow: 0 1px 3px rgba(16, 24, 40, 0.08);
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-theme="light"]) {
+        --bg: #12141c;
+        --panel-bg: #1a1d28;
+        --panel-border: #2a2f40;
+        --text: #e6e9f2;
+        --text-muted: #98a1b5;
+        --input-bg: #12141c;
+        --input-border: #3a4157;
+        --tag-bg: #3a1f2e;
+        --tag-text: #f19ac2;
+        --sig-bg: #222634;
+        --shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+      }
+    }
+
+    :root[data-theme="dark"] {
+      --bg: #12141c;
+      --panel-bg: #1a1d28;
+      --panel-border: #2a2f40;
+      --text: #e6e9f2;
+      --text-muted: #98a1b5;
+      --input-bg: #12141c;
+      --input-border: #3a4157;
+      --tag-bg: #3a1f2e;
+      --tag-text: #f19ac2;
+      --sig-bg: #222634;
+      --shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+      line-height: 1.65;
+    }
+
+    code {
+      font-family: ui-monospace, "Cascadia Mono", "SFMono-Regular", Consolas, monospace;
+      font-size: 0.84rem;
+    }
+
+    .bar {
+      position: sticky;
+      top: 0;
+      z-index: 20;
+      display: flex;
+      align-items: baseline;
+      gap: 0.9rem;
+      flex-wrap: wrap;
+      padding: 0.7rem clamp(1rem, 3vw, 2rem);
+      background: var(--panel-bg);
+      border-bottom: 1px solid var(--panel-border);
+    }
+    .bar h1 { font-size: 1rem; margin: 0; }
+    .back { color: var(--accent); text-decoration: none; font-size: 0.85rem; white-space: nowrap; }
+    .back:hover { text-decoration: underline; }
+    .meta { color: var(--text-muted); font-size: 0.8rem; font-variant-numeric: tabular-nums; }
+
+    .layout {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr);
+      gap: 0 2rem;
+      max-width: 1240px;
+      margin-inline: auto;
+      padding: 0 clamp(1rem, 3vw, 2rem) 4rem;
+    }
+
+    @media (min-width: 60rem) {
+      .layout { grid-template-columns: 17rem minmax(0, 1fr); }
+      .sidebar {
+        position: sticky;
+        top: 3.4rem;
+        align-self: start;
+        max-height: calc(100vh - 4.5rem);
+        overflow-y: auto;
+      }
+    }
+
+    .sidebar { padding-top: 1.5rem; }
+
+    #q {
+      width: 100%;
+      padding: 0.45rem 0.7rem;
+      margin-bottom: 1rem;
+      background: var(--input-bg);
+      color: var(--text);
+      border: 1px solid var(--input-border);
+      border-radius: 6px;
+      font: inherit;
+      font-size: 0.86rem;
+    }
+    #q:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+
+    .toc-ns {
+      margin: 1rem 0 0.4rem;
+      font-size: 0.7rem;
+      letter-spacing: 0.11em;
+      text-transform: uppercase;
+      color: var(--text-muted);
+    }
+    .toc-ns:first-of-type { margin-top: 0; }
+
+    .toc-item {
+      display: block;
+      padding: 0.13rem 0.55rem;
+      border-left: 2px solid transparent;
+      color: var(--text-muted);
+      text-decoration: none;
+      font-size: 0.82rem;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .toc-item:hover { color: var(--text); }
+    .toc-item.current { border-left-color: var(--accent); color: var(--accent); }
+
+    main { padding-top: 1.5rem; min-width: 0; }
+
+    .ns > h2 {
+      margin: 0 0 1rem;
+      padding-bottom: 0.4rem;
+      border-bottom: 1px solid var(--panel-border);
+      font-size: 0.95rem;
+      font-weight: 600;
+      color: var(--text-muted);
+    }
+
+    .type {
+      padding-bottom: 1.6rem;
+      margin-bottom: 1.6rem;
+      border-bottom: 1px solid var(--panel-border);
+      scroll-margin-top: 4rem;
+    }
+    .type:last-child { border-bottom: 0; }
+    .type[hidden], .member[hidden], .ns[hidden], .toc-item[hidden], .toc-ns[hidden] { display: none; }
+
+    .type > h3 {
+      margin: 0;
+      font-weight: 500;
+      overflow-x: auto;
+      white-space: nowrap;
+      padding-bottom: 0.15rem;
+    }
+
+    .anchor {
+      color: var(--text-muted);
+      text-decoration: none;
+      margin-right: 0.45rem;
+      opacity: 0;
+    }
+    .type:hover > h3 .anchor, .anchor:focus-visible { opacity: 1; }
+
+    /* Doc text is prose, so it gets prose width and the body face; signatures stay mono. */
+    .doc {
+      margin: 0.4rem 0 0;
+      max-width: 74ch;
+      font-size: 0.86rem;
+      color: var(--text-muted);
+    }
+    .type > .doc { margin-bottom: 0.2rem; }
+
+    /* Remarks are the reasoning behind the summary, so they sit a step back from it. */
+    .notes { margin-top: 0.3rem; }
+    .notes > summary {
+      display: inline-block;
+      cursor: pointer;
+      font-size: 0.74rem;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      color: var(--text-muted);
+      list-style: none;
+    }
+    .notes > summary::-webkit-details-marker { display: none; }
+    .notes > summary::before { content: "\25B8"; display: inline-block; margin-right: 0.35rem; }
+    .notes[open] > summary::before { content: "\25BE"; }
+    .notes > summary:hover { color: var(--accent); }
+    .notes > summary:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+    .remarks {
+      margin-top: 0.3rem;
+      padding-left: 0.7rem;
+      border-left: 1px solid var(--panel-border);
+      font-size: 0.82rem;
+      opacity: 0.85;
+    }
+
+    .members { margin-top: 1rem; }
+
+    .member {
+      padding: 0.5rem 0 0.5rem 0.9rem;
+      border-left: 2px solid var(--panel-border);
+      margin-bottom: 0.15rem;
+    }
+    .member:hover { border-left-color: var(--accent); }
+    .member > code {
+      display: block;
+      padding: 0.28rem 0.55rem;
+      background: var(--sig-bg);
+      border-radius: 4px;
+      overflow-x: auto;
+      white-space: nowrap;
+    }
+
+    .tag {
+      display: inline-block;
+      margin-left: 0.5rem;
+      padding: 0.02rem 0.4rem;
+      border-radius: 999px;
+      background: var(--tag-bg);
+      color: var(--tag-text);
+      font-size: 0.65rem;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+
+    .empty { color: var(--text-muted); }
+    .empty[hidden] { display: none; }
+
+    @media (prefers-reduced-motion: no-preference) {
+      html { scroll-behavior: smooth; }
+    }
+  </style>
+</head>
+
+<body>
+  <header class="bar">
+    <a class="back" href="../">&#8592; Playground</a>
+    <h1>SkiaSharp.QrCode API</h1>
+    <span class="meta">1.2.0.0 &middot; <span id="count">57 types</span></span>
+  </header>
+
+  <div class="layout">
+    <aside class="sidebar">
+      <input id="q" type="search" placeholder="Filter (press /)" autocomplete="off" spellcheck="false"
+        aria-label="Filter types and members" />
+      <nav id="toc" aria-label="Types">
+        <p class="toc-ns">SkiaSharp.QrCode</p>
+        <a class="toc-item" href="#SkiaSharp.QrCode.Compression" data-for="SkiaSharp.QrCode.Compression">Compression</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.ECCLevel" data-for="SkiaSharp.QrCode.ECCLevel">ECCLevel</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.EciMode" data-for="SkiaSharp.QrCode.EciMode">EciMode</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.MicroQRCodeCalculatedSize" data-for="SkiaSharp.QrCode.MicroQRCodeCalculatedSize">MicroQRCodeCalculatedSize</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.MicroQRCodeData" data-for="SkiaSharp.QrCode.MicroQRCodeData">MicroQRCodeData</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.MicroQRCodeDecodeInfo" data-for="SkiaSharp.QrCode.MicroQRCodeDecodeInfo">MicroQRCodeDecodeInfo</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.MicroQRCodeDecoder" data-for="SkiaSharp.QrCode.MicroQRCodeDecoder">MicroQRCodeDecoder</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.MicroQRCodeGenerator" data-for="SkiaSharp.QrCode.MicroQRCodeGenerator">MicroQRCodeGenerator</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.MicroQRCodeGeneratorOptions" data-for="SkiaSharp.QrCode.MicroQRCodeGeneratorOptions">MicroQRCodeGeneratorOptions</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.MicroQREccLevel" data-for="SkiaSharp.QrCode.MicroQREccLevel">MicroQREccLevel</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.MicroQRSegmentation" data-for="SkiaSharp.QrCode.MicroQRSegmentation">MicroQRSegmentation</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.MicroQRVersion" data-for="SkiaSharp.QrCode.MicroQRVersion">MicroQRVersion</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.MicroQRVersionRange" data-for="SkiaSharp.QrCode.MicroQRVersionRange">MicroQRVersionRange</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.ModuleRect" data-for="SkiaSharp.QrCode.ModuleRect">ModuleRect</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.QRCodeCalculatedSize" data-for="SkiaSharp.QrCode.QRCodeCalculatedSize">QRCodeCalculatedSize</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.QRCodeData" data-for="SkiaSharp.QrCode.QRCodeData">QRCodeData</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.QRCodeDecodeInfo" data-for="SkiaSharp.QrCode.QRCodeDecodeInfo">QRCodeDecodeInfo</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.QRCodeDecodeStatus" data-for="SkiaSharp.QrCode.QRCodeDecodeStatus">QRCodeDecodeStatus</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.QRCodeDecoder" data-for="SkiaSharp.QrCode.QRCodeDecoder">QRCodeDecoder</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.QRCodeExtensions" data-for="SkiaSharp.QrCode.QRCodeExtensions">QRCodeExtensions</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.QRCodeGenerator" data-for="SkiaSharp.QrCode.QRCodeGenerator">QRCodeGenerator</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.QRCodeGeneratorOptions" data-for="SkiaSharp.QrCode.QRCodeGeneratorOptions">QRCodeGeneratorOptions</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.QRCodeRenderer" data-for="SkiaSharp.QrCode.QRCodeRenderer">QRCodeRenderer</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.QRCodeSegmentation" data-for="SkiaSharp.QrCode.QRCodeSegmentation">QRCodeSegmentation</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.QRCodeVersionRange" data-for="SkiaSharp.QrCode.QRCodeVersionRange">QRCodeVersionRange</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.RmQRCodeCalculatedSize" data-for="SkiaSharp.QrCode.RmQRCodeCalculatedSize">RmQRCodeCalculatedSize</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.RmQRCodeData" data-for="SkiaSharp.QrCode.RmQRCodeData">RmQRCodeData</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.RmQRCodeDecodeInfo" data-for="SkiaSharp.QrCode.RmQRCodeDecodeInfo">RmQRCodeDecodeInfo</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.RmQRCodeDecoder" data-for="SkiaSharp.QrCode.RmQRCodeDecoder">RmQRCodeDecoder</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.RmQRCodeGenerator" data-for="SkiaSharp.QrCode.RmQRCodeGenerator">RmQRCodeGenerator</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.RmQRCodeGeneratorOptions" data-for="SkiaSharp.QrCode.RmQRCodeGeneratorOptions">RmQRCodeGeneratorOptions</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.RmQREccLevel" data-for="SkiaSharp.QrCode.RmQREccLevel">RmQREccLevel</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.RmQRFitStrategy" data-for="SkiaSharp.QrCode.RmQRFitStrategy">RmQRFitStrategy</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.RmQRHeight" data-for="SkiaSharp.QrCode.RmQRHeight">RmQRHeight</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.RmQRSegmentation" data-for="SkiaSharp.QrCode.RmQRSegmentation">RmQRSegmentation</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.RmQRVersion" data-for="SkiaSharp.QrCode.RmQRVersion">RmQRVersion</a>
+        <p class="toc-ns">SkiaSharp.QrCode.Image</p>
+        <a class="toc-item" href="#SkiaSharp.QrCode.Image.CircleFinderPatternShape" data-for="SkiaSharp.QrCode.Image.CircleFinderPatternShape">CircleFinderPatternShape</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.Image.CircleModuleShape" data-for="SkiaSharp.QrCode.Image.CircleModuleShape">CircleModuleShape</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.Image.FinderPatternShape" data-for="SkiaSharp.QrCode.Image.FinderPatternShape">FinderPatternShape</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.Image.GradientDirection" data-for="SkiaSharp.QrCode.Image.GradientDirection">GradientDirection</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.Image.GradientOptions" data-for="SkiaSharp.QrCode.Image.GradientOptions">GradientOptions</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.Image.IconData" data-for="SkiaSharp.QrCode.Image.IconData">IconData</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.Image.IconShape" data-for="SkiaSharp.QrCode.Image.IconShape">IconShape</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.Image.ImageIconShape" data-for="SkiaSharp.QrCode.Image.ImageIconShape">ImageIconShape</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.Image.ImageTextIconShape" data-for="SkiaSharp.QrCode.Image.ImageTextIconShape">ImageTextIconShape</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.Image.MicroQRCodeImageBuilder" data-for="SkiaSharp.QrCode.Image.MicroQRCodeImageBuilder">MicroQRCodeImageBuilder</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.Image.ModuleShape" data-for="SkiaSharp.QrCode.Image.ModuleShape">ModuleShape</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.Image.QRCodeImageBuilder" data-for="SkiaSharp.QrCode.Image.QRCodeImageBuilder">QRCodeImageBuilder</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.Image.QRCodeImageBuilderBase" data-for="SkiaSharp.QrCode.Image.QRCodeImageBuilderBase">QRCodeImageBuilderBase</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.Image.RectangleFinderPatternShape" data-for="SkiaSharp.QrCode.Image.RectangleFinderPatternShape">RectangleFinderPatternShape</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.Image.RectangleModuleShape" data-for="SkiaSharp.QrCode.Image.RectangleModuleShape">RectangleModuleShape</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.Image.RmQRCodeImageBuilder" data-for="SkiaSharp.QrCode.Image.RmQRCodeImageBuilder">RmQRCodeImageBuilder</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.Image.RoundedRectangleCircleFinderPatternShape" data-for="SkiaSharp.QrCode.Image.RoundedRectangleCircleFinderPatternShape">RoundedRectangleCircleFinderPatternShape</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.Image.RoundedRectangleFinderPatternShape" data-for="SkiaSharp.QrCode.Image.RoundedRectangleFinderPatternShape">RoundedRectangleFinderPatternShape</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.Image.RoundedRectangleModuleShape" data-for="SkiaSharp.QrCode.Image.RoundedRectangleModuleShape">RoundedRectangleModuleShape</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.Image.TextVerticalAlignment" data-for="SkiaSharp.QrCode.Image.TextVerticalAlignment">TextVerticalAlignment</a>
+        <a class="toc-item" href="#SkiaSharp.QrCode.Image.Vector2Slim" data-for="SkiaSharp.QrCode.Image.Vector2Slim">Vector2Slim</a>
+      </nav>
+    </aside>
+
+    <main>
+      <section class="ns">
+        <h2>namespace SkiaSharp.QrCode</h2>
+        <article class="type" id="SkiaSharp.QrCode.Compression" data-name="skiasharp.qrcode.compression" data-text="skiasharp.qrcode.compression public enum compression : int compression mode for qr code data serialization. no api in this library accepts or returns this type. the serialization feature it described was removed before 1.0.0; the enum was left behind and shipped in 1.1.1, which is the only reason it still exists. compress the bytes from getrawdata() yourself, as shown in docs/migration.md. uncompressed = 0, no compression  deflate = 1, deflate compression (rfc 1951)  gzip = 2, gzip compression (rfc 1952) ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Compression" aria-label="Link to SkiaSharp.QrCode.Compression">#</a><code>public enum Compression : int</code> <span class="tag">obsolete</span></h3>
+          <p class="doc">Compression mode for QR code data serialization.</p>
+          <details class="notes" data-text="no api in this library accepts or returns this type. the serialization feature it described was removed before 1.0.0; the enum was left behind and shipped in 1.1.1, which is the only reason it still exists. compress the bytes from getrawdata() yourself, as shown in docs/migration.md.">
+            <summary>Notes</summary>
+            <p class="doc remarks">No API in this library accepts or returns this type. The serialization feature it described was removed before 1.0.0; the enum was left behind and shipped in 1.1.1, which is the only reason it still exists. Compress the bytes from GetRawData() yourself, as shown in docs/migration.md.</p>
+          </details>
+          <div class="members">
+            <div class="member" data-text="uncompressed = 0, no compression ">
+              <code>Uncompressed = 0,</code>
+              <p class="doc">No compression</p>
+            </div>
+            <div class="member" data-text="deflate = 1, deflate compression (rfc 1951) ">
+              <code>Deflate = 1,</code>
+              <p class="doc">DEFLATE compression (RFC 1951)</p>
+            </div>
+            <div class="member" data-text="gzip = 2, gzip compression (rfc 1952) ">
+              <code>GZip = 2,</code>
+              <p class="doc">GZIP compression (RFC 1952)</p>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.ECCLevel" data-name="skiasharp.qrcode.ecclevel" data-text="skiasharp.qrcode.ecclevel public enum ecclevel : int the error correction level: how much of a symbol can be damaged, dirty or covered while the code still scans. higher levels leave less room for content, so the same text may need a larger symbol.  l = 0, 7% may be lost before recovery is not possible  m = 1, 15% may be lost before recovery is not possible  q = 2, 25% may be lost before recovery is not possible  h = 3, 30% may be lost before recovery is not possible ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.ECCLevel" aria-label="Link to SkiaSharp.QrCode.ECCLevel">#</a><code>public enum ECCLevel : int</code></h3>
+          <p class="doc">The error correction level: how much of a symbol can be damaged, dirty or covered while the code still scans. Higher levels leave less room for content, so the same text may need a larger symbol.</p>
+          <div class="members">
+            <div class="member" data-text="l = 0, 7% may be lost before recovery is not possible ">
+              <code>L = 0,</code>
+              <p class="doc">7% may be lost before recovery is not possible</p>
+            </div>
+            <div class="member" data-text="m = 1, 15% may be lost before recovery is not possible ">
+              <code>M = 1,</code>
+              <p class="doc">15% may be lost before recovery is not possible</p>
+            </div>
+            <div class="member" data-text="q = 2, 25% may be lost before recovery is not possible ">
+              <code>Q = 2,</code>
+              <p class="doc">25% may be lost before recovery is not possible</p>
+            </div>
+            <div class="member" data-text="h = 3, 30% may be lost before recovery is not possible ">
+              <code>H = 3,</code>
+              <p class="doc">30% may be lost before recovery is not possible</p>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.EciMode" data-name="skiasharp.qrcode.ecimode" data-text="skiasharp.qrcode.ecimode public enum ecimode : int eci (extended channel interpretation) mode for character encoding.  default = 0, auto-detect encoding and add appropriate eci header (recommended for most use cases). automatic encoding detectionascii-only (0x00-0x7f): no eci header (maximum compatibility, smallest size)iso-8859-1 compatible: auto-upgrade to iso8859_1 (eci 3 header added)unicode (emojis, cjk, etc.): auto-upgrade to utf8 (eci 26 header added)examples: &quot;hello&quot; → no eci header (ascii-only, 29 bits for &quot;he&quot;) &quot;café&quot; → eci 3 (iso-8859-1, 41 bits for &quot;ca&quot;) &quot;🎉&quot; → eci 26 (utf-8, 41 bits + utf-8 bytes) &quot;こんにちは&quot; → eci 26 (utf-8, auto-detected) iso8859_1 = 3, iso-8859-1 (latin-1) encoding - western european characters. adds an eci header: 12 bits in standard qr, 11 bits in rmqr. character support:ascii (0x00-0x7f): a-z, 0-9, basic symbolsextended latin (0x80-0xff): à, ç, ñ, é, ü, etc.use when:content is western european languages (english, french, spanish, german, etc.)you need explicit iso-8859-1 encoding declarationcompatibility with iso-8859-1 readers is requiredcannot encode:emojis (🎉, 😀, etc.)cjk characters (日本語, 中文, 한글)cyrillic beyond basic range utf8 = 26, utf-8 unicode encoding - universal character support. adds an eci header: 12 bits in standard qr, 11 bits in rmqr. character support:all unicode characters (u+0000 to u+10ffff)emojis, cjk, arabic, hebrew, cyrillic, etc.multi-byte encoding: 1-4 bytes per charactersize impact:eci header: +12 bits in standard qr, +11 bits in rmqrdata encoding: variable (1-4 bytes per character)standard qr example: &quot;🎉&quot; = 12 (header) + 4 + 9 + 32 (4-byte utf-8) = 57 bitsstandard qr example: &quot;café&quot; = 12 (header) + 4 + 9 + 40 (5 bytes: c,a,f,é=c3a9) = 65 bitsutf-8 byte examples: 'a' → 0x41 (1 byte, ascii) 'é' → 0xc3 0xa9 (2 bytes, latin extended) '中' → 0xe4 0xb8 0xad (3 bytes, cjk) '🎉' → 0xf0 0x9f 0x8e 0x89 (4 bytes, emoji) use when:content includes emojis or symbolscontent includes cjk characters (japanese, chinese, korean)content includes non-latin scripts (cyrillic, arabic, hebrew, etc.)you need universal unicode supporttrade-offs:larger data size for non-ascii characters (multi-byte encoding)eci header adds 12 bits in standard qr or 11 bits in rmqrfor western european text, iso8859_1 is more efficient">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.EciMode" aria-label="Link to SkiaSharp.QrCode.EciMode">#</a><code>public enum EciMode : int</code></h3>
+          <p class="doc">ECI (Extended Channel Interpretation) mode for character encoding.</p>
+          <div class="members">
+            <div class="member" data-text="default = 0, auto-detect encoding and add appropriate eci header (recommended for most use cases). automatic encoding detectionascii-only (0x00-0x7f): no eci header (maximum compatibility, smallest size)iso-8859-1 compatible: auto-upgrade to iso8859_1 (eci 3 header added)unicode (emojis, cjk, etc.): auto-upgrade to utf8 (eci 26 header added)examples: &quot;hello&quot; → no eci header (ascii-only, 29 bits for &quot;he&quot;) &quot;café&quot; → eci 3 (iso-8859-1, 41 bits for &quot;ca&quot;) &quot;🎉&quot; → eci 26 (utf-8, 41 bits + utf-8 bytes) &quot;こんにちは&quot; → eci 26 (utf-8, auto-detected)">
+              <code>Default = 0,</code>
+              <p class="doc">Auto-detect encoding and add appropriate ECI header (recommended for most use cases).</p>
+              <details class="notes" data-text="automatic encoding detectionascii-only (0x00-0x7f): no eci header (maximum compatibility, smallest size)iso-8859-1 compatible: auto-upgrade to iso8859_1 (eci 3 header added)unicode (emojis, cjk, etc.): auto-upgrade to utf8 (eci 26 header added)examples: &quot;hello&quot; → no eci header (ascii-only, 29 bits for &quot;he&quot;) &quot;café&quot; → eci 3 (iso-8859-1, 41 bits for &quot;ca&quot;) &quot;🎉&quot; → eci 26 (utf-8, 41 bits + utf-8 bytes) &quot;こんにちは&quot; → eci 26 (utf-8, auto-detected)">
+                <summary>Notes</summary>
+                <p class="doc remarks">Automatic Encoding DetectionASCII-only (0x00-0x7F): No ECI header (maximum compatibility, smallest size)ISO-8859-1 compatible: Auto-upgrade to Iso8859_1 (ECI 3 header added)Unicode (emojis, CJK, etc.): Auto-upgrade to Utf8 (ECI 26 header added)Examples: &quot;HELLO&quot; → No ECI header (ASCII-only, 29 bits for &quot;HE&quot;) &quot;Café&quot; → ECI 3 (ISO-8859-1, 41 bits for &quot;Ca&quot;) &quot;🎉&quot; → ECI 26 (UTF-8, 41 bits + UTF-8 bytes) &quot;こんにちは&quot; → ECI 26 (UTF-8, auto-detected)</p>
+              </details>
+            </div>
+            <div class="member" data-text="iso8859_1 = 3, iso-8859-1 (latin-1) encoding - western european characters. adds an eci header: 12 bits in standard qr, 11 bits in rmqr. character support:ascii (0x00-0x7f): a-z, 0-9, basic symbolsextended latin (0x80-0xff): à, ç, ñ, é, ü, etc.use when:content is western european languages (english, french, spanish, german, etc.)you need explicit iso-8859-1 encoding declarationcompatibility with iso-8859-1 readers is requiredcannot encode:emojis (🎉, 😀, etc.)cjk characters (日本語, 中文, 한글)cyrillic beyond basic range">
+              <code>Iso8859_1 = 3,</code>
+              <p class="doc">ISO-8859-1 (Latin-1) encoding - Western European characters. Adds an ECI header: 12 bits in Standard QR, 11 bits in rMQR.</p>
+              <details class="notes" data-text="character support:ascii (0x00-0x7f): a-z, 0-9, basic symbolsextended latin (0x80-0xff): à, ç, ñ, é, ü, etc.use when:content is western european languages (english, french, spanish, german, etc.)you need explicit iso-8859-1 encoding declarationcompatibility with iso-8859-1 readers is requiredcannot encode:emojis (🎉, 😀, etc.)cjk characters (日本語, 中文, 한글)cyrillic beyond basic range">
+                <summary>Notes</summary>
+                <p class="doc remarks">Character Support:ASCII (0x00-0x7F): A-Z, 0-9, basic symbolsExtended Latin (0x80-0xFF): À, Ç, Ñ, é, ü, etc.Use when:Content is Western European languages (English, French, Spanish, German, etc.)You need explicit ISO-8859-1 encoding declarationCompatibility with ISO-8859-1 readers is requiredCannot encode:Emojis (🎉, 😀, etc.)CJK characters (日本語, 中文, 한글)Cyrillic beyond basic range</p>
+              </details>
+            </div>
+            <div class="member" data-text="utf8 = 26, utf-8 unicode encoding - universal character support. adds an eci header: 12 bits in standard qr, 11 bits in rmqr. character support:all unicode characters (u+0000 to u+10ffff)emojis, cjk, arabic, hebrew, cyrillic, etc.multi-byte encoding: 1-4 bytes per charactersize impact:eci header: +12 bits in standard qr, +11 bits in rmqrdata encoding: variable (1-4 bytes per character)standard qr example: &quot;🎉&quot; = 12 (header) + 4 + 9 + 32 (4-byte utf-8) = 57 bitsstandard qr example: &quot;café&quot; = 12 (header) + 4 + 9 + 40 (5 bytes: c,a,f,é=c3a9) = 65 bitsutf-8 byte examples: 'a' → 0x41 (1 byte, ascii) 'é' → 0xc3 0xa9 (2 bytes, latin extended) '中' → 0xe4 0xb8 0xad (3 bytes, cjk) '🎉' → 0xf0 0x9f 0x8e 0x89 (4 bytes, emoji) use when:content includes emojis or symbolscontent includes cjk characters (japanese, chinese, korean)content includes non-latin scripts (cyrillic, arabic, hebrew, etc.)you need universal unicode supporttrade-offs:larger data size for non-ascii characters (multi-byte encoding)eci header adds 12 bits in standard qr or 11 bits in rmqrfor western european text, iso8859_1 is more efficient">
+              <code>Utf8 = 26,</code>
+              <p class="doc">UTF-8 Unicode encoding - Universal character support. Adds an ECI header: 12 bits in Standard QR, 11 bits in rMQR.</p>
+              <details class="notes" data-text="character support:all unicode characters (u+0000 to u+10ffff)emojis, cjk, arabic, hebrew, cyrillic, etc.multi-byte encoding: 1-4 bytes per charactersize impact:eci header: +12 bits in standard qr, +11 bits in rmqrdata encoding: variable (1-4 bytes per character)standard qr example: &quot;🎉&quot; = 12 (header) + 4 + 9 + 32 (4-byte utf-8) = 57 bitsstandard qr example: &quot;café&quot; = 12 (header) + 4 + 9 + 40 (5 bytes: c,a,f,é=c3a9) = 65 bitsutf-8 byte examples: 'a' → 0x41 (1 byte, ascii) 'é' → 0xc3 0xa9 (2 bytes, latin extended) '中' → 0xe4 0xb8 0xad (3 bytes, cjk) '🎉' → 0xf0 0x9f 0x8e 0x89 (4 bytes, emoji) use when:content includes emojis or symbolscontent includes cjk characters (japanese, chinese, korean)content includes non-latin scripts (cyrillic, arabic, hebrew, etc.)you need universal unicode supporttrade-offs:larger data size for non-ascii characters (multi-byte encoding)eci header adds 12 bits in standard qr or 11 bits in rmqrfor western european text, iso8859_1 is more efficient">
+                <summary>Notes</summary>
+                <p class="doc remarks">Character Support:All Unicode characters (U+0000 to U+10FFFF)Emojis, CJK, Arabic, Hebrew, Cyrillic, etc.Multi-byte encoding: 1-4 bytes per characterSize Impact:ECI header: +12 bits in Standard QR, +11 bits in rMQRData encoding: Variable (1-4 bytes per character)Standard QR example: &quot;🎉&quot; = 12 (header) + 4 + 9 + 32 (4-byte UTF-8) = 57 bitsStandard QR example: &quot;Café&quot; = 12 (header) + 4 + 9 + 40 (5 bytes: C,a,f,é=C3A9) = 65 bitsUTF-8 Byte Examples: 'A' → 0x41 (1 byte, ASCII) 'é' → 0xC3 0xA9 (2 bytes, Latin Extended) '中' → 0xE4 0xB8 0xAD (3 bytes, CJK) '🎉' → 0xF0 0x9F 0x8E 0x89 (4 bytes, Emoji) Use when:Content includes emojis or symbolsContent includes CJK characters (Japanese, Chinese, Korean)Content includes non-Latin scripts (Cyrillic, Arabic, Hebrew, etc.)You need universal Unicode supportTrade-offs:Larger data size for non-ASCII characters (multi-byte encoding)ECI header adds 12 bits in Standard QR or 11 bits in rMQRFor Western European text, Iso8859_1 is more efficient</p>
+              </details>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.MicroQRCodeCalculatedSize" data-name="skiasharp.qrcode.microqrcodecalculatedsize" data-text="skiasharp.qrcode.microqrcodecalculatedsize public readonly struct microqrcodecalculatedsize result of trygetrequiredbuffersize : buffer size, matrix side length and selected version for a pending micro qr encode.  public microqrversion version { get; } the micro qr version that will be produced.  public int buffersize { get; } required destination buffer size in bytes (one byte per module, quiet zone included).  public int qrsize { get; } matrix side length in modules, quiet zone included. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.MicroQRCodeCalculatedSize" aria-label="Link to SkiaSharp.QrCode.MicroQRCodeCalculatedSize">#</a><code>public readonly struct MicroQRCodeCalculatedSize</code></h3>
+          <p class="doc">Result of TryGetRequiredBufferSize : buffer size, matrix side length and selected version for a pending Micro QR encode.</p>
+          <div class="members">
+            <div class="member" data-text="public microqrversion version { get; } the micro qr version that will be produced. ">
+              <code>public MicroQRVersion Version { get; }</code>
+              <p class="doc">The Micro QR version that will be produced.</p>
+            </div>
+            <div class="member" data-text="public int buffersize { get; } required destination buffer size in bytes (one byte per module, quiet zone included). ">
+              <code>public int BufferSize { get; }</code>
+              <p class="doc">Required destination buffer size in bytes (one byte per module, quiet zone included).</p>
+            </div>
+            <div class="member" data-text="public int qrsize { get; } matrix side length in modules, quiet zone included. ">
+              <code>public int QrSize { get; }</code>
+              <p class="doc">Matrix side length in modules, quiet zone included.</p>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.MicroQRCodeData" data-name="skiasharp.qrcode.microqrcodedata" data-text="skiasharp.qrcode.microqrcodedata public class microqrcodedata represents micro qr code data as a 2d boolean matrix (versions m1-m4, 11×11 to 17×17 modules). storage mirrors qrcodedata : core modules only (no quiet zone), bit-packed msb-first in flat row-major order; the quiet zone is virtual and always reads light. serialization uses the &quot;qrx&quot; container: &quot;qrx&quot; + symbol type (1 byte) + width (1 byte) + height (1 byte) + packed core bits. the legacy &quot;qrr&quot; format remains exclusive to standard qr. public microqrcodedata(microqrversion version, int quietzonesize); initializes an empty matrix for the specified version.  public microqrcodedata(readonlyspan&lt;byte&gt; rawdata, int quietzonesize);  public microqrcodedata(byte[] rawdata, int quietzonesize); deserializes micro qr data previously produced by getrawdata .  public microqrversion version { get; } gets the micro qr version (m1-m4).  public bool this[int row, int col] { get; } gets the module state at the specified position (quiet zone included). quiet zone positions always read false.  public int size { get; } gets the matrix side length in modules, including the quiet zone.  public modulerect[] getmodulerectangles(); gets the dark modules as merged rectangles in module coordinates, for rendering with any graphics api without skiasharp (svg path data, draw calls, vector output). coordinates use the same space as the indexer (this[row, col]): one unit is one module, origin at the top-left including the quiet zone, x is the column and y is the row. consumers scale by the pixel size of one module; size gives the total extent in modules. three properties are contractual: rectangles never overlap, cover only dark modules, and cover every dark module. the decomposition shape and ordering are unspecified and may change between versions (currently maximal horizontal runs in row-major order, the same merge the built-in renderer draws). public bool trygetmodulerectangles(span&lt;modulerect&gt; destination, out int written); writes the dark modules as merged rectangles into a caller-provided buffer. same contract as getmodulerectangles without allocations.  public byte[] getrawdata(); serializes the core modules (quiet zone excluded) to a new byte array.  public int getmodulerectanglesmaxcount(); gets an upper bound on the number of rectangles getmodulerectangles can return, suitable for sizing a pooled buffer for trygetmodulerectangles . o(1), no matrix scan.  public int getrawdata(ibufferwriter&lt;byte&gt; writer); writes the serialized data to the specified buffer writer without intermediate allocation.  public int getrawdatasize(); gets the serialized size in bytes (&quot;qrx&quot; header + packed core bits). ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.MicroQRCodeData" aria-label="Link to SkiaSharp.QrCode.MicroQRCodeData">#</a><code>public class MicroQRCodeData</code></h3>
+          <p class="doc">Represents Micro QR code data as a 2D boolean matrix (versions M1-M4, 11×11 to 17×17 modules).</p>
+          <details class="notes" data-text="storage mirrors qrcodedata : core modules only (no quiet zone), bit-packed msb-first in flat row-major order; the quiet zone is virtual and always reads light. serialization uses the &quot;qrx&quot; container: &quot;qrx&quot; + symbol type (1 byte) + width (1 byte) + height (1 byte) + packed core bits. the legacy &quot;qrr&quot; format remains exclusive to standard qr.">
+            <summary>Notes</summary>
+            <p class="doc remarks">Storage mirrors QRCodeData : core modules only (no quiet zone), bit-packed MSB-first in flat row-major order; the quiet zone is virtual and always reads light. Serialization uses the &quot;QRX&quot; container: &quot;QRX&quot; + symbol type (1 byte) + width (1 byte) + height (1 byte) + packed core bits. The legacy &quot;QRR&quot; format remains exclusive to Standard QR.</p>
+          </details>
+          <div class="members">
+            <div class="member" data-text="public microqrcodedata(microqrversion version, int quietzonesize); initializes an empty matrix for the specified version. ">
+              <code>public MicroQRCodeData(MicroQRVersion version, int quietZoneSize);</code>
+              <p class="doc">Initializes an empty matrix for the specified version.</p>
+            </div>
+            <div class="member" data-text="public microqrcodedata(readonlyspan&lt;byte&gt; rawdata, int quietzonesize); ">
+              <code>public MicroQRCodeData(ReadOnlySpan&lt;byte&gt; rawData, int quietZoneSize);</code>
+            </div>
+            <div class="member" data-text="public microqrcodedata(byte[] rawdata, int quietzonesize); deserializes micro qr data previously produced by getrawdata . ">
+              <code>public MicroQRCodeData(byte[] rawData, int quietZoneSize);</code>
+              <p class="doc">Deserializes Micro QR data previously produced by GetRawData .</p>
+            </div>
+            <div class="member" data-text="public microqrversion version { get; } gets the micro qr version (m1-m4). ">
+              <code>public MicroQRVersion Version { get; }</code>
+              <p class="doc">Gets the Micro QR version (M1-M4).</p>
+            </div>
+            <div class="member" data-text="public bool this[int row, int col] { get; } gets the module state at the specified position (quiet zone included). quiet zone positions always read false. ">
+              <code>public bool this[int row, int col] { get; }</code>
+              <p class="doc">Gets the module state at the specified position (quiet zone included). Quiet zone positions always read false.</p>
+            </div>
+            <div class="member" data-text="public int size { get; } gets the matrix side length in modules, including the quiet zone. ">
+              <code>public int Size { get; }</code>
+              <p class="doc">Gets the matrix side length in modules, including the quiet zone.</p>
+            </div>
+            <div class="member" data-text="public modulerect[] getmodulerectangles(); gets the dark modules as merged rectangles in module coordinates, for rendering with any graphics api without skiasharp (svg path data, draw calls, vector output). coordinates use the same space as the indexer (this[row, col]): one unit is one module, origin at the top-left including the quiet zone, x is the column and y is the row. consumers scale by the pixel size of one module; size gives the total extent in modules. three properties are contractual: rectangles never overlap, cover only dark modules, and cover every dark module. the decomposition shape and ordering are unspecified and may change between versions (currently maximal horizontal runs in row-major order, the same merge the built-in renderer draws).">
+              <code>public ModuleRect[] GetModuleRectangles();</code>
+              <p class="doc">Gets the dark modules as merged rectangles in module coordinates, for rendering with any graphics API without SkiaSharp (SVG path data, draw calls, vector output).</p>
+              <details class="notes" data-text="coordinates use the same space as the indexer (this[row, col]): one unit is one module, origin at the top-left including the quiet zone, x is the column and y is the row. consumers scale by the pixel size of one module; size gives the total extent in modules. three properties are contractual: rectangles never overlap, cover only dark modules, and cover every dark module. the decomposition shape and ordering are unspecified and may change between versions (currently maximal horizontal runs in row-major order, the same merge the built-in renderer draws).">
+                <summary>Notes</summary>
+                <p class="doc remarks">Coordinates use the same space as the indexer (this[row, col]): one unit is one module, origin at the top-left including the quiet zone, X is the column and Y is the row. Consumers scale by the pixel size of one module; Size gives the total extent in modules. Three properties are contractual: rectangles never overlap, cover only dark modules, and cover every dark module. The decomposition shape and ordering are unspecified and may change between versions (currently maximal horizontal runs in row-major order, the same merge the built-in renderer draws).</p>
+              </details>
+            </div>
+            <div class="member" data-text="public bool trygetmodulerectangles(span&lt;modulerect&gt; destination, out int written); writes the dark modules as merged rectangles into a caller-provided buffer. same contract as getmodulerectangles without allocations. ">
+              <code>public bool TryGetModuleRectangles(Span&lt;ModuleRect&gt; destination, out int written);</code>
+              <p class="doc">Writes the dark modules as merged rectangles into a caller-provided buffer. Same contract as GetModuleRectangles without allocations.</p>
+            </div>
+            <div class="member" data-text="public byte[] getrawdata(); serializes the core modules (quiet zone excluded) to a new byte array. ">
+              <code>public byte[] GetRawData();</code>
+              <p class="doc">Serializes the core modules (quiet zone excluded) to a new byte array.</p>
+            </div>
+            <div class="member" data-text="public int getmodulerectanglesmaxcount(); gets an upper bound on the number of rectangles getmodulerectangles can return, suitable for sizing a pooled buffer for trygetmodulerectangles . o(1), no matrix scan. ">
+              <code>public int GetModuleRectanglesMaxCount();</code>
+              <p class="doc">Gets an upper bound on the number of rectangles GetModuleRectangles can return, suitable for sizing a pooled buffer for TryGetModuleRectangles . O(1), no matrix scan.</p>
+            </div>
+            <div class="member" data-text="public int getrawdata(ibufferwriter&lt;byte&gt; writer); writes the serialized data to the specified buffer writer without intermediate allocation. ">
+              <code>public int GetRawData(IBufferWriter&lt;byte&gt; writer);</code>
+              <p class="doc">Writes the serialized data to the specified buffer writer without intermediate allocation.</p>
+            </div>
+            <div class="member" data-text="public int getrawdatasize(); gets the serialized size in bytes (&quot;qrx&quot; header + packed core bits). ">
+              <code>public int GetRawDataSize();</code>
+              <p class="doc">Gets the serialized size in bytes (&quot;QRX&quot; header + packed core bits).</p>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.MicroQRCodeDecodeInfo" data-name="skiasharp.qrcode.microqrcodedecodeinfo" data-text="skiasharp.qrcode.microqrcodedecodeinfo public readonly struct microqrcodedecodeinfo diagnostic information produced by a micro qr code decode attempt. statuses are shared with the standard qr decoder ( qrcodedecodestatus ); version, ecc level and mask pattern use the micro qr domains. public microqrecclevel ecclevel { get; } error correction level read from the format information.  public microqrversion version { get; } micro qr version (m1-m4), or default (0) when the matrix was invalid.  public qrcodedecodestatus status { get; } decode result status. success when decoding succeeded.  public int errorscorrected { get; } number of codeword errors corrected by reed-solomon decoding.  public int maskpattern { get; } mask pattern (0-3) read from the format information, or -1 when unknown. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.MicroQRCodeDecodeInfo" aria-label="Link to SkiaSharp.QrCode.MicroQRCodeDecodeInfo">#</a><code>public readonly struct MicroQRCodeDecodeInfo</code></h3>
+          <p class="doc">Diagnostic information produced by a Micro QR code decode attempt.</p>
+          <details class="notes" data-text="statuses are shared with the standard qr decoder ( qrcodedecodestatus ); version, ecc level and mask pattern use the micro qr domains.">
+            <summary>Notes</summary>
+            <p class="doc remarks">Statuses are shared with the Standard QR decoder ( QRCodeDecodeStatus ); version, ECC level and mask pattern use the Micro QR domains.</p>
+          </details>
+          <div class="members">
+            <div class="member" data-text="public microqrecclevel ecclevel { get; } error correction level read from the format information. ">
+              <code>public MicroQREccLevel EccLevel { get; }</code>
+              <p class="doc">Error correction level read from the format information.</p>
+            </div>
+            <div class="member" data-text="public microqrversion version { get; } micro qr version (m1-m4), or default (0) when the matrix was invalid. ">
+              <code>public MicroQRVersion Version { get; }</code>
+              <p class="doc">Micro QR version (M1-M4), or default (0) when the matrix was invalid.</p>
+            </div>
+            <div class="member" data-text="public qrcodedecodestatus status { get; } decode result status. success when decoding succeeded. ">
+              <code>public QRCodeDecodeStatus Status { get; }</code>
+              <p class="doc">Decode result status. Success when decoding succeeded.</p>
+            </div>
+            <div class="member" data-text="public int errorscorrected { get; } number of codeword errors corrected by reed-solomon decoding. ">
+              <code>public int ErrorsCorrected { get; }</code>
+              <p class="doc">Number of codeword errors corrected by Reed-Solomon decoding.</p>
+            </div>
+            <div class="member" data-text="public int maskpattern { get; } mask pattern (0-3) read from the format information, or -1 when unknown. ">
+              <code>public int MaskPattern { get; }</code>
+              <p class="doc">Mask pattern (0-3) read from the format information, or -1 when unknown.</p>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.MicroQRCodeDecoder" data-name="skiasharp.qrcode.microqrcodedecoder" data-text="skiasharp.qrcode.microqrcodedecoder public static class microqrcodedecoder micro qr code decoder based on iso/iec 18004. decodes micro qr module matrices back into text, including reed-solomon error correction. supported content: numeric, alphanumeric and byte mode segments (iso-8859-1 and utf-8), all versions m1-m4 and all legal ecc levels, plus kanji mode segments in m3 and m4 (decoded as jis x 0208; this library never emits them). a kanji cell outside the jis x 0208 repertoire fails the whole symbol with unmappedcharacter rather than substituting a replacement character. micro qr has no eci mode; byte segments use utf-8 when the payload validates as utf-8 and iso-8859-1 otherwise (matching this library's encoder). inputs are module matrices ( microqrcodedata or byte-per-module buffers as produced by microqrcodegenerator ; a uniform light quiet zone border is detected and skipped automatically) or images via the trydecode / trydecodeimage overloads. image detection targets clean, screen-rendered or scanned images: arbitrary rotation, mirroring, reflectance reversal, uniform or non-uniform scaling, translation and mild perspective distortion are supported. micro qr image scanning is a separate, explicitly-typed entry point — qrcodedecoder continues to scan standard qr only. public static bool trydecode(microqrcodedata data, out string text); decodes the text content from micro qr code data.  public static bool trydecode(microqrcodedata data, out string text, out microqrcodedecodeinfo info); decodes the text content from micro qr code data, with diagnostic information.  public static bool trydecode(readonlyspan&lt;byte&gt; modules, int size, span&lt;char&gt; destination, out int charswritten, out microqrcodedecodeinfo info); decodes the text content from a module matrix into a caller-provided buffer without per-call heap allocation.  public static bool trydecode(readonlyspan&lt;byte&gt; modules, int size, out string text, out microqrcodedecodeinfo info); decodes the text content from a module matrix.  public static bool trydecode(skbitmap bitmap, out string text); detects and decodes a micro qr code from a bitmap image. targets clean, well-lit images such as screenshots, rendered symbols and scans: arbitrary rotation, mirroring, reflectance reversal (light-on-dark), uniform or non-uniform scaling, translation and mild perspective distortion are handled. strong perspective, uneven lighting and blur are out of scope. public static bool trydecode(skbitmap bitmap, out string text, out microqrcodedecodeinfo info); detects and decodes a micro qr code from a bitmap image, with diagnostic information. see trydecode for the supported image envelope. public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, span&lt;char&gt; destination, out int charswritten, out microqrcodedecodeinfo info); detects and decodes a micro qr code from grayscale image pixels into a caller-provided buffer without per-call heap allocation.  public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, out string text, out microqrcodedecodeinfo info); detects and decodes a micro qr code from grayscale image pixels.  public static int getmaxdecodedlength(microqrversion version); calculates the maximum possible decoded character count for a micro qr version, across all ecc levels and encoding modes. use to size the destination buffer for the allocation-free trydecode overload. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.MicroQRCodeDecoder" aria-label="Link to SkiaSharp.QrCode.MicroQRCodeDecoder">#</a><code>public static class MicroQRCodeDecoder</code></h3>
+          <p class="doc">Micro QR code decoder based on ISO/IEC 18004. Decodes Micro QR module matrices back into text, including Reed-Solomon error correction.</p>
+          <details class="notes" data-text="supported content: numeric, alphanumeric and byte mode segments (iso-8859-1 and utf-8), all versions m1-m4 and all legal ecc levels, plus kanji mode segments in m3 and m4 (decoded as jis x 0208; this library never emits them). a kanji cell outside the jis x 0208 repertoire fails the whole symbol with unmappedcharacter rather than substituting a replacement character. micro qr has no eci mode; byte segments use utf-8 when the payload validates as utf-8 and iso-8859-1 otherwise (matching this library's encoder). inputs are module matrices ( microqrcodedata or byte-per-module buffers as produced by microqrcodegenerator ; a uniform light quiet zone border is detected and skipped automatically) or images via the trydecode / trydecodeimage overloads. image detection targets clean, screen-rendered or scanned images: arbitrary rotation, mirroring, reflectance reversal, uniform or non-uniform scaling, translation and mild perspective distortion are supported. micro qr image scanning is a separate, explicitly-typed entry point — qrcodedecoder continues to scan standard qr only.">
+            <summary>Notes</summary>
+            <p class="doc remarks">Supported content: Numeric, Alphanumeric and Byte mode segments (ISO-8859-1 and UTF-8), all versions M1-M4 and all legal ECC levels, plus Kanji mode segments in M3 and M4 (decoded as JIS X 0208; this library never emits them). A Kanji cell outside the JIS X 0208 repertoire fails the whole symbol with UnmappedCharacter rather than substituting a replacement character. Micro QR has no ECI mode; byte segments use UTF-8 when the payload validates as UTF-8 and ISO-8859-1 otherwise (matching this library's encoder). Inputs are module matrices ( MicroQRCodeData or byte-per-module buffers as produced by MicroQRCodeGenerator ; a uniform light quiet zone border is detected and skipped automatically) or images via the TryDecode / TryDecodeImage overloads. Image detection targets clean, screen-rendered or scanned images: arbitrary rotation, mirroring, reflectance reversal, uniform or non-uniform scaling, translation and mild perspective distortion are supported. Micro QR image scanning is a separate, explicitly-typed entry point — QRCodeDecoder continues to scan Standard QR only.</p>
+          </details>
+          <div class="members">
+            <div class="member" data-text="public static bool trydecode(microqrcodedata data, out string text); decodes the text content from micro qr code data. ">
+              <code>public static bool TryDecode(MicroQRCodeData data, out string text);</code>
+              <p class="doc">Decodes the text content from Micro QR code data.</p>
+            </div>
+            <div class="member" data-text="public static bool trydecode(microqrcodedata data, out string text, out microqrcodedecodeinfo info); decodes the text content from micro qr code data, with diagnostic information. ">
+              <code>public static bool TryDecode(MicroQRCodeData data, out string text, out MicroQRCodeDecodeInfo info);</code>
+              <p class="doc">Decodes the text content from Micro QR code data, with diagnostic information.</p>
+            </div>
+            <div class="member" data-text="public static bool trydecode(readonlyspan&lt;byte&gt; modules, int size, span&lt;char&gt; destination, out int charswritten, out microqrcodedecodeinfo info); decodes the text content from a module matrix into a caller-provided buffer without per-call heap allocation. ">
+              <code>public static bool TryDecode(ReadOnlySpan&lt;byte&gt; modules, int size, Span&lt;char&gt; destination, out int charsWritten, out MicroQRCodeDecodeInfo info);</code>
+              <p class="doc">Decodes the text content from a module matrix into a caller-provided buffer without per-call heap allocation.</p>
+            </div>
+            <div class="member" data-text="public static bool trydecode(readonlyspan&lt;byte&gt; modules, int size, out string text, out microqrcodedecodeinfo info); decodes the text content from a module matrix. ">
+              <code>public static bool TryDecode(ReadOnlySpan&lt;byte&gt; modules, int size, out string text, out MicroQRCodeDecodeInfo info);</code>
+              <p class="doc">Decodes the text content from a module matrix.</p>
+            </div>
+            <div class="member" data-text="public static bool trydecode(skbitmap bitmap, out string text); detects and decodes a micro qr code from a bitmap image. targets clean, well-lit images such as screenshots, rendered symbols and scans: arbitrary rotation, mirroring, reflectance reversal (light-on-dark), uniform or non-uniform scaling, translation and mild perspective distortion are handled. strong perspective, uneven lighting and blur are out of scope.">
+              <code>public static bool TryDecode(SKBitmap bitmap, out string text);</code>
+              <p class="doc">Detects and decodes a Micro QR code from a bitmap image.</p>
+              <details class="notes" data-text="targets clean, well-lit images such as screenshots, rendered symbols and scans: arbitrary rotation, mirroring, reflectance reversal (light-on-dark), uniform or non-uniform scaling, translation and mild perspective distortion are handled. strong perspective, uneven lighting and blur are out of scope.">
+                <summary>Notes</summary>
+                <p class="doc remarks">Targets clean, well-lit images such as screenshots, rendered symbols and scans: arbitrary rotation, mirroring, reflectance reversal (light-on-dark), uniform or non-uniform scaling, translation and mild perspective distortion are handled. Strong perspective, uneven lighting and blur are out of scope.</p>
+              </details>
+            </div>
+            <div class="member" data-text="public static bool trydecode(skbitmap bitmap, out string text, out microqrcodedecodeinfo info); detects and decodes a micro qr code from a bitmap image, with diagnostic information. see trydecode for the supported image envelope.">
+              <code>public static bool TryDecode(SKBitmap bitmap, out string text, out MicroQRCodeDecodeInfo info);</code>
+              <p class="doc">Detects and decodes a Micro QR code from a bitmap image, with diagnostic information.</p>
+              <details class="notes" data-text="see trydecode for the supported image envelope.">
+                <summary>Notes</summary>
+                <p class="doc remarks">See TryDecode for the supported image envelope.</p>
+              </details>
+            </div>
+            <div class="member" data-text="public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, span&lt;char&gt; destination, out int charswritten, out microqrcodedecodeinfo info); detects and decodes a micro qr code from grayscale image pixels into a caller-provided buffer without per-call heap allocation. ">
+              <code>public static bool TryDecodeImage(ReadOnlySpan&lt;byte&gt; luminance, int width, int height, Span&lt;char&gt; destination, out int charsWritten, out MicroQRCodeDecodeInfo info);</code>
+              <p class="doc">Detects and decodes a Micro QR code from grayscale image pixels into a caller-provided buffer without per-call heap allocation.</p>
+            </div>
+            <div class="member" data-text="public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, out string text, out microqrcodedecodeinfo info); detects and decodes a micro qr code from grayscale image pixels. ">
+              <code>public static bool TryDecodeImage(ReadOnlySpan&lt;byte&gt; luminance, int width, int height, out string text, out MicroQRCodeDecodeInfo info);</code>
+              <p class="doc">Detects and decodes a Micro QR code from grayscale image pixels.</p>
+            </div>
+            <div class="member" data-text="public static int getmaxdecodedlength(microqrversion version); calculates the maximum possible decoded character count for a micro qr version, across all ecc levels and encoding modes. use to size the destination buffer for the allocation-free trydecode overload. ">
+              <code>public static int GetMaxDecodedLength(MicroQRVersion version);</code>
+              <p class="doc">Calculates the maximum possible decoded character count for a Micro QR version, across all ECC levels and encoding modes. Use to size the destination buffer for the allocation-free TryDecode overload.</p>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.MicroQRCodeGenerator" data-name="skiasharp.qrcode.microqrcodegenerator" data-text="skiasharp.qrcode.microqrcodegenerator public static class microqrcodegenerator micro qr code generator based on iso/iec 18004 (versions m1-m4). micro qr constraints enforced by this generator (they differ per version, so invalid combinations throw instead of silently degrading): m1: numeric mode only, errordetectiononly only.m2: numeric/alphanumeric, ecc l or m.m3: numeric/alphanumeric/byte, ecc l or m.m4: numeric/alphanumeric/byte, ecc l, m or q. micro qr has no eci mode; text that is not iso-8859-1-representable is encoded as raw utf-8 bytes in byte mode. kanji mode is not written; microqrcodedecoder does read the kanji segments (m3 and m4) that other encoders produce, so the two directions are deliberately asymmetric. [obsolete] public static microqrcodecalculatedsize getrequiredbuffersize(readonlyspan&lt;char&gt; text, microqrecclevel ecclevel, microqrversion? requestedversion = null, int quietzonesize = 2); calculates the required buffer size for encoding the specified text as a micro qr code.  public static microqrcodedata createmicroqrcode(readonlyspan&lt;char&gt; textspan, microqrecclevel ecclevel, microqrversion? requestedversion = null, int quietzonesize = 2);  public static microqrcodedata createmicroqrcode(readonlyspan&lt;char&gt; textspan, microqrecclevel ecclevel, in microqrcodegeneratoroptions options);  public static microqrcodedata createmicroqrcode(string plaintext, microqrecclevel ecclevel, microqrversion? requestedversion = null, int quietzonesize = 2); creates a micro qr code from the provided plain text.  public static microqrcodedata createmicroqrcode(string plaintext, microqrecclevel ecclevel, in microqrcodegeneratoroptions options);  public static bool trygetrequiredbuffersize(readonlyspan&lt;char&gt; text, microqrecclevel ecclevel, out microqrcodecalculatedsize size, in microqrcodegeneratoroptions options = null); calculates the required buffer size, matrix size and version for encoding the specified text as a micro qr code, reporting content that does not fit as false rather than as an exception. false means the content does not fit, which here includes an encoding mode the version or ecc level does not offer, since the text is what picks the mode. argument errors throw (rationale: specs/rmqr-encoder.md), and so does a version range that offers ecclevel on no version at all, which no content could satisfy. micro qr m1 holds 5 digits, so an overflow is an ordinary answer here. pass the same options you will encode with: segmentation can select a different version, so a buffer sized for one can be too small for the other. public static int createmicroqrcode(readonlyspan&lt;char&gt; textspan, microqrecclevel ecclevel, span&lt;byte&gt; destination, microqrversion? requestedversion = null, int quietzonesize = 2); creates a micro qr code and writes the module matrix into the caller-provided buffer without per-call heap allocation. output format matches createqrcode : one byte per module (0 = light, 1 = dark), flat row-major, quiet zone included. use trygetrequiredbuffersize to size the destination. public static int createmicroqrcode(readonlyspan&lt;char&gt; textspan, microqrecclevel ecclevel, span&lt;byte&gt; destination, in microqrcodegeneratoroptions options); ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.MicroQRCodeGenerator" aria-label="Link to SkiaSharp.QrCode.MicroQRCodeGenerator">#</a><code>public static class MicroQRCodeGenerator</code></h3>
+          <p class="doc">Micro QR code generator based on ISO/IEC 18004 (versions M1-M4).</p>
+          <details class="notes" data-text="micro qr constraints enforced by this generator (they differ per version, so invalid combinations throw instead of silently degrading): m1: numeric mode only, errordetectiononly only.m2: numeric/alphanumeric, ecc l or m.m3: numeric/alphanumeric/byte, ecc l or m.m4: numeric/alphanumeric/byte, ecc l, m or q. micro qr has no eci mode; text that is not iso-8859-1-representable is encoded as raw utf-8 bytes in byte mode. kanji mode is not written; microqrcodedecoder does read the kanji segments (m3 and m4) that other encoders produce, so the two directions are deliberately asymmetric.">
+            <summary>Notes</summary>
+            <p class="doc remarks">Micro QR constraints enforced by this generator (they differ per version, so invalid combinations throw instead of silently degrading): M1: Numeric mode only, ErrorDetectionOnly only.M2: Numeric/Alphanumeric, ECC L or M.M3: Numeric/Alphanumeric/Byte, ECC L or M.M4: Numeric/Alphanumeric/Byte, ECC L, M or Q. Micro QR has no ECI mode; text that is not ISO-8859-1-representable is encoded as raw UTF-8 bytes in Byte mode. Kanji mode is not written; MicroQRCodeDecoder does read the Kanji segments (M3 and M4) that other encoders produce, so the two directions are deliberately asymmetric.</p>
+          </details>
+          <div class="members">
+            <div class="member" data-text="public static microqrcodecalculatedsize getrequiredbuffersize(readonlyspan&lt;char&gt; text, microqrecclevel ecclevel, microqrversion? requestedversion = null, int quietzonesize = 2); calculates the required buffer size for encoding the specified text as a micro qr code. ">
+              <code>public static MicroQRCodeCalculatedSize GetRequiredBufferSize(ReadOnlySpan&lt;char&gt; text, MicroQREccLevel eccLevel, MicroQRVersion? requestedVersion = null, int quietZoneSize = 2);</code> <span class="tag">obsolete</span>
+              <p class="doc">Calculates the required buffer size for encoding the specified text as a Micro QR code.</p>
+            </div>
+            <div class="member" data-text="public static microqrcodedata createmicroqrcode(readonlyspan&lt;char&gt; textspan, microqrecclevel ecclevel, microqrversion? requestedversion = null, int quietzonesize = 2); ">
+              <code>public static MicroQRCodeData CreateMicroQRCode(ReadOnlySpan&lt;char&gt; textSpan, MicroQREccLevel eccLevel, MicroQRVersion? requestedVersion = null, int quietZoneSize = 2);</code>
+            </div>
+            <div class="member" data-text="public static microqrcodedata createmicroqrcode(readonlyspan&lt;char&gt; textspan, microqrecclevel ecclevel, in microqrcodegeneratoroptions options); ">
+              <code>public static MicroQRCodeData CreateMicroQRCode(ReadOnlySpan&lt;char&gt; textSpan, MicroQREccLevel eccLevel, in MicroQRCodeGeneratorOptions options);</code>
+            </div>
+            <div class="member" data-text="public static microqrcodedata createmicroqrcode(string plaintext, microqrecclevel ecclevel, microqrversion? requestedversion = null, int quietzonesize = 2); creates a micro qr code from the provided plain text. ">
+              <code>public static MicroQRCodeData CreateMicroQRCode(string plainText, MicroQREccLevel eccLevel, MicroQRVersion? requestedVersion = null, int quietZoneSize = 2);</code>
+              <p class="doc">Creates a Micro QR code from the provided plain text.</p>
+            </div>
+            <div class="member" data-text="public static microqrcodedata createmicroqrcode(string plaintext, microqrecclevel ecclevel, in microqrcodegeneratoroptions options); ">
+              <code>public static MicroQRCodeData CreateMicroQRCode(string plainText, MicroQREccLevel eccLevel, in MicroQRCodeGeneratorOptions options);</code>
+            </div>
+            <div class="member" data-text="public static bool trygetrequiredbuffersize(readonlyspan&lt;char&gt; text, microqrecclevel ecclevel, out microqrcodecalculatedsize size, in microqrcodegeneratoroptions options = null); calculates the required buffer size, matrix size and version for encoding the specified text as a micro qr code, reporting content that does not fit as false rather than as an exception. false means the content does not fit, which here includes an encoding mode the version or ecc level does not offer, since the text is what picks the mode. argument errors throw (rationale: specs/rmqr-encoder.md), and so does a version range that offers ecclevel on no version at all, which no content could satisfy. micro qr m1 holds 5 digits, so an overflow is an ordinary answer here. pass the same options you will encode with: segmentation can select a different version, so a buffer sized for one can be too small for the other.">
+              <code>public static bool TryGetRequiredBufferSize(ReadOnlySpan&lt;char&gt; text, MicroQREccLevel eccLevel, out MicroQRCodeCalculatedSize size, in MicroQRCodeGeneratorOptions options = null);</code>
+              <p class="doc">Calculates the required buffer size, matrix size and version for encoding the specified text as a Micro QR code, reporting content that does not fit as false rather than as an exception.</p>
+              <details class="notes" data-text="false means the content does not fit, which here includes an encoding mode the version or ecc level does not offer, since the text is what picks the mode. argument errors throw (rationale: specs/rmqr-encoder.md), and so does a version range that offers ecclevel on no version at all, which no content could satisfy. micro qr m1 holds 5 digits, so an overflow is an ordinary answer here. pass the same options you will encode with: segmentation can select a different version, so a buffer sized for one can be too small for the other.">
+                <summary>Notes</summary>
+                <p class="doc remarks">false means the content does not fit, which here includes an encoding mode the version or ECC level does not offer, since the text is what picks the mode. Argument errors throw (rationale: specs/rmqr-encoder.md), and so does a Version range that offers eccLevel on no version at all, which no content could satisfy. Micro QR M1 holds 5 digits, so an overflow is an ordinary answer here. Pass the same options you will encode with: Segmentation can select a different version, so a buffer sized for one can be too small for the other.</p>
+              </details>
+            </div>
+            <div class="member" data-text="public static int createmicroqrcode(readonlyspan&lt;char&gt; textspan, microqrecclevel ecclevel, span&lt;byte&gt; destination, microqrversion? requestedversion = null, int quietzonesize = 2); creates a micro qr code and writes the module matrix into the caller-provided buffer without per-call heap allocation. output format matches createqrcode : one byte per module (0 = light, 1 = dark), flat row-major, quiet zone included. use trygetrequiredbuffersize to size the destination.">
+              <code>public static int CreateMicroQRCode(ReadOnlySpan&lt;char&gt; textSpan, MicroQREccLevel eccLevel, Span&lt;byte&gt; destination, MicroQRVersion? requestedVersion = null, int quietZoneSize = 2);</code>
+              <p class="doc">Creates a Micro QR code and writes the module matrix into the caller-provided buffer without per-call heap allocation.</p>
+              <details class="notes" data-text="output format matches createqrcode : one byte per module (0 = light, 1 = dark), flat row-major, quiet zone included. use trygetrequiredbuffersize to size the destination.">
+                <summary>Notes</summary>
+                <p class="doc remarks">Output format matches CreateQrCode : one byte per module (0 = light, 1 = dark), flat row-major, quiet zone included. Use TryGetRequiredBufferSize to size the destination.</p>
+              </details>
+            </div>
+            <div class="member" data-text="public static int createmicroqrcode(readonlyspan&lt;char&gt; textspan, microqrecclevel ecclevel, span&lt;byte&gt; destination, in microqrcodegeneratoroptions options); ">
+              <code>public static int CreateMicroQRCode(ReadOnlySpan&lt;char&gt; textSpan, MicroQREccLevel eccLevel, Span&lt;byte&gt; destination, in MicroQRCodeGeneratorOptions options);</code>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.MicroQRCodeGeneratorOptions" data-name="skiasharp.qrcode.microqrcodegeneratoroptions" data-text="skiasharp.qrcode.microqrcodegeneratoroptions public readonly struct microqrcodegeneratoroptions : iequatable&lt;microqrcodegeneratoroptions&gt; optional settings for microqrcodegenerator . default is the complete default configuration (automatic version, 2-module quiet zone), so set only what you need: new microqrcodegeneratoroptions { version = microqrversion.m3, quietzonesize = 0 }. the smallest option set of the three symbologies: micro qr has no eci, and no fit strategy because m1-m4 are totally ordered by capacity. public microqrsegmentation segmentation { get; init; } how the content is split into encoding-mode segments (see microqrsegmentation ). defaults to single . optimal never selects a larger version, and emits the identical bit stream when a split would not shrink the symbol. size a destination buffer with the same value you encode with.  public microqrversionrange version { get; init; } the versions the generator may choose from. defaults to any ; a microqrversion or its nullable converts implicitly, so a null means automatic.  public int quietzonesize { get; init; } quiet zone width in modules. defaults to 2, the iso/iec 18004 value for micro qr; 0 is valid.  public int? maskpattern { get; init; } pin one of the four micro qr data mask patterns (0-3, iso/iec 18004 table 10) instead of the automatic edge-score selection. null (the default) selects the highest-scoring pattern. any pattern yields a valid, decodable symbol; the automatic choice merely optimizes scan reliability. for reproducing a symbol produced elsewhere byte-for-byte (the pattern another encoder chose is reported by maskpattern ), and for exercising a decoder against all four patterns. micro qr numbers its patterns 0-3; they are not the standard qr patterns of the same index. like version , an invalid value is an argument error and is rejected here rather than when a generator reads it. public static microqrcodegeneratoroptions default { get; } the default configuration, identical to default. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.MicroQRCodeGeneratorOptions" aria-label="Link to SkiaSharp.QrCode.MicroQRCodeGeneratorOptions">#</a><code>public readonly struct MicroQRCodeGeneratorOptions : IEquatable&lt;MicroQRCodeGeneratorOptions&gt;</code></h3>
+          <p class="doc">Optional settings for MicroQRCodeGenerator . default is the complete default configuration (automatic version, 2-module quiet zone), so set only what you need: new MicroQRCodeGeneratorOptions { Version = MicroQRVersion.M3, QuietZoneSize = 0 }.</p>
+          <details class="notes" data-text="the smallest option set of the three symbologies: micro qr has no eci, and no fit strategy because m1-m4 are totally ordered by capacity.">
+            <summary>Notes</summary>
+            <p class="doc remarks">The smallest option set of the three symbologies: Micro QR has no ECI, and no fit strategy because M1-M4 are totally ordered by capacity.</p>
+          </details>
+          <div class="members">
+            <div class="member" data-text="public microqrsegmentation segmentation { get; init; } how the content is split into encoding-mode segments (see microqrsegmentation ). defaults to single . optimal never selects a larger version, and emits the identical bit stream when a split would not shrink the symbol. size a destination buffer with the same value you encode with. ">
+              <code>public MicroQRSegmentation Segmentation { get; init; }</code>
+              <p class="doc">How the content is split into encoding-mode segments (see MicroQRSegmentation ). Defaults to Single . Optimal never selects a larger version, and emits the identical bit stream when a split would not shrink the symbol. Size a destination buffer with the same value you encode with.</p>
+            </div>
+            <div class="member" data-text="public microqrversionrange version { get; init; } the versions the generator may choose from. defaults to any ; a microqrversion or its nullable converts implicitly, so a null means automatic. ">
+              <code>public MicroQRVersionRange Version { get; init; }</code>
+              <p class="doc">The versions the generator may choose from. Defaults to Any ; a MicroQRVersion or its nullable converts implicitly, so a null means automatic.</p>
+            </div>
+            <div class="member" data-text="public int quietzonesize { get; init; } quiet zone width in modules. defaults to 2, the iso/iec 18004 value for micro qr; 0 is valid. ">
+              <code>public int QuietZoneSize { get; init; }</code>
+              <p class="doc">Quiet zone width in modules. Defaults to 2, the ISO/IEC 18004 value for Micro QR; 0 is valid.</p>
+            </div>
+            <div class="member" data-text="public int? maskpattern { get; init; } pin one of the four micro qr data mask patterns (0-3, iso/iec 18004 table 10) instead of the automatic edge-score selection. null (the default) selects the highest-scoring pattern. any pattern yields a valid, decodable symbol; the automatic choice merely optimizes scan reliability. for reproducing a symbol produced elsewhere byte-for-byte (the pattern another encoder chose is reported by maskpattern ), and for exercising a decoder against all four patterns. micro qr numbers its patterns 0-3; they are not the standard qr patterns of the same index. like version , an invalid value is an argument error and is rejected here rather than when a generator reads it.">
+              <code>public int? MaskPattern { get; init; }</code>
+              <p class="doc">Pin one of the four Micro QR data mask patterns (0-3, ISO/IEC 18004 Table 10) instead of the automatic edge-score selection. null (the default) selects the highest-scoring pattern. Any pattern yields a valid, decodable symbol; the automatic choice merely optimizes scan reliability.</p>
+              <details class="notes" data-text="for reproducing a symbol produced elsewhere byte-for-byte (the pattern another encoder chose is reported by maskpattern ), and for exercising a decoder against all four patterns. micro qr numbers its patterns 0-3; they are not the standard qr patterns of the same index. like version , an invalid value is an argument error and is rejected here rather than when a generator reads it.">
+                <summary>Notes</summary>
+                <p class="doc remarks">For reproducing a symbol produced elsewhere byte-for-byte (the pattern another encoder chose is reported by MaskPattern ), and for exercising a decoder against all four patterns. Micro QR numbers its patterns 0-3; they are not the Standard QR patterns of the same index. Like Version , an invalid value is an argument error and is rejected here rather than when a generator reads it.</p>
+              </details>
+            </div>
+            <div class="member" data-text="public static microqrcodegeneratoroptions default { get; } the default configuration, identical to default. ">
+              <code>public static MicroQRCodeGeneratorOptions Default { get; }</code>
+              <p class="doc">The default configuration, identical to default.</p>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.MicroQREccLevel" data-name="skiasharp.qrcode.microqrecclevel" data-text="skiasharp.qrcode.microqrecclevel public enum microqrecclevel : int micro qr code error correction level (iso/iec 18004). micro qr levels differ from standard qr ecclevel : version m1 supports error detection only, and level h does not exist.  errordetectiononly = 0, error detection only, no correction capacity. valid only for version m1.  l = 1, ~7% recovery capacity. valid for versions m2-m4.  m = 2, ~15% recovery capacity. valid for versions m2-m4.  q = 3, ~25% recovery capacity. valid for version m4 only. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.MicroQREccLevel" aria-label="Link to SkiaSharp.QrCode.MicroQREccLevel">#</a><code>public enum MicroQREccLevel : int</code></h3>
+          <p class="doc">Micro QR Code error correction level (ISO/IEC 18004). Micro QR levels differ from Standard QR ECCLevel : version M1 supports error detection only, and level H does not exist.</p>
+          <div class="members">
+            <div class="member" data-text="errordetectiononly = 0, error detection only, no correction capacity. valid only for version m1. ">
+              <code>ErrorDetectionOnly = 0,</code>
+              <p class="doc">Error detection only, no correction capacity. Valid only for version M1.</p>
+            </div>
+            <div class="member" data-text="l = 1, ~7% recovery capacity. valid for versions m2-m4. ">
+              <code>L = 1,</code>
+              <p class="doc">~7% recovery capacity. Valid for versions M2-M4.</p>
+            </div>
+            <div class="member" data-text="m = 2, ~15% recovery capacity. valid for versions m2-m4. ">
+              <code>M = 2,</code>
+              <p class="doc">~15% recovery capacity. Valid for versions M2-M4.</p>
+            </div>
+            <div class="member" data-text="q = 3, ~25% recovery capacity. valid for version m4 only. ">
+              <code>Q = 3,</code>
+              <p class="doc">~25% recovery capacity. Valid for version M4 only.</p>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.MicroQRSegmentation" data-name="skiasharp.qrcode.microqrsegmentation" data-text="skiasharp.qrcode.microqrsegmentation public enum microqrsegmentation : int how microqrcodegenerator splits the content into encoding-mode segments. micro qr capacities are tiny (5 digits at m1, 15 byte-mode characters at m4-l), so mixing modes (for example a short prefix followed by a numeric tail) can drop the symbol a version, or encode content no single mode fits at all.  single = 0, one segment in the single mode that can represent the whole content (numeric, else alphanumeric, else byte). the default, and the cheapest to encode.  optimal = 1, the mixed-mode split with the fewest total bits. never selects a larger version than single , emits the single bit stream verbatim when a split would not shrink the symbol, and additionally encodes content that overflows every version in a single mode — unless the minimal-bit plan would be misread on decode (a relocated byte order mark, or a latin-1 run the charset heuristic would read as utf-8), in which case it reports &quot;does not fit&quot; rather than emitting a stream that decodes differently. opt-in because it prices candidate versions; the search allocates nothing (micro qr content never exceeds 35 characters). the plan respects each version's mode set — m1 is numeric-only and m2 has no byte mode — so a version is never selected for a plan whose runs it cannot carry. size buffers with the same segmentation you encode with, the two can select different versions.">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.MicroQRSegmentation" aria-label="Link to SkiaSharp.QrCode.MicroQRSegmentation">#</a><code>public enum MicroQRSegmentation : int</code></h3>
+          <p class="doc">How MicroQRCodeGenerator splits the content into encoding-mode segments. Micro QR capacities are tiny (5 digits at M1, 15 Byte-mode characters at M4-L), so mixing modes (for example a short prefix followed by a numeric tail) can drop the symbol a version, or encode content no single mode fits at all.</p>
+          <div class="members">
+            <div class="member" data-text="single = 0, one segment in the single mode that can represent the whole content (numeric, else alphanumeric, else byte). the default, and the cheapest to encode. ">
+              <code>Single = 0,</code>
+              <p class="doc">One segment in the single mode that can represent the whole content (Numeric, else Alphanumeric, else Byte). The default, and the cheapest to encode.</p>
+            </div>
+            <div class="member" data-text="optimal = 1, the mixed-mode split with the fewest total bits. never selects a larger version than single , emits the single bit stream verbatim when a split would not shrink the symbol, and additionally encodes content that overflows every version in a single mode — unless the minimal-bit plan would be misread on decode (a relocated byte order mark, or a latin-1 run the charset heuristic would read as utf-8), in which case it reports &quot;does not fit&quot; rather than emitting a stream that decodes differently. opt-in because it prices candidate versions; the search allocates nothing (micro qr content never exceeds 35 characters). the plan respects each version's mode set — m1 is numeric-only and m2 has no byte mode — so a version is never selected for a plan whose runs it cannot carry. size buffers with the same segmentation you encode with, the two can select different versions.">
+              <code>Optimal = 1,</code>
+              <p class="doc">The mixed-mode split with the fewest total bits. Never selects a larger version than Single , emits the Single bit stream verbatim when a split would not shrink the symbol, and additionally encodes content that overflows every version in a single mode — unless the minimal-bit plan would be misread on decode (a relocated byte order mark, or a Latin-1 run the charset heuristic would read as UTF-8), in which case it reports &quot;does not fit&quot; rather than emitting a stream that decodes differently.</p>
+              <details class="notes" data-text="opt-in because it prices candidate versions; the search allocates nothing (micro qr content never exceeds 35 characters). the plan respects each version's mode set — m1 is numeric-only and m2 has no byte mode — so a version is never selected for a plan whose runs it cannot carry. size buffers with the same segmentation you encode with, the two can select different versions.">
+                <summary>Notes</summary>
+                <p class="doc remarks">Opt-in because it prices candidate versions; the search allocates nothing (Micro QR content never exceeds 35 characters). The plan respects each version's mode set — M1 is Numeric-only and M2 has no Byte mode — so a version is never selected for a plan whose runs it cannot carry. Size buffers with the same segmentation you encode with, the two can select different versions.</p>
+              </details>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.MicroQRVersion" data-name="skiasharp.qrcode.microqrversion" data-text="skiasharp.qrcode.microqrversion public enum microqrversion : int micro qr code symbol version (iso/iec 18004). determines symbol size: m1 = 11×11, m2 = 13×13, m3 = 15×15, m4 = 17×17 modules.  m1 = 1, 11×11 modules. numeric mode only, error detection only.  m2 = 2, 13×13 modules. numeric and alphanumeric modes, ecc l/m.  m3 = 3, 15×15 modules. numeric, alphanumeric and byte modes, ecc l/m.  m4 = 4, 17×17 modules. numeric, alphanumeric and byte modes, ecc l/m/q. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.MicroQRVersion" aria-label="Link to SkiaSharp.QrCode.MicroQRVersion">#</a><code>public enum MicroQRVersion : int</code></h3>
+          <p class="doc">Micro QR Code symbol version (ISO/IEC 18004). Determines symbol size: M1 = 11×11, M2 = 13×13, M3 = 15×15, M4 = 17×17 modules.</p>
+          <div class="members">
+            <div class="member" data-text="m1 = 1, 11×11 modules. numeric mode only, error detection only. ">
+              <code>M1 = 1,</code>
+              <p class="doc">11×11 modules. Numeric mode only, error detection only.</p>
+            </div>
+            <div class="member" data-text="m2 = 2, 13×13 modules. numeric and alphanumeric modes, ecc l/m. ">
+              <code>M2 = 2,</code>
+              <p class="doc">13×13 modules. Numeric and Alphanumeric modes, ECC L/M.</p>
+            </div>
+            <div class="member" data-text="m3 = 3, 15×15 modules. numeric, alphanumeric and byte modes, ecc l/m. ">
+              <code>M3 = 3,</code>
+              <p class="doc">15×15 modules. Numeric, Alphanumeric and Byte modes, ECC L/M.</p>
+            </div>
+            <div class="member" data-text="m4 = 4, 17×17 modules. numeric, alphanumeric and byte modes, ecc l/m/q. ">
+              <code>M4 = 4,</code>
+              <p class="doc">17×17 modules. Numeric, Alphanumeric and Byte modes, ECC L/M/Q.</p>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.MicroQRVersionRange" data-name="skiasharp.qrcode.microqrversionrange" data-text="skiasharp.qrcode.microqrversionrange public readonly struct microqrversionrange : iequatable&lt;microqrversionrange&gt; the micro qr versions a generator may choose from: the smallest one in the range that holds the content is used. the micro qr counterpart of qrcodeversionrange . m1-m4 differ in the modes and ecc levels they offer, not only in capacity, so a range can leave nothing usable for two reasons. no version offering the requested ecc level is a contradiction and throws; none carrying the mode the text needs is a poor fit and returns false, since the text is what picks the mode. public const microqrversion maxversion; the highest micro qr version, m4.  public const microqrversion minversion; the lowest micro qr version, m1.  public microqrversionrange(microqrversion min, microqrversion max); an inclusive range from min to max .  public microqrversion max { get; } the highest permitted version (m4 when unbounded above).  public microqrversion min { get; } the lowest permitted version (m1 when unbounded below).  public bool isany { get; } whether this range constrains nothing (the default).  public bool isexact { get; } whether this range pins a single version.  public static microqrversionrange any { get; } every version, m1 to m4. identical to default.  public bool contains(microqrversion version); whether version falls inside this range.  public override string tostring();  public static microqrversionrange atleast(microqrversion version); version or larger.  public static microqrversionrange atmost(microqrversion version); version or smaller.  public static microqrversionrange between(microqrversion min, microqrversion max); an inclusive range from min to max .  public static microqrversionrange exactly(microqrversion version); exactly version , with no automatic selection.  public static microqrversionrange op_implicit(microqrversion version); a single version, as exactly .  public static microqrversionrange op_implicit(microqrversion? version); a single version, or any when there is none, so an optional version needs no branch. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.MicroQRVersionRange" aria-label="Link to SkiaSharp.QrCode.MicroQRVersionRange">#</a><code>public readonly struct MicroQRVersionRange : IEquatable&lt;MicroQRVersionRange&gt;</code></h3>
+          <p class="doc">The Micro QR versions a generator may choose from: the smallest one in the range that holds the content is used. The Micro QR counterpart of QRCodeVersionRange .</p>
+          <details class="notes" data-text="m1-m4 differ in the modes and ecc levels they offer, not only in capacity, so a range can leave nothing usable for two reasons. no version offering the requested ecc level is a contradiction and throws; none carrying the mode the text needs is a poor fit and returns false, since the text is what picks the mode.">
+            <summary>Notes</summary>
+            <p class="doc remarks">M1-M4 differ in the modes and ECC levels they offer, not only in capacity, so a range can leave nothing usable for two reasons. No version offering the requested ECC level is a contradiction and throws; none carrying the mode the text needs is a poor fit and returns false, since the text is what picks the mode.</p>
+          </details>
+          <div class="members">
+            <div class="member" data-text="public const microqrversion maxversion; the highest micro qr version, m4. ">
+              <code>public const MicroQRVersion MaxVersion;</code>
+              <p class="doc">The highest Micro QR version, M4.</p>
+            </div>
+            <div class="member" data-text="public const microqrversion minversion; the lowest micro qr version, m1. ">
+              <code>public const MicroQRVersion MinVersion;</code>
+              <p class="doc">The lowest Micro QR version, M1.</p>
+            </div>
+            <div class="member" data-text="public microqrversionrange(microqrversion min, microqrversion max); an inclusive range from min to max . ">
+              <code>public MicroQRVersionRange(MicroQRVersion min, MicroQRVersion max);</code>
+              <p class="doc">An inclusive range from min to max .</p>
+            </div>
+            <div class="member" data-text="public microqrversion max { get; } the highest permitted version (m4 when unbounded above). ">
+              <code>public MicroQRVersion Max { get; }</code>
+              <p class="doc">The highest permitted version (M4 when unbounded above).</p>
+            </div>
+            <div class="member" data-text="public microqrversion min { get; } the lowest permitted version (m1 when unbounded below). ">
+              <code>public MicroQRVersion Min { get; }</code>
+              <p class="doc">The lowest permitted version (M1 when unbounded below).</p>
+            </div>
+            <div class="member" data-text="public bool isany { get; } whether this range constrains nothing (the default). ">
+              <code>public bool IsAny { get; }</code>
+              <p class="doc">Whether this range constrains nothing (the default).</p>
+            </div>
+            <div class="member" data-text="public bool isexact { get; } whether this range pins a single version. ">
+              <code>public bool IsExact { get; }</code>
+              <p class="doc">Whether this range pins a single version.</p>
+            </div>
+            <div class="member" data-text="public static microqrversionrange any { get; } every version, m1 to m4. identical to default. ">
+              <code>public static MicroQRVersionRange Any { get; }</code>
+              <p class="doc">Every version, M1 to M4. Identical to default.</p>
+            </div>
+            <div class="member" data-text="public bool contains(microqrversion version); whether version falls inside this range. ">
+              <code>public bool Contains(MicroQRVersion version);</code>
+              <p class="doc">Whether version falls inside this range.</p>
+            </div>
+            <div class="member" data-text="public override string tostring(); ">
+              <code>public override string ToString();</code>
+            </div>
+            <div class="member" data-text="public static microqrversionrange atleast(microqrversion version); version or larger. ">
+              <code>public static MicroQRVersionRange AtLeast(MicroQRVersion version);</code>
+              <p class="doc">version or larger.</p>
+            </div>
+            <div class="member" data-text="public static microqrversionrange atmost(microqrversion version); version or smaller. ">
+              <code>public static MicroQRVersionRange AtMost(MicroQRVersion version);</code>
+              <p class="doc">version or smaller.</p>
+            </div>
+            <div class="member" data-text="public static microqrversionrange between(microqrversion min, microqrversion max); an inclusive range from min to max . ">
+              <code>public static MicroQRVersionRange Between(MicroQRVersion min, MicroQRVersion max);</code>
+              <p class="doc">An inclusive range from min to max .</p>
+            </div>
+            <div class="member" data-text="public static microqrversionrange exactly(microqrversion version); exactly version , with no automatic selection. ">
+              <code>public static MicroQRVersionRange Exactly(MicroQRVersion version);</code>
+              <p class="doc">Exactly version , with no automatic selection.</p>
+            </div>
+            <div class="member" data-text="public static microqrversionrange op_implicit(microqrversion version); a single version, as exactly . ">
+              <code>public static MicroQRVersionRange op_Implicit(MicroQRVersion version);</code>
+              <p class="doc">A single version, as Exactly .</p>
+            </div>
+            <div class="member" data-text="public static microqrversionrange op_implicit(microqrversion? version); a single version, or any when there is none, so an optional version needs no branch. ">
+              <code>public static MicroQRVersionRange op_Implicit(MicroQRVersion? version);</code>
+              <p class="doc">A single version, or Any when there is none, so an optional version needs no branch.</p>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.ModuleRect" data-name="skiasharp.qrcode.modulerect" data-text="skiasharp.qrcode.modulerect public readonly struct modulerect : iequatable&lt;modulerect&gt; an axis-aligned rectangle of dark modules, in module coordinates. produced by the getmodulerectangles family on qrcodedata , microqrcodedata , and rmqrcodedata . coordinates use the same space as the matrix indexer: one unit is one module, origin at the top-left corner of the symbol including its quiet zone, x growing right and y growing down. the module at column c, row r read via data[r, c] corresponds to the unit rectangle at x = c, y = r. renderers map to pixels by multiplying all four values by the pixel size of one module. no scale or pixel size is baked in, so the same value works for svg path data (viewbox in module units), draw calls, and any other coordinate transform the consumer applies. public modulerect(int x, int y, int width, int height); an axis-aligned rectangle of dark modules, in module coordinates. produced by the getmodulerectangles family on qrcodedata , microqrcodedata , and rmqrcodedata . coordinates use the same space as the matrix indexer: one unit is one module, origin at the top-left corner of the symbol including its quiet zone, x growing right and y growing down. the module at column c, row r read via data[r, c] corresponds to the unit rectangle at x = c, y = r. renderers map to pixels by multiplying all four values by the pixel size of one module. no scale or pixel size is baked in, so the same value works for svg path data (viewbox in module units), draw calls, and any other coordinate transform the consumer applies. public int height { get; init; } height in modules (always positive).  public int width { get; init; } width in modules (always positive).  public int x { get; init; } column of the left edge (0-based, including the quiet zone if present).  public int y { get; init; } row of the top edge (0-based, including the quiet zone if present). ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.ModuleRect" aria-label="Link to SkiaSharp.QrCode.ModuleRect">#</a><code>public readonly struct ModuleRect : IEquatable&lt;ModuleRect&gt;</code></h3>
+          <p class="doc">An axis-aligned rectangle of dark modules, in module coordinates. Produced by the GetModuleRectangles family on QRCodeData , MicroQRCodeData , and RmQRCodeData .</p>
+          <details class="notes" data-text="coordinates use the same space as the matrix indexer: one unit is one module, origin at the top-left corner of the symbol including its quiet zone, x growing right and y growing down. the module at column c, row r read via data[r, c] corresponds to the unit rectangle at x = c, y = r. renderers map to pixels by multiplying all four values by the pixel size of one module. no scale or pixel size is baked in, so the same value works for svg path data (viewbox in module units), draw calls, and any other coordinate transform the consumer applies.">
+            <summary>Notes</summary>
+            <p class="doc remarks">Coordinates use the same space as the matrix indexer: one unit is one module, origin at the top-left corner of the symbol including its quiet zone, X growing right and Y growing down. The module at column c, row r read via data[r, c] corresponds to the unit rectangle at X = c, Y = r. Renderers map to pixels by multiplying all four values by the pixel size of one module. No scale or pixel size is baked in, so the same value works for SVG path data (viewBox in module units), draw calls, and any other coordinate transform the consumer applies.</p>
+          </details>
+          <div class="members">
+            <div class="member" data-text="public modulerect(int x, int y, int width, int height); an axis-aligned rectangle of dark modules, in module coordinates. produced by the getmodulerectangles family on qrcodedata , microqrcodedata , and rmqrcodedata . coordinates use the same space as the matrix indexer: one unit is one module, origin at the top-left corner of the symbol including its quiet zone, x growing right and y growing down. the module at column c, row r read via data[r, c] corresponds to the unit rectangle at x = c, y = r. renderers map to pixels by multiplying all four values by the pixel size of one module. no scale or pixel size is baked in, so the same value works for svg path data (viewbox in module units), draw calls, and any other coordinate transform the consumer applies.">
+              <code>public ModuleRect(int X, int Y, int Width, int Height);</code>
+              <p class="doc">An axis-aligned rectangle of dark modules, in module coordinates. Produced by the GetModuleRectangles family on QRCodeData , MicroQRCodeData , and RmQRCodeData .</p>
+              <details class="notes" data-text="coordinates use the same space as the matrix indexer: one unit is one module, origin at the top-left corner of the symbol including its quiet zone, x growing right and y growing down. the module at column c, row r read via data[r, c] corresponds to the unit rectangle at x = c, y = r. renderers map to pixels by multiplying all four values by the pixel size of one module. no scale or pixel size is baked in, so the same value works for svg path data (viewbox in module units), draw calls, and any other coordinate transform the consumer applies.">
+                <summary>Notes</summary>
+                <p class="doc remarks">Coordinates use the same space as the matrix indexer: one unit is one module, origin at the top-left corner of the symbol including its quiet zone, X growing right and Y growing down. The module at column c, row r read via data[r, c] corresponds to the unit rectangle at X = c, Y = r. Renderers map to pixels by multiplying all four values by the pixel size of one module. No scale or pixel size is baked in, so the same value works for SVG path data (viewBox in module units), draw calls, and any other coordinate transform the consumer applies.</p>
+              </details>
+            </div>
+            <div class="member" data-text="public int height { get; init; } height in modules (always positive). ">
+              <code>public int Height { get; init; }</code>
+              <p class="doc">Height in modules (always positive).</p>
+            </div>
+            <div class="member" data-text="public int width { get; init; } width in modules (always positive). ">
+              <code>public int Width { get; init; }</code>
+              <p class="doc">Width in modules (always positive).</p>
+            </div>
+            <div class="member" data-text="public int x { get; init; } column of the left edge (0-based, including the quiet zone if present). ">
+              <code>public int X { get; init; }</code>
+              <p class="doc">Column of the left edge (0-based, including the quiet zone if present).</p>
+            </div>
+            <div class="member" data-text="public int y { get; init; } row of the top edge (0-based, including the quiet zone if present). ">
+              <code>public int Y { get; init; }</code>
+              <p class="doc">Row of the top edge (0-based, including the quiet zone if present).</p>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.QRCodeCalculatedSize" data-name="skiasharp.qrcode.qrcodecalculatedsize" data-text="skiasharp.qrcode.qrcodecalculatedsize public readonly struct qrcodecalculatedsize : iequatable&lt;qrcodecalculatedsize&gt; calculated qr code size information.  public qrcodecalculatedsize(int buffersize, int qrsize, int version); calculated qr code size information.  public bool isvalid { get; } validates that the calculated size values are within acceptable ranges.  public int buffersize { get; init; } required buffer size for the qr code matrix data (in bytes). calculated as qrsize × qrsize.  public int qrsize { get; init; } qr code size in modules per side (including quiet zone if specified)  public int version { get; init; } qr code version (1-40) determined by data capacity requirements ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeCalculatedSize" aria-label="Link to SkiaSharp.QrCode.QRCodeCalculatedSize">#</a><code>public readonly struct QRCodeCalculatedSize : IEquatable&lt;QRCodeCalculatedSize&gt;</code></h3>
+          <p class="doc">Calculated QR code size information.</p>
+          <div class="members">
+            <div class="member" data-text="public qrcodecalculatedsize(int buffersize, int qrsize, int version); calculated qr code size information. ">
+              <code>public QRCodeCalculatedSize(int BufferSize, int QrSize, int Version);</code>
+              <p class="doc">Calculated QR code size information.</p>
+            </div>
+            <div class="member" data-text="public bool isvalid { get; } validates that the calculated size values are within acceptable ranges. ">
+              <code>public bool IsValid { get; }</code>
+              <p class="doc">Validates that the calculated size values are within acceptable ranges.</p>
+            </div>
+            <div class="member" data-text="public int buffersize { get; init; } required buffer size for the qr code matrix data (in bytes). calculated as qrsize × qrsize. ">
+              <code>public int BufferSize { get; init; }</code>
+              <p class="doc">Required buffer size for the QR code matrix data (in bytes). Calculated as QrSize × QrSize.</p>
+            </div>
+            <div class="member" data-text="public int qrsize { get; init; } qr code size in modules per side (including quiet zone if specified) ">
+              <code>public int QrSize { get; init; }</code>
+              <p class="doc">QR code size in modules per side (including quiet zone if specified)</p>
+            </div>
+            <div class="member" data-text="public int version { get; init; } qr code version (1-40) determined by data capacity requirements ">
+              <code>public int Version { get; init; }</code>
+              <p class="doc">QR code version (1-40) determined by data capacity requirements</p>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.QRCodeData" data-name="skiasharp.qrcode.qrcodedata" data-text="skiasharp.qrcode.qrcodedata public class qrcodedata represents qr code data as a 2d boolean matrix. qr code structure: - version: 1-40 (determines size: 21×21 to 177×177) - module matrix: 2d array of boolean values (dark/light) - serialization format: &quot;qrr&quot; header + size + bit-packed data public qrcodedata(readonlyspan&lt;byte&gt; rawdataspan, int quietzonesize); initializes a new instance of the qrcodedata class from serialized raw data. this constructor deserializes qr code data that was previously serialized using getrawdata . the raw data contains only the core qr code modules (excluding quiet zone). data format: &quot;qrr&quot; header (3 bytes) + base size (1 byte) + bit-packed module data the quiet zone (white border) can be added during deserialization by specifying the quietzonesize parameter. this overload is useful for high-performance scenarios where you want to deserialize from existing memory buffers (e.g., memory , arraysegment , or stack-allocated arrays) without allocating a new byte array. public qrcodedata(byte[] rawdata, int quietzonesize); initializes a new instance of the qrcodedata class from serialized raw data. this constructor deserializes qr code data that was previously serialized using getrawdata . the raw data contains only the core qr code modules (excluding quiet zone). data format: &quot;qrr&quot; header (3 bytes) + base size (1 byte) + bit-packed module data the quiet zone (white border) can be added during deserialization by specifying the quietzonesize parameter. public qrcodedata(int version, int quietzonesize); initializes with the specified version.  public bool this[int row, int col] { get; } gets or sets the module state at the specified position. quiet zone positions always read false (the quiet zone is light by definition and is not stored). the internal setter only accepts core positions, quiet zone modules cannot be modified. public int size { get; } gets the size of the qr code matrix (modules per side).  public int version { get; } get the qr code version (1-40)  public modulerect[] getmodulerectangles(); gets the dark modules as merged rectangles in module coordinates, for rendering with any graphics api without skiasharp (svg path data, draw calls, vector output). coordinates use the same space as the indexer (this[row, col]): one unit is one module, origin at the top-left including the quiet zone, x is the column and y is the row. consumers scale by the pixel size of one module; size gives the total extent in modules. three properties are contractual: rectangles never overlap, cover only dark modules, and cover every dark module. the decomposition shape and ordering are unspecified and may change between versions (currently maximal horizontal runs in row-major order, the same merge the built-in renderer draws). public bool isfinderpattern(int row, int col); checks if the specified module position (excluding quiet zone) is part of a finder pattern.  public bool trygetmodulerectangles(span&lt;modulerect&gt; destination, out int written); writes the dark modules as merged rectangles into a caller-provided buffer. same contract as getmodulerectangles without allocations.  public byte[] getrawdata(); serializes the qr code data to a byte array. the serialized data contains only the core qr code modules (excluding quiet zone). the quiet zone can be added when deserializing via the #ctor constructor. format: &quot;qrr&quot; header (3 bytes) + base size (1 byte) + bit-packed module data public int getfinderpatternindex(int row, int col); gets the finder pattern index for the specified module position (excluding quiet zone).  public int getmodulerectanglesmaxcount(); gets an upper bound on the number of rectangles getmodulerectangles can return, suitable for sizing a pooled buffer for trygetmodulerectangles . o(1), no matrix scan.  public int getrawdata(ibufferwriter&lt;byte&gt; writer); writes the serialized qr code data to the specified buffer writer. this method writes only the core qr mode modules (excluding quiet zone). the quiet zone can be added when deserializing via the #ctor constructor. format: &quot;qrr&quot; header (3 bytes) + base size (1 byte) + bit-packed module data this overload is useful for high-performance scenarios where memory allocations need to be minimized, such as response writing or streaming. public int getrawdatasize(); calculates the required buffer size for serialization. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeData" aria-label="Link to SkiaSharp.QrCode.QRCodeData">#</a><code>public class QRCodeData</code></h3>
+          <p class="doc">Represents QR code data as a 2D boolean matrix.</p>
+          <details class="notes" data-text="qr code structure: - version: 1-40 (determines size: 21×21 to 177×177) - module matrix: 2d array of boolean values (dark/light) - serialization format: &quot;qrr&quot; header + size + bit-packed data">
+            <summary>Notes</summary>
+            <p class="doc remarks">QR code structure: - Version: 1-40 (determines size: 21×21 to 177×177) - Module matrix: 2D array of boolean values (dark/light) - Serialization format: &quot;QRR&quot; header + size + bit-packed data</p>
+          </details>
+          <div class="members">
+            <div class="member" data-text="public qrcodedata(readonlyspan&lt;byte&gt; rawdataspan, int quietzonesize); initializes a new instance of the qrcodedata class from serialized raw data. this constructor deserializes qr code data that was previously serialized using getrawdata . the raw data contains only the core qr code modules (excluding quiet zone). data format: &quot;qrr&quot; header (3 bytes) + base size (1 byte) + bit-packed module data the quiet zone (white border) can be added during deserialization by specifying the quietzonesize parameter. this overload is useful for high-performance scenarios where you want to deserialize from existing memory buffers (e.g., memory , arraysegment , or stack-allocated arrays) without allocating a new byte array.">
+              <code>public QRCodeData(ReadOnlySpan&lt;byte&gt; rawDataSpan, int quietZoneSize);</code>
+              <p class="doc">Initializes a new instance of the QRCodeData class from serialized raw data.</p>
+              <details class="notes" data-text="this constructor deserializes qr code data that was previously serialized using getrawdata . the raw data contains only the core qr code modules (excluding quiet zone). data format: &quot;qrr&quot; header (3 bytes) + base size (1 byte) + bit-packed module data the quiet zone (white border) can be added during deserialization by specifying the quietzonesize parameter. this overload is useful for high-performance scenarios where you want to deserialize from existing memory buffers (e.g., memory , arraysegment , or stack-allocated arrays) without allocating a new byte array.">
+                <summary>Notes</summary>
+                <p class="doc remarks">This constructor deserializes QR code data that was previously serialized using GetRawData . The raw data contains only the core QR code modules (excluding quiet zone). Data format: &quot;QRR&quot; header (3 bytes) + base size (1 byte) + bit-packed module data The quiet zone (white border) can be added during deserialization by specifying the quietZoneSize parameter. This overload is useful for high-performance scenarios where you want to deserialize from existing memory buffers (e.g., Memory , ArraySegment , or stack-allocated arrays) without allocating a new byte array.</p>
+              </details>
+            </div>
+            <div class="member" data-text="public qrcodedata(byte[] rawdata, int quietzonesize); initializes a new instance of the qrcodedata class from serialized raw data. this constructor deserializes qr code data that was previously serialized using getrawdata . the raw data contains only the core qr code modules (excluding quiet zone). data format: &quot;qrr&quot; header (3 bytes) + base size (1 byte) + bit-packed module data the quiet zone (white border) can be added during deserialization by specifying the quietzonesize parameter.">
+              <code>public QRCodeData(byte[] rawData, int quietZoneSize);</code>
+              <p class="doc">Initializes a new instance of the QRCodeData class from serialized raw data.</p>
+              <details class="notes" data-text="this constructor deserializes qr code data that was previously serialized using getrawdata . the raw data contains only the core qr code modules (excluding quiet zone). data format: &quot;qrr&quot; header (3 bytes) + base size (1 byte) + bit-packed module data the quiet zone (white border) can be added during deserialization by specifying the quietzonesize parameter.">
+                <summary>Notes</summary>
+                <p class="doc remarks">This constructor deserializes QR code data that was previously serialized using GetRawData . The raw data contains only the core QR code modules (excluding quiet zone). Data format: &quot;QRR&quot; header (3 bytes) + base size (1 byte) + bit-packed module data The quiet zone (white border) can be added during deserialization by specifying the quietZoneSize parameter.</p>
+              </details>
+            </div>
+            <div class="member" data-text="public qrcodedata(int version, int quietzonesize); initializes with the specified version. ">
+              <code>public QRCodeData(int version, int quietZoneSize);</code>
+              <p class="doc">Initializes with the specified version.</p>
+            </div>
+            <div class="member" data-text="public bool this[int row, int col] { get; } gets or sets the module state at the specified position. quiet zone positions always read false (the quiet zone is light by definition and is not stored). the internal setter only accepts core positions, quiet zone modules cannot be modified.">
+              <code>public bool this[int row, int col] { get; }</code>
+              <p class="doc">Gets or sets the module state at the specified position.</p>
+              <details class="notes" data-text="quiet zone positions always read false (the quiet zone is light by definition and is not stored). the internal setter only accepts core positions, quiet zone modules cannot be modified.">
+                <summary>Notes</summary>
+                <p class="doc remarks">Quiet zone positions always read false (the quiet zone is light by definition and is not stored). The internal setter only accepts core positions, quiet zone modules cannot be modified.</p>
+              </details>
+            </div>
+            <div class="member" data-text="public int size { get; } gets the size of the qr code matrix (modules per side). ">
+              <code>public int Size { get; }</code>
+              <p class="doc">Gets the size of the QR code matrix (modules per side).</p>
+            </div>
+            <div class="member" data-text="public int version { get; } get the qr code version (1-40) ">
+              <code>public int Version { get; }</code>
+              <p class="doc">Get the QR code version (1-40)</p>
+            </div>
+            <div class="member" data-text="public modulerect[] getmodulerectangles(); gets the dark modules as merged rectangles in module coordinates, for rendering with any graphics api without skiasharp (svg path data, draw calls, vector output). coordinates use the same space as the indexer (this[row, col]): one unit is one module, origin at the top-left including the quiet zone, x is the column and y is the row. consumers scale by the pixel size of one module; size gives the total extent in modules. three properties are contractual: rectangles never overlap, cover only dark modules, and cover every dark module. the decomposition shape and ordering are unspecified and may change between versions (currently maximal horizontal runs in row-major order, the same merge the built-in renderer draws).">
+              <code>public ModuleRect[] GetModuleRectangles();</code>
+              <p class="doc">Gets the dark modules as merged rectangles in module coordinates, for rendering with any graphics API without SkiaSharp (SVG path data, draw calls, vector output).</p>
+              <details class="notes" data-text="coordinates use the same space as the indexer (this[row, col]): one unit is one module, origin at the top-left including the quiet zone, x is the column and y is the row. consumers scale by the pixel size of one module; size gives the total extent in modules. three properties are contractual: rectangles never overlap, cover only dark modules, and cover every dark module. the decomposition shape and ordering are unspecified and may change between versions (currently maximal horizontal runs in row-major order, the same merge the built-in renderer draws).">
+                <summary>Notes</summary>
+                <p class="doc remarks">Coordinates use the same space as the indexer (this[row, col]): one unit is one module, origin at the top-left including the quiet zone, X is the column and Y is the row. Consumers scale by the pixel size of one module; Size gives the total extent in modules. Three properties are contractual: rectangles never overlap, cover only dark modules, and cover every dark module. The decomposition shape and ordering are unspecified and may change between versions (currently maximal horizontal runs in row-major order, the same merge the built-in renderer draws).</p>
+              </details>
+            </div>
+            <div class="member" data-text="public bool isfinderpattern(int row, int col); checks if the specified module position (excluding quiet zone) is part of a finder pattern. ">
+              <code>public bool IsFinderPattern(int row, int col);</code>
+              <p class="doc">Checks if the specified module position (excluding quiet zone) is part of a finder pattern.</p>
+            </div>
+            <div class="member" data-text="public bool trygetmodulerectangles(span&lt;modulerect&gt; destination, out int written); writes the dark modules as merged rectangles into a caller-provided buffer. same contract as getmodulerectangles without allocations. ">
+              <code>public bool TryGetModuleRectangles(Span&lt;ModuleRect&gt; destination, out int written);</code>
+              <p class="doc">Writes the dark modules as merged rectangles into a caller-provided buffer. Same contract as GetModuleRectangles without allocations.</p>
+            </div>
+            <div class="member" data-text="public byte[] getrawdata(); serializes the qr code data to a byte array. the serialized data contains only the core qr code modules (excluding quiet zone). the quiet zone can be added when deserializing via the #ctor constructor. format: &quot;qrr&quot; header (3 bytes) + base size (1 byte) + bit-packed module data">
+              <code>public byte[] GetRawData();</code>
+              <p class="doc">Serializes the QR code data to a byte array.</p>
+              <details class="notes" data-text="the serialized data contains only the core qr code modules (excluding quiet zone). the quiet zone can be added when deserializing via the #ctor constructor. format: &quot;qrr&quot; header (3 bytes) + base size (1 byte) + bit-packed module data">
+                <summary>Notes</summary>
+                <p class="doc remarks">The serialized data contains only the core QR code modules (excluding quiet zone). The quiet zone can be added when deserializing via the #ctor constructor. Format: &quot;QRR&quot; header (3 bytes) + base size (1 byte) + bit-packed module data</p>
+              </details>
+            </div>
+            <div class="member" data-text="public int getfinderpatternindex(int row, int col); gets the finder pattern index for the specified module position (excluding quiet zone). ">
+              <code>public int GetFinderPatternIndex(int row, int col);</code>
+              <p class="doc">Gets the finder pattern index for the specified module position (excluding quiet zone).</p>
+            </div>
+            <div class="member" data-text="public int getmodulerectanglesmaxcount(); gets an upper bound on the number of rectangles getmodulerectangles can return, suitable for sizing a pooled buffer for trygetmodulerectangles . o(1), no matrix scan. ">
+              <code>public int GetModuleRectanglesMaxCount();</code>
+              <p class="doc">Gets an upper bound on the number of rectangles GetModuleRectangles can return, suitable for sizing a pooled buffer for TryGetModuleRectangles . O(1), no matrix scan.</p>
+            </div>
+            <div class="member" data-text="public int getrawdata(ibufferwriter&lt;byte&gt; writer); writes the serialized qr code data to the specified buffer writer. this method writes only the core qr mode modules (excluding quiet zone). the quiet zone can be added when deserializing via the #ctor constructor. format: &quot;qrr&quot; header (3 bytes) + base size (1 byte) + bit-packed module data this overload is useful for high-performance scenarios where memory allocations need to be minimized, such as response writing or streaming.">
+              <code>public int GetRawData(IBufferWriter&lt;byte&gt; writer);</code>
+              <p class="doc">Writes the serialized QR code data to the specified buffer writer.</p>
+              <details class="notes" data-text="this method writes only the core qr mode modules (excluding quiet zone). the quiet zone can be added when deserializing via the #ctor constructor. format: &quot;qrr&quot; header (3 bytes) + base size (1 byte) + bit-packed module data this overload is useful for high-performance scenarios where memory allocations need to be minimized, such as response writing or streaming.">
+                <summary>Notes</summary>
+                <p class="doc remarks">This method writes only the core QR mode modules (excluding quiet zone). The quiet zone can be added when deserializing via the #ctor constructor. Format: &quot;QRR&quot; header (3 bytes) + base size (1 byte) + bit-packed module data This overload is useful for high-performance scenarios where memory allocations need to be minimized, such as response writing or streaming.</p>
+              </details>
+            </div>
+            <div class="member" data-text="public int getrawdatasize(); calculates the required buffer size for serialization. ">
+              <code>public int GetRawDataSize();</code>
+              <p class="doc">Calculates the required buffer size for serialization.</p>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.QRCodeDecodeInfo" data-name="skiasharp.qrcode.qrcodedecodeinfo" data-text="skiasharp.qrcode.qrcodedecodeinfo public readonly struct qrcodedecodeinfo diagnostic information produced by a qr code decode attempt.  public ecclevel ecclevel { get; } error correction level read from the format information.  public qrcodedecodestatus status { get; } decode result status. success when decoding succeeded.  public int errorscorrected { get; } total number of codeword errors corrected by reed-solomon decoding.  public int maskpattern { get; } mask pattern (0-7) read from the format information, or -1 when unknown.  public int version { get; } qr code version (1-40), or 0 when the matrix was invalid. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeDecodeInfo" aria-label="Link to SkiaSharp.QrCode.QRCodeDecodeInfo">#</a><code>public readonly struct QRCodeDecodeInfo</code></h3>
+          <p class="doc">Diagnostic information produced by a QR code decode attempt.</p>
+          <div class="members">
+            <div class="member" data-text="public ecclevel ecclevel { get; } error correction level read from the format information. ">
+              <code>public ECCLevel EccLevel { get; }</code>
+              <p class="doc">Error correction level read from the format information.</p>
+            </div>
+            <div class="member" data-text="public qrcodedecodestatus status { get; } decode result status. success when decoding succeeded. ">
+              <code>public QRCodeDecodeStatus Status { get; }</code>
+              <p class="doc">Decode result status. Success when decoding succeeded.</p>
+            </div>
+            <div class="member" data-text="public int errorscorrected { get; } total number of codeword errors corrected by reed-solomon decoding. ">
+              <code>public int ErrorsCorrected { get; }</code>
+              <p class="doc">Total number of codeword errors corrected by Reed-Solomon decoding.</p>
+            </div>
+            <div class="member" data-text="public int maskpattern { get; } mask pattern (0-7) read from the format information, or -1 when unknown. ">
+              <code>public int MaskPattern { get; }</code>
+              <p class="doc">Mask pattern (0-7) read from the format information, or -1 when unknown.</p>
+            </div>
+            <div class="member" data-text="public int version { get; } qr code version (1-40), or 0 when the matrix was invalid. ">
+              <code>public int Version { get; }</code>
+              <p class="doc">QR code version (1-40), or 0 when the matrix was invalid.</p>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.QRCodeDecodeStatus" data-name="skiasharp.qrcode.qrcodedecodestatus" data-text="skiasharp.qrcode.qrcodedecodestatus public enum qrcodedecodestatus : int result status of a qr code decode attempt.  success = 0, decoding succeeded.  invalidmatrix = 1, the input is not a valid qr module matrix (invalid size or no dark modules).  formatinformationinvalid = 2, both format information copies are corrupted beyond bch correction capacity.  datauncorrectable = 3, one or more reed-solomon blocks contain more errors than the ecc level can correct.  invalidbitstream = 4, the data bitstream is malformed (invalid segment values or truncated data).  unsupportedcontent = 5, the bitstream is well-formed but uses a feature this decoder does not support (fnc1, structured append, or an unsupported eci charset). a property of the symbol's structure, not of its text; see unmappedcharacter for the per-character case.  destinationtoosmall = 6, the destination buffer is too small for the decoded text.  notdetected = 7, no qr code was detected in the image (finder patterns not found or inconsistent).  unmappedcharacter = 8, the symbol was read correctly, but one character has no mapping under the charset this decoder applies, so no text is produced. today this means a kanji mode cell outside jis x 0208 — in practice one of the 83 characters microsoft cp932 adds in nec row 13 (circled digits, roman numerals, unit ligatures). it is deliberately distinct from unsupportedcontent : that says the symbol uses a feature this library does not implement, and no reader choice changes it, whereas this says the symbol is well formed and a cp932-capable reader would read it. a caller that wants to fall back to such a reader should branch on exactly this status.">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeDecodeStatus" aria-label="Link to SkiaSharp.QrCode.QRCodeDecodeStatus">#</a><code>public enum QRCodeDecodeStatus : int</code></h3>
+          <p class="doc">Result status of a QR code decode attempt.</p>
+          <div class="members">
+            <div class="member" data-text="success = 0, decoding succeeded. ">
+              <code>Success = 0,</code>
+              <p class="doc">Decoding succeeded.</p>
+            </div>
+            <div class="member" data-text="invalidmatrix = 1, the input is not a valid qr module matrix (invalid size or no dark modules). ">
+              <code>InvalidMatrix = 1,</code>
+              <p class="doc">The input is not a valid QR module matrix (invalid size or no dark modules).</p>
+            </div>
+            <div class="member" data-text="formatinformationinvalid = 2, both format information copies are corrupted beyond bch correction capacity. ">
+              <code>FormatInformationInvalid = 2,</code>
+              <p class="doc">Both format information copies are corrupted beyond BCH correction capacity.</p>
+            </div>
+            <div class="member" data-text="datauncorrectable = 3, one or more reed-solomon blocks contain more errors than the ecc level can correct. ">
+              <code>DataUncorrectable = 3,</code>
+              <p class="doc">One or more Reed-Solomon blocks contain more errors than the ECC level can correct.</p>
+            </div>
+            <div class="member" data-text="invalidbitstream = 4, the data bitstream is malformed (invalid segment values or truncated data). ">
+              <code>InvalidBitstream = 4,</code>
+              <p class="doc">The data bitstream is malformed (invalid segment values or truncated data).</p>
+            </div>
+            <div class="member" data-text="unsupportedcontent = 5, the bitstream is well-formed but uses a feature this decoder does not support (fnc1, structured append, or an unsupported eci charset). a property of the symbol's structure, not of its text; see unmappedcharacter for the per-character case. ">
+              <code>UnsupportedContent = 5,</code>
+              <p class="doc">The bitstream is well-formed but uses a feature this decoder does not support (FNC1, Structured Append, or an unsupported ECI charset). A property of the symbol's structure, not of its text; see UnmappedCharacter for the per-character case.</p>
+            </div>
+            <div class="member" data-text="destinationtoosmall = 6, the destination buffer is too small for the decoded text. ">
+              <code>DestinationTooSmall = 6,</code>
+              <p class="doc">The destination buffer is too small for the decoded text.</p>
+            </div>
+            <div class="member" data-text="notdetected = 7, no qr code was detected in the image (finder patterns not found or inconsistent). ">
+              <code>NotDetected = 7,</code>
+              <p class="doc">No QR code was detected in the image (finder patterns not found or inconsistent).</p>
+            </div>
+            <div class="member" data-text="unmappedcharacter = 8, the symbol was read correctly, but one character has no mapping under the charset this decoder applies, so no text is produced. today this means a kanji mode cell outside jis x 0208 — in practice one of the 83 characters microsoft cp932 adds in nec row 13 (circled digits, roman numerals, unit ligatures). it is deliberately distinct from unsupportedcontent : that says the symbol uses a feature this library does not implement, and no reader choice changes it, whereas this says the symbol is well formed and a cp932-capable reader would read it. a caller that wants to fall back to such a reader should branch on exactly this status.">
+              <code>UnmappedCharacter = 8,</code>
+              <p class="doc">The symbol was read correctly, but one character has no mapping under the charset this decoder applies, so no text is produced.</p>
+              <details class="notes" data-text="today this means a kanji mode cell outside jis x 0208 — in practice one of the 83 characters microsoft cp932 adds in nec row 13 (circled digits, roman numerals, unit ligatures). it is deliberately distinct from unsupportedcontent : that says the symbol uses a feature this library does not implement, and no reader choice changes it, whereas this says the symbol is well formed and a cp932-capable reader would read it. a caller that wants to fall back to such a reader should branch on exactly this status.">
+                <summary>Notes</summary>
+                <p class="doc remarks">Today this means a Kanji mode cell outside JIS X 0208 — in practice one of the 83 characters Microsoft CP932 adds in NEC row 13 (circled digits, roman numerals, unit ligatures). It is deliberately distinct from UnsupportedContent : that says the symbol uses a feature this library does not implement, and no reader choice changes it, whereas this says the symbol is well formed and a CP932-capable reader would read it. A caller that wants to fall back to such a reader should branch on exactly this status.</p>
+              </details>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.QRCodeDecoder" data-name="skiasharp.qrcode.qrcodedecoder" data-text="skiasharp.qrcode.qrcodedecoder public static class qrcodedecoder qr code decoder based on iso/iec 18004 standard. decodes qr module matrices back into text, including reed-solomon error correction. supported content: numeric, alphanumeric and byte mode segments (iso-8859-1 and utf-8, with or without eci headers), the full version range 1-40 and all ecc levels. kanji mode is decoded as jis x 0208; the generator never emits it, so kanji is a read-only mode here. a kanji cell outside the jis x 0208 repertoire (most visibly the nec row 13 characters cp932 adds, such as circled digits) fails the whole symbol with unmappedcharacter rather than substituting a replacement character; that status is distinct from unsupportedcontent so a caller can tell &quot;a cp932 reader would read this&quot; from &quot;this uses a feature we do not implement&quot;. fnc1 and structured append are the latter. byte segments without an eci header have no declared charset. the decoder uses utf-8 when the payload is valid utf-8 (or carries a bom) and iso-8859-1 otherwise. public static bool trydecode(qrcodedata data, out string text); decodes the text content from qr code data.  public static bool trydecode(qrcodedata data, out string text, out qrcodedecodeinfo info); decodes the text content from qr code data, with diagnostic information.  public static bool trydecode(readonlyspan&lt;byte&gt; modules, int size, span&lt;char&gt; destination, out int charswritten, out qrcodedecodeinfo info); decodes the text content from a module matrix into a caller-provided buffer without per-call heap allocation.  public static bool trydecode(readonlyspan&lt;byte&gt; modules, int size, out string text, out qrcodedecodeinfo info); decodes the text content from a module matrix.  public static bool trydecode(skbitmap bitmap, out string text); detects and decodes a qr code from a bitmap image. tier-1/2 image support: clean, well-lit images such as screenshots, rendered qr codes and scans, including arbitrary rotation, mirroring, reflectance reversal (light-on-dark) and mild perspective distortion. photos with strong perspective distortion, uneven lighting or blur are out of scope — use a computer-vision grade reader (e.g. zxing.net) for those. public static bool trydecode(skbitmap bitmap, out string text, out qrcodedecodeinfo info); detects and decodes a qr code from a bitmap image, with diagnostic information. tier-1/2 image support: clean, well-lit images such as screenshots, rendered qr codes and scans, including arbitrary rotation, mirroring, reflectance reversal (light-on-dark) and mild perspective distortion. photos with strong perspective distortion, uneven lighting or blur are out of scope — use a computer-vision grade reader (e.g. zxing.net) for those. public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, span&lt;char&gt; destination, out int charswritten, out qrcodedecodeinfo info); detects and decodes a qr code from grayscale image pixels into a caller-provided buffer without per-call heap allocation.  public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, out string text, out qrcodedecodeinfo info); detects and decodes a qr code from grayscale image pixels.  public static int getmaxdecodedlength(int version); calculates the maximum possible decoded character count for a qr code version, across all ecc levels and encoding modes. use to size the destination buffer for the allocation-free trydecode overload. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeDecoder" aria-label="Link to SkiaSharp.QrCode.QRCodeDecoder">#</a><code>public static class QRCodeDecoder</code></h3>
+          <p class="doc">QR code decoder based on ISO/IEC 18004 standard. Decodes QR module matrices back into text, including Reed-Solomon error correction.</p>
+          <details class="notes" data-text="supported content: numeric, alphanumeric and byte mode segments (iso-8859-1 and utf-8, with or without eci headers), the full version range 1-40 and all ecc levels. kanji mode is decoded as jis x 0208; the generator never emits it, so kanji is a read-only mode here. a kanji cell outside the jis x 0208 repertoire (most visibly the nec row 13 characters cp932 adds, such as circled digits) fails the whole symbol with unmappedcharacter rather than substituting a replacement character; that status is distinct from unsupportedcontent so a caller can tell &quot;a cp932 reader would read this&quot; from &quot;this uses a feature we do not implement&quot;. fnc1 and structured append are the latter. byte segments without an eci header have no declared charset. the decoder uses utf-8 when the payload is valid utf-8 (or carries a bom) and iso-8859-1 otherwise.">
+            <summary>Notes</summary>
+            <p class="doc remarks">Supported content: Numeric, Alphanumeric and Byte mode segments (ISO-8859-1 and UTF-8, with or without ECI headers), the full version range 1-40 and all ECC levels. Kanji mode is decoded as JIS X 0208; the generator never emits it, so Kanji is a read-only mode here. A Kanji cell outside the JIS X 0208 repertoire (most visibly the NEC row 13 characters CP932 adds, such as circled digits) fails the WHOLE symbol with UnmappedCharacter rather than substituting a replacement character; that status is distinct from UnsupportedContent so a caller can tell &quot;a CP932 reader would read this&quot; from &quot;this uses a feature we do not implement&quot;. FNC1 and Structured Append are the latter. Byte segments without an ECI header have no declared charset. The decoder uses UTF-8 when the payload is valid UTF-8 (or carries a BOM) and ISO-8859-1 otherwise.</p>
+          </details>
+          <div class="members">
+            <div class="member" data-text="public static bool trydecode(qrcodedata data, out string text); decodes the text content from qr code data. ">
+              <code>public static bool TryDecode(QRCodeData data, out string text);</code>
+              <p class="doc">Decodes the text content from QR code data.</p>
+            </div>
+            <div class="member" data-text="public static bool trydecode(qrcodedata data, out string text, out qrcodedecodeinfo info); decodes the text content from qr code data, with diagnostic information. ">
+              <code>public static bool TryDecode(QRCodeData data, out string text, out QRCodeDecodeInfo info);</code>
+              <p class="doc">Decodes the text content from QR code data, with diagnostic information.</p>
+            </div>
+            <div class="member" data-text="public static bool trydecode(readonlyspan&lt;byte&gt; modules, int size, span&lt;char&gt; destination, out int charswritten, out qrcodedecodeinfo info); decodes the text content from a module matrix into a caller-provided buffer without per-call heap allocation. ">
+              <code>public static bool TryDecode(ReadOnlySpan&lt;byte&gt; modules, int size, Span&lt;char&gt; destination, out int charsWritten, out QRCodeDecodeInfo info);</code>
+              <p class="doc">Decodes the text content from a module matrix into a caller-provided buffer without per-call heap allocation.</p>
+            </div>
+            <div class="member" data-text="public static bool trydecode(readonlyspan&lt;byte&gt; modules, int size, out string text, out qrcodedecodeinfo info); decodes the text content from a module matrix. ">
+              <code>public static bool TryDecode(ReadOnlySpan&lt;byte&gt; modules, int size, out string text, out QRCodeDecodeInfo info);</code>
+              <p class="doc">Decodes the text content from a module matrix.</p>
+            </div>
+            <div class="member" data-text="public static bool trydecode(skbitmap bitmap, out string text); detects and decodes a qr code from a bitmap image. tier-1/2 image support: clean, well-lit images such as screenshots, rendered qr codes and scans, including arbitrary rotation, mirroring, reflectance reversal (light-on-dark) and mild perspective distortion. photos with strong perspective distortion, uneven lighting or blur are out of scope — use a computer-vision grade reader (e.g. zxing.net) for those.">
+              <code>public static bool TryDecode(SKBitmap bitmap, out string text);</code>
+              <p class="doc">Detects and decodes a QR code from a bitmap image.</p>
+              <details class="notes" data-text="tier-1/2 image support: clean, well-lit images such as screenshots, rendered qr codes and scans, including arbitrary rotation, mirroring, reflectance reversal (light-on-dark) and mild perspective distortion. photos with strong perspective distortion, uneven lighting or blur are out of scope — use a computer-vision grade reader (e.g. zxing.net) for those.">
+                <summary>Notes</summary>
+                <p class="doc remarks">Tier-1/2 image support: clean, well-lit images such as screenshots, rendered QR codes and scans, including arbitrary rotation, mirroring, reflectance reversal (light-on-dark) and mild perspective distortion. Photos with strong perspective distortion, uneven lighting or blur are out of scope — use a computer-vision grade reader (e.g. ZXing.Net) for those.</p>
+              </details>
+            </div>
+            <div class="member" data-text="public static bool trydecode(skbitmap bitmap, out string text, out qrcodedecodeinfo info); detects and decodes a qr code from a bitmap image, with diagnostic information. tier-1/2 image support: clean, well-lit images such as screenshots, rendered qr codes and scans, including arbitrary rotation, mirroring, reflectance reversal (light-on-dark) and mild perspective distortion. photos with strong perspective distortion, uneven lighting or blur are out of scope — use a computer-vision grade reader (e.g. zxing.net) for those.">
+              <code>public static bool TryDecode(SKBitmap bitmap, out string text, out QRCodeDecodeInfo info);</code>
+              <p class="doc">Detects and decodes a QR code from a bitmap image, with diagnostic information.</p>
+              <details class="notes" data-text="tier-1/2 image support: clean, well-lit images such as screenshots, rendered qr codes and scans, including arbitrary rotation, mirroring, reflectance reversal (light-on-dark) and mild perspective distortion. photos with strong perspective distortion, uneven lighting or blur are out of scope — use a computer-vision grade reader (e.g. zxing.net) for those.">
+                <summary>Notes</summary>
+                <p class="doc remarks">Tier-1/2 image support: clean, well-lit images such as screenshots, rendered QR codes and scans, including arbitrary rotation, mirroring, reflectance reversal (light-on-dark) and mild perspective distortion. Photos with strong perspective distortion, uneven lighting or blur are out of scope — use a computer-vision grade reader (e.g. ZXing.Net) for those.</p>
+              </details>
+            </div>
+            <div class="member" data-text="public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, span&lt;char&gt; destination, out int charswritten, out qrcodedecodeinfo info); detects and decodes a qr code from grayscale image pixels into a caller-provided buffer without per-call heap allocation. ">
+              <code>public static bool TryDecodeImage(ReadOnlySpan&lt;byte&gt; luminance, int width, int height, Span&lt;char&gt; destination, out int charsWritten, out QRCodeDecodeInfo info);</code>
+              <p class="doc">Detects and decodes a QR code from grayscale image pixels into a caller-provided buffer without per-call heap allocation.</p>
+            </div>
+            <div class="member" data-text="public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, out string text, out qrcodedecodeinfo info); detects and decodes a qr code from grayscale image pixels. ">
+              <code>public static bool TryDecodeImage(ReadOnlySpan&lt;byte&gt; luminance, int width, int height, out string text, out QRCodeDecodeInfo info);</code>
+              <p class="doc">Detects and decodes a QR code from grayscale image pixels.</p>
+            </div>
+            <div class="member" data-text="public static int getmaxdecodedlength(int version); calculates the maximum possible decoded character count for a qr code version, across all ecc levels and encoding modes. use to size the destination buffer for the allocation-free trydecode overload. ">
+              <code>public static int GetMaxDecodedLength(int version);</code>
+              <p class="doc">Calculates the maximum possible decoded character count for a QR code version, across all ECC levels and encoding modes. Use to size the destination buffer for the allocation-free TryDecode overload.</p>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.QRCodeExtensions" data-name="skiasharp.qrcode.qrcodeextensions" data-text="skiasharp.qrcode.qrcodeextensions public static class qrcodeextensions extension methods that render a qr, micro qr or rmqr symbol onto an skcanvas you already have, instead of producing an image file. each method clears the whole canvas before drawing, so anything already on it is lost. to place a symbol inside a larger drawing, wrap the call in save and cliprect , or call qrcoderenderer directly, which draws only the symbol. public static void render(skcanvas canvas, microqrcodedata data, skrect area, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); renders a micro qr code on the canvas with custom colors. micro qr does not offer the standard qr icon overlay or custom finder pattern shape options (single finder pattern, no error-correction headroom for overlays). public static void render(skcanvas canvas, microqrcodedata data, int width, int height, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); renders a micro qr code on the canvas with default colors. micro qr does not offer the standard qr icon overlay or custom finder pattern shape options (single finder pattern, no error-correction headroom for overlays). public static void render(skcanvas canvas, qrcodedata data, skrect area, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, icondata? icondata = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null, finderpatternshape? finderpatternshape = null); renders a qr code on the canvas with custom colors.  public static void render(skcanvas canvas, qrcodedata data, int width, int height, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, icondata? icondata = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null, finderpatternshape? finderpatternshape = null); renders a qr code on the canvas with default colors.  public static void render(skcanvas canvas, rmqrcodedata data, skrect area, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); renders an rmqr code on the canvas with custom colors. the rectangular symbol (quiet zone included) is drawn with a uniform module scale and centered in the area (letterbox); the whole area receives the background color. rmqr offers no icon overlay or finder styling options. public static void render(skcanvas canvas, rmqrcodedata data, int width, int height, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); renders an rmqr code on the canvas with default colors. the rectangular symbol (quiet zone included) is drawn with a uniform module scale and centered in the area (letterbox); the whole area receives the background color. rmqr offers no icon overlay or finder styling options.">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeExtensions" aria-label="Link to SkiaSharp.QrCode.QRCodeExtensions">#</a><code>public static class QRCodeExtensions</code></h3>
+          <p class="doc">Extension methods that render a QR, Micro QR or rMQR symbol onto an SKCanvas you already have, instead of producing an image file.</p>
+          <details class="notes" data-text="each method clears the whole canvas before drawing, so anything already on it is lost. to place a symbol inside a larger drawing, wrap the call in save and cliprect , or call qrcoderenderer directly, which draws only the symbol.">
+            <summary>Notes</summary>
+            <p class="doc remarks">Each method clears the whole canvas before drawing, so anything already on it is lost. To place a symbol inside a larger drawing, wrap the call in Save and ClipRect , or call QRCodeRenderer directly, which draws only the symbol.</p>
+          </details>
+          <div class="members">
+            <div class="member" data-text="public static void render(skcanvas canvas, microqrcodedata data, skrect area, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); renders a micro qr code on the canvas with custom colors. micro qr does not offer the standard qr icon overlay or custom finder pattern shape options (single finder pattern, no error-correction headroom for overlays).">
+              <code>public static void Render(SKCanvas canvas, MicroQRCodeData data, SKRect area, SKColor? clearColor = null, SKColor? codeColor = null, SKColor? backgroundColor = null, ModuleShape? moduleShape = null, float moduleSizePercent = 1, GradientOptions? gradientOptions = null);</code>
+              <p class="doc">Renders a Micro QR code on the canvas with custom colors.</p>
+              <details class="notes" data-text="micro qr does not offer the standard qr icon overlay or custom finder pattern shape options (single finder pattern, no error-correction headroom for overlays).">
+                <summary>Notes</summary>
+                <p class="doc remarks">Micro QR does not offer the Standard QR icon overlay or custom finder pattern shape options (single finder pattern, no error-correction headroom for overlays).</p>
+              </details>
+            </div>
+            <div class="member" data-text="public static void render(skcanvas canvas, microqrcodedata data, int width, int height, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); renders a micro qr code on the canvas with default colors. micro qr does not offer the standard qr icon overlay or custom finder pattern shape options (single finder pattern, no error-correction headroom for overlays).">
+              <code>public static void Render(SKCanvas canvas, MicroQRCodeData data, int width, int height, SKColor? clearColor = null, SKColor? codeColor = null, SKColor? backgroundColor = null, ModuleShape? moduleShape = null, float moduleSizePercent = 1, GradientOptions? gradientOptions = null);</code>
+              <p class="doc">Renders a Micro QR code on the canvas with default colors.</p>
+              <details class="notes" data-text="micro qr does not offer the standard qr icon overlay or custom finder pattern shape options (single finder pattern, no error-correction headroom for overlays).">
+                <summary>Notes</summary>
+                <p class="doc remarks">Micro QR does not offer the Standard QR icon overlay or custom finder pattern shape options (single finder pattern, no error-correction headroom for overlays).</p>
+              </details>
+            </div>
+            <div class="member" data-text="public static void render(skcanvas canvas, qrcodedata data, skrect area, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, icondata? icondata = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null, finderpatternshape? finderpatternshape = null); renders a qr code on the canvas with custom colors. ">
+              <code>public static void Render(SKCanvas canvas, QRCodeData data, SKRect area, SKColor? clearColor = null, SKColor? codeColor = null, SKColor? backgroundColor = null, IconData? iconData = null, ModuleShape? moduleShape = null, float moduleSizePercent = 1, GradientOptions? gradientOptions = null, FinderPatternShape? finderPatternShape = null);</code>
+              <p class="doc">Renders a QR code on the canvas with custom colors.</p>
+            </div>
+            <div class="member" data-text="public static void render(skcanvas canvas, qrcodedata data, int width, int height, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, icondata? icondata = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null, finderpatternshape? finderpatternshape = null); renders a qr code on the canvas with default colors. ">
+              <code>public static void Render(SKCanvas canvas, QRCodeData data, int width, int height, SKColor? clearColor = null, SKColor? codeColor = null, SKColor? backgroundColor = null, IconData? iconData = null, ModuleShape? moduleShape = null, float moduleSizePercent = 1, GradientOptions? gradientOptions = null, FinderPatternShape? finderPatternShape = null);</code>
+              <p class="doc">Renders a QR code on the canvas with default colors.</p>
+            </div>
+            <div class="member" data-text="public static void render(skcanvas canvas, rmqrcodedata data, skrect area, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); renders an rmqr code on the canvas with custom colors. the rectangular symbol (quiet zone included) is drawn with a uniform module scale and centered in the area (letterbox); the whole area receives the background color. rmqr offers no icon overlay or finder styling options.">
+              <code>public static void Render(SKCanvas canvas, RmQRCodeData data, SKRect area, SKColor? clearColor = null, SKColor? codeColor = null, SKColor? backgroundColor = null, ModuleShape? moduleShape = null, float moduleSizePercent = 1, GradientOptions? gradientOptions = null);</code>
+              <p class="doc">Renders an rMQR code on the canvas with custom colors.</p>
+              <details class="notes" data-text="the rectangular symbol (quiet zone included) is drawn with a uniform module scale and centered in the area (letterbox); the whole area receives the background color. rmqr offers no icon overlay or finder styling options.">
+                <summary>Notes</summary>
+                <p class="doc remarks">The rectangular symbol (quiet zone included) is drawn with a uniform module scale and centered in the area (letterbox); the whole area receives the background color. rMQR offers no icon overlay or finder styling options.</p>
+              </details>
+            </div>
+            <div class="member" data-text="public static void render(skcanvas canvas, rmqrcodedata data, int width, int height, skcolor? clearcolor = null, skcolor? codecolor = null, skcolor? backgroundcolor = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); renders an rmqr code on the canvas with default colors. the rectangular symbol (quiet zone included) is drawn with a uniform module scale and centered in the area (letterbox); the whole area receives the background color. rmqr offers no icon overlay or finder styling options.">
+              <code>public static void Render(SKCanvas canvas, RmQRCodeData data, int width, int height, SKColor? clearColor = null, SKColor? codeColor = null, SKColor? backgroundColor = null, ModuleShape? moduleShape = null, float moduleSizePercent = 1, GradientOptions? gradientOptions = null);</code>
+              <p class="doc">Renders an rMQR code on the canvas with default colors.</p>
+              <details class="notes" data-text="the rectangular symbol (quiet zone included) is drawn with a uniform module scale and centered in the area (letterbox); the whole area receives the background color. rmqr offers no icon overlay or finder styling options.">
+                <summary>Notes</summary>
+                <p class="doc remarks">The rectangular symbol (quiet zone included) is drawn with a uniform module scale and centered in the area (letterbox); the whole area receives the background color. rMQR offers no icon overlay or finder styling options.</p>
+              </details>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.QRCodeGenerator" data-name="skiasharp.qrcode.qrcodegenerator" data-text="skiasharp.qrcode.qrcodegenerator public static class qrcodegenerator qr code generator based on iso/iec 18004 standard. supports qr code versions 1-40 with multiple encoding modes and error correction levels. encoding modes written here are numeric, alphanumeric and byte (iso-8859-1 / utf-8, with eci). kanji mode is never written, japanese text goes out as utf-8 in byte mode; qrcodedecoder does read kanji segments other encoders produce, so the two directions are deliberately asymmetric. [obsolete] public static qrcodecalculatedsize getrequiredbuffersize(readonlyspan&lt;char&gt; text, ecclevel ecclevel, bool utf8bom = false, ecimode ecimode = 0, int quietzonesize = 4); calculates the required buffer size for encoding the specified text as a qr code.  public static qrcodedata createqrcode(readonlyspan&lt;char&gt; textspan, ecclevel ecclevel, bool utf8bom = false, ecimode ecimode = 0, int requestedversion = -1, int quietzonesize = 4); creates a qr code from the provided plain text.  public static qrcodedata createqrcode(readonlyspan&lt;char&gt; textspan, ecclevel ecclevel, in qrcodegeneratoroptions options);  public static qrcodedata createqrcode(string plaintext, ecclevel ecclevel, bool utf8bom = false, ecimode ecimode = 0, int requestedversion = -1, int quietzonesize = 4); creates a qr code from the provided plain text.  public static qrcodedata createqrcode(string plaintext, ecclevel ecclevel, in qrcodegeneratoroptions options);  public static bool trygetrequiredbuffersize(readonlyspan&lt;char&gt; text, ecclevel ecclevel, out qrcodecalculatedsize size, in qrcodegeneratoroptions options = null); calculates the required buffer size, matrix size and version for encoding the specified text as a qr code, reporting content that does not fit as false rather than as an exception. false means the content does not fit, and nothing else: argument errors throw (rationale: specs/rmqr-encoder.md). when version is narrower than any , that means no version in that range holds the content, not merely that it exceeds version 40. boostecclevel has no effect here: the boost never changes the version, and the buffer size depends only on the version. pass the same options you will encode with: segmentation and ecimode can select different versions, so a buffer sized for one can be too small for the other. public static int createqrcode(readonlyspan&lt;char&gt; textspan, ecclevel ecclevel, span&lt;byte&gt; destination, bool utf8bom = false, ecimode ecimode = 0, int requestedversion = -1, int quietzonesize = 4); creates a qr code from the provided plain text and writes the module matrix into the caller-provided buffer without per-call heap allocation. output format: one byte per module (0 = light, 1 = dark), flat row-major order, quiet zone included. module at (row, col) is destination[row * qrsize + col] where qrsize is qrsize returned by trygetrequiredbuffersize . usage flow for allocation-free generation: if (!qrcodegenerator.trygetrequiredbuffersize(text, ecclevel.m, out var calculated, qrcodegeneratoroptions.default)) return; // content does not fit version 40 at this ecc level var buffer = arraypool&lt;byte&gt;.shared.rent(calculated.buffersize); var written = qrcodegenerator.createqrcode(text, ecclevel.m, buffer); var matrix = buffer.asspan(0, written); // ... consume matrix ... arraypool&lt;byte&gt;.shared.return(buffer); only the first buffersize bytes of destination are written (every byte of that region is written, so a dirty pooled buffer is fine); any remaining bytes are left untouched. public static int createqrcode(readonlyspan&lt;char&gt; textspan, ecclevel ecclevel, span&lt;byte&gt; destination, in qrcodegeneratoroptions options);  public static int createqrcode(string plaintext, ecclevel ecclevel, span&lt;byte&gt; destination, bool utf8bom = false, ecimode ecimode = 0, int requestedversion = -1, int quietzonesize = 4); creates a qr code from the provided plain text and writes the module matrix into the caller-provided buffer without per-call heap allocation.  public static int createqrcode(string plaintext, ecclevel ecclevel, span&lt;byte&gt; destination, in qrcodegeneratoroptions options); ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeGenerator" aria-label="Link to SkiaSharp.QrCode.QRCodeGenerator">#</a><code>public static class QRCodeGenerator</code></h3>
+          <p class="doc">QR code generator based on ISO/IEC 18004 standard. Supports QR code versions 1-40 with multiple encoding modes and error correction levels.</p>
+          <details class="notes" data-text="encoding modes written here are numeric, alphanumeric and byte (iso-8859-1 / utf-8, with eci). kanji mode is never written, japanese text goes out as utf-8 in byte mode; qrcodedecoder does read kanji segments other encoders produce, so the two directions are deliberately asymmetric.">
+            <summary>Notes</summary>
+            <p class="doc remarks">Encoding modes written here are Numeric, Alphanumeric and Byte (ISO-8859-1 / UTF-8, with ECI). Kanji mode is never written, Japanese text goes out as UTF-8 in Byte mode; QRCodeDecoder does read Kanji segments other encoders produce, so the two directions are deliberately asymmetric.</p>
+          </details>
+          <div class="members">
+            <div class="member" data-text="public static qrcodecalculatedsize getrequiredbuffersize(readonlyspan&lt;char&gt; text, ecclevel ecclevel, bool utf8bom = false, ecimode ecimode = 0, int quietzonesize = 4); calculates the required buffer size for encoding the specified text as a qr code. ">
+              <code>public static QRCodeCalculatedSize GetRequiredBufferSize(ReadOnlySpan&lt;char&gt; text, ECCLevel eccLevel, bool utf8BOM = false, EciMode eciMode = 0, int quietZoneSize = 4);</code> <span class="tag">obsolete</span>
+              <p class="doc">Calculates the required buffer size for encoding the specified text as a QR code.</p>
+            </div>
+            <div class="member" data-text="public static qrcodedata createqrcode(readonlyspan&lt;char&gt; textspan, ecclevel ecclevel, bool utf8bom = false, ecimode ecimode = 0, int requestedversion = -1, int quietzonesize = 4); creates a qr code from the provided plain text. ">
+              <code>public static QRCodeData CreateQrCode(ReadOnlySpan&lt;char&gt; textSpan, ECCLevel eccLevel, bool utf8BOM = false, EciMode eciMode = 0, int requestedVersion = -1, int quietZoneSize = 4);</code>
+              <p class="doc">Creates a QR code from the provided plain text.</p>
+            </div>
+            <div class="member" data-text="public static qrcodedata createqrcode(readonlyspan&lt;char&gt; textspan, ecclevel ecclevel, in qrcodegeneratoroptions options); ">
+              <code>public static QRCodeData CreateQrCode(ReadOnlySpan&lt;char&gt; textSpan, ECCLevel eccLevel, in QRCodeGeneratorOptions options);</code>
+            </div>
+            <div class="member" data-text="public static qrcodedata createqrcode(string plaintext, ecclevel ecclevel, bool utf8bom = false, ecimode ecimode = 0, int requestedversion = -1, int quietzonesize = 4); creates a qr code from the provided plain text. ">
+              <code>public static QRCodeData CreateQrCode(string plainText, ECCLevel eccLevel, bool utf8BOM = false, EciMode eciMode = 0, int requestedVersion = -1, int quietZoneSize = 4);</code>
+              <p class="doc">Creates a QR code from the provided plain text.</p>
+            </div>
+            <div class="member" data-text="public static qrcodedata createqrcode(string plaintext, ecclevel ecclevel, in qrcodegeneratoroptions options); ">
+              <code>public static QRCodeData CreateQrCode(string plainText, ECCLevel eccLevel, in QRCodeGeneratorOptions options);</code>
+            </div>
+            <div class="member" data-text="public static bool trygetrequiredbuffersize(readonlyspan&lt;char&gt; text, ecclevel ecclevel, out qrcodecalculatedsize size, in qrcodegeneratoroptions options = null); calculates the required buffer size, matrix size and version for encoding the specified text as a qr code, reporting content that does not fit as false rather than as an exception. false means the content does not fit, and nothing else: argument errors throw (rationale: specs/rmqr-encoder.md). when version is narrower than any , that means no version in that range holds the content, not merely that it exceeds version 40. boostecclevel has no effect here: the boost never changes the version, and the buffer size depends only on the version. pass the same options you will encode with: segmentation and ecimode can select different versions, so a buffer sized for one can be too small for the other.">
+              <code>public static bool TryGetRequiredBufferSize(ReadOnlySpan&lt;char&gt; text, ECCLevel eccLevel, out QRCodeCalculatedSize size, in QRCodeGeneratorOptions options = null);</code>
+              <p class="doc">Calculates the required buffer size, matrix size and version for encoding the specified text as a QR code, reporting content that does not fit as false rather than as an exception.</p>
+              <details class="notes" data-text="false means the content does not fit, and nothing else: argument errors throw (rationale: specs/rmqr-encoder.md). when version is narrower than any , that means no version in that range holds the content, not merely that it exceeds version 40. boostecclevel has no effect here: the boost never changes the version, and the buffer size depends only on the version. pass the same options you will encode with: segmentation and ecimode can select different versions, so a buffer sized for one can be too small for the other.">
+                <summary>Notes</summary>
+                <p class="doc remarks">false means the content does not fit, and nothing else: argument errors throw (rationale: specs/rmqr-encoder.md). When Version is narrower than Any , that means no version in that range holds the content, not merely that it exceeds version 40. BoostEccLevel has no effect here: the boost never changes the version, and the buffer size depends only on the version. Pass the same options you will encode with: Segmentation and EciMode can select different versions, so a buffer sized for one can be too small for the other.</p>
+              </details>
+            </div>
+            <div class="member" data-text="public static int createqrcode(readonlyspan&lt;char&gt; textspan, ecclevel ecclevel, span&lt;byte&gt; destination, bool utf8bom = false, ecimode ecimode = 0, int requestedversion = -1, int quietzonesize = 4); creates a qr code from the provided plain text and writes the module matrix into the caller-provided buffer without per-call heap allocation. output format: one byte per module (0 = light, 1 = dark), flat row-major order, quiet zone included. module at (row, col) is destination[row * qrsize + col] where qrsize is qrsize returned by trygetrequiredbuffersize . usage flow for allocation-free generation: if (!qrcodegenerator.trygetrequiredbuffersize(text, ecclevel.m, out var calculated, qrcodegeneratoroptions.default)) return; // content does not fit version 40 at this ecc level var buffer = arraypool&lt;byte&gt;.shared.rent(calculated.buffersize); var written = qrcodegenerator.createqrcode(text, ecclevel.m, buffer); var matrix = buffer.asspan(0, written); // ... consume matrix ... arraypool&lt;byte&gt;.shared.return(buffer); only the first buffersize bytes of destination are written (every byte of that region is written, so a dirty pooled buffer is fine); any remaining bytes are left untouched.">
+              <code>public static int CreateQrCode(ReadOnlySpan&lt;char&gt; textSpan, ECCLevel eccLevel, Span&lt;byte&gt; destination, bool utf8BOM = false, EciMode eciMode = 0, int requestedVersion = -1, int quietZoneSize = 4);</code>
+              <p class="doc">Creates a QR code from the provided plain text and writes the module matrix into the caller-provided buffer without per-call heap allocation.</p>
+              <details class="notes" data-text="output format: one byte per module (0 = light, 1 = dark), flat row-major order, quiet zone included. module at (row, col) is destination[row * qrsize + col] where qrsize is qrsize returned by trygetrequiredbuffersize . usage flow for allocation-free generation: if (!qrcodegenerator.trygetrequiredbuffersize(text, ecclevel.m, out var calculated, qrcodegeneratoroptions.default)) return; // content does not fit version 40 at this ecc level var buffer = arraypool&lt;byte&gt;.shared.rent(calculated.buffersize); var written = qrcodegenerator.createqrcode(text, ecclevel.m, buffer); var matrix = buffer.asspan(0, written); // ... consume matrix ... arraypool&lt;byte&gt;.shared.return(buffer); only the first buffersize bytes of destination are written (every byte of that region is written, so a dirty pooled buffer is fine); any remaining bytes are left untouched.">
+                <summary>Notes</summary>
+                <p class="doc remarks">Output format: one byte per module (0 = light, 1 = dark), flat row-major order, quiet zone included. Module at (row, col) is destination[row * qrSize + col] where qrSize is QrSize returned by TryGetRequiredBufferSize . Usage flow for allocation-free generation: if (!QRCodeGenerator.TryGetRequiredBufferSize(text, ECCLevel.M, out var calculated, QRCodeGeneratorOptions.Default)) return; // content does not fit version 40 at this ECC level var buffer = ArrayPool&lt;byte&gt;.Shared.Rent(calculated.BufferSize); var written = QRCodeGenerator.CreateQrCode(text, ECCLevel.M, buffer); var matrix = buffer.AsSpan(0, written); // ... consume matrix ... ArrayPool&lt;byte&gt;.Shared.Return(buffer); Only the first BufferSize bytes of destination are written (every byte of that region is written, so a dirty pooled buffer is fine); any remaining bytes are left untouched.</p>
+              </details>
+            </div>
+            <div class="member" data-text="public static int createqrcode(readonlyspan&lt;char&gt; textspan, ecclevel ecclevel, span&lt;byte&gt; destination, in qrcodegeneratoroptions options); ">
+              <code>public static int CreateQrCode(ReadOnlySpan&lt;char&gt; textSpan, ECCLevel eccLevel, Span&lt;byte&gt; destination, in QRCodeGeneratorOptions options);</code>
+            </div>
+            <div class="member" data-text="public static int createqrcode(string plaintext, ecclevel ecclevel, span&lt;byte&gt; destination, bool utf8bom = false, ecimode ecimode = 0, int requestedversion = -1, int quietzonesize = 4); creates a qr code from the provided plain text and writes the module matrix into the caller-provided buffer without per-call heap allocation. ">
+              <code>public static int CreateQrCode(string plainText, ECCLevel eccLevel, Span&lt;byte&gt; destination, bool utf8BOM = false, EciMode eciMode = 0, int requestedVersion = -1, int quietZoneSize = 4);</code>
+              <p class="doc">Creates a QR code from the provided plain text and writes the module matrix into the caller-provided buffer without per-call heap allocation.</p>
+            </div>
+            <div class="member" data-text="public static int createqrcode(string plaintext, ecclevel ecclevel, span&lt;byte&gt; destination, in qrcodegeneratoroptions options); ">
+              <code>public static int CreateQrCode(string plainText, ECCLevel eccLevel, Span&lt;byte&gt; destination, in QRCodeGeneratorOptions options);</code>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.QRCodeGeneratorOptions" data-name="skiasharp.qrcode.qrcodegeneratoroptions" data-text="skiasharp.qrcode.qrcodegeneratoroptions public readonly struct qrcodegeneratoroptions : iequatable&lt;qrcodegeneratoroptions&gt; optional settings for qrcodegenerator . default is the complete default configuration, so set only what you need: new qrcodegeneratoroptions { ecimode = ecimode.utf8, quietzonesize = 0 }. standard qr specific rather than shared: the three generators agree on almost nothing. version is a different type in each, quietzonesize has a different specified default in each, micro qr has no eci, and rmqr carries fit options that mean nothing here. public ecimode ecimode { get; init; } character encoding declaration. the default auto-detects ascii (no eci), iso-8859-1 (assignment 3) or utf-8 (assignment 26) from the content.  public qrcodesegmentation segmentation { get; init; } how the content is split into encoding-mode segments (see qrcodesegmentation ). defaults to single . optimal never selects a larger version, emits the identical bit stream when a split would not shrink the symbol, and defers to the single-mode stream when utf8bom would actually write a byte order mark. size a destination buffer with the same value you encode with.  public qrcodeversionrange version { get; init; } the versions the generator may choose from. defaults to any ; an int or int? converts implicitly, so version = 15 pins one and a null means automatic.  public bool boostecclevel { get; init; } raise the error correction level above the requested one when the chosen version's capacity allows it, without changing the version. the requested level becomes the minimum; the version is still chosen for it, so boosting never produces a larger symbol, only spends padding that would otherwise be wasted. recommended when an icon or custom module shape overlays the symbol. off by default: a raised level rewrites the format information and can change the chosen mask, so a default of on would silently change every existing symbol. sizing is unaffected either way, the buffer size depends only on the version. public bool utf8bom { get; init; } include a utf-8 byte order mark. ignored unless the content is written as utf-8 in byte mode. when a bom would be written, optimal emits the single-mode stream instead of a split (the bom is a stream-level prefix, and a split would relocate it into the middle of the decoded text).  public int quietzonesize { get; init; } quiet zone width in modules. defaults to 4, the iso/iec 18004 value; 0 is valid.  public int? maskpattern { get; init; } pin one of the eight iso/iec 18004 data mask patterns (0-7) instead of the automatic penalty-scored selection. null (the default) selects the lowest-penalty pattern. any pattern yields a valid, decodable symbol; the automatic choice merely optimizes scan reliability. for reproducing a symbol produced elsewhere byte-for-byte (the pattern another encoder chose is reported by maskpattern ), and for exercising a decoder against all eight patterns. like version , an invalid value is an argument error and is rejected here rather than when a generator reads it. public static qrcodegeneratoroptions default { get; } the default configuration, identical to default. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeGeneratorOptions" aria-label="Link to SkiaSharp.QrCode.QRCodeGeneratorOptions">#</a><code>public readonly struct QRCodeGeneratorOptions : IEquatable&lt;QRCodeGeneratorOptions&gt;</code></h3>
+          <p class="doc">Optional settings for QRCodeGenerator . default is the complete default configuration, so set only what you need: new QRCodeGeneratorOptions { EciMode = EciMode.Utf8, QuietZoneSize = 0 }.</p>
+          <details class="notes" data-text="standard qr specific rather than shared: the three generators agree on almost nothing. version is a different type in each, quietzonesize has a different specified default in each, micro qr has no eci, and rmqr carries fit options that mean nothing here.">
+            <summary>Notes</summary>
+            <p class="doc remarks">Standard QR specific rather than shared: the three generators agree on almost nothing. Version is a different type in each, QuietZoneSize has a different specified default in each, Micro QR has no ECI, and rMQR carries fit options that mean nothing here.</p>
+          </details>
+          <div class="members">
+            <div class="member" data-text="public ecimode ecimode { get; init; } character encoding declaration. the default auto-detects ascii (no eci), iso-8859-1 (assignment 3) or utf-8 (assignment 26) from the content. ">
+              <code>public EciMode EciMode { get; init; }</code>
+              <p class="doc">Character encoding declaration. The default auto-detects ASCII (no ECI), ISO-8859-1 (assignment 3) or UTF-8 (assignment 26) from the content.</p>
+            </div>
+            <div class="member" data-text="public qrcodesegmentation segmentation { get; init; } how the content is split into encoding-mode segments (see qrcodesegmentation ). defaults to single . optimal never selects a larger version, emits the identical bit stream when a split would not shrink the symbol, and defers to the single-mode stream when utf8bom would actually write a byte order mark. size a destination buffer with the same value you encode with. ">
+              <code>public QRCodeSegmentation Segmentation { get; init; }</code>
+              <p class="doc">How the content is split into encoding-mode segments (see QRCodeSegmentation ). Defaults to Single . Optimal never selects a larger version, emits the identical bit stream when a split would not shrink the symbol, and defers to the single-mode stream when Utf8BOM would actually write a byte order mark. Size a destination buffer with the same value you encode with.</p>
+            </div>
+            <div class="member" data-text="public qrcodeversionrange version { get; init; } the versions the generator may choose from. defaults to any ; an int or int? converts implicitly, so version = 15 pins one and a null means automatic. ">
+              <code>public QRCodeVersionRange Version { get; init; }</code>
+              <p class="doc">The versions the generator may choose from. Defaults to Any ; an int or int? converts implicitly, so Version = 15 pins one and a null means automatic.</p>
+            </div>
+            <div class="member" data-text="public bool boostecclevel { get; init; } raise the error correction level above the requested one when the chosen version's capacity allows it, without changing the version. the requested level becomes the minimum; the version is still chosen for it, so boosting never produces a larger symbol, only spends padding that would otherwise be wasted. recommended when an icon or custom module shape overlays the symbol. off by default: a raised level rewrites the format information and can change the chosen mask, so a default of on would silently change every existing symbol. sizing is unaffected either way, the buffer size depends only on the version.">
+              <code>public bool BoostEccLevel { get; init; }</code>
+              <p class="doc">Raise the error correction level above the requested one when the chosen version's capacity allows it, without changing the version. The requested level becomes the minimum; the version is still chosen for it, so boosting never produces a larger symbol, only spends padding that would otherwise be wasted. Recommended when an icon or custom module shape overlays the symbol.</p>
+              <details class="notes" data-text="off by default: a raised level rewrites the format information and can change the chosen mask, so a default of on would silently change every existing symbol. sizing is unaffected either way, the buffer size depends only on the version.">
+                <summary>Notes</summary>
+                <p class="doc remarks">Off by default: a raised level rewrites the format information and can change the chosen mask, so a default of on would silently change every existing symbol. Sizing is unaffected either way, the buffer size depends only on the version.</p>
+              </details>
+            </div>
+            <div class="member" data-text="public bool utf8bom { get; init; } include a utf-8 byte order mark. ignored unless the content is written as utf-8 in byte mode. when a bom would be written, optimal emits the single-mode stream instead of a split (the bom is a stream-level prefix, and a split would relocate it into the middle of the decoded text). ">
+              <code>public bool Utf8BOM { get; init; }</code>
+              <p class="doc">Include a UTF-8 byte order mark. Ignored unless the content is written as UTF-8 in Byte mode. When a BOM would be written, Optimal emits the single-mode stream instead of a split (the BOM is a stream-level prefix, and a split would relocate it into the middle of the decoded text).</p>
+            </div>
+            <div class="member" data-text="public int quietzonesize { get; init; } quiet zone width in modules. defaults to 4, the iso/iec 18004 value; 0 is valid. ">
+              <code>public int QuietZoneSize { get; init; }</code>
+              <p class="doc">Quiet zone width in modules. Defaults to 4, the ISO/IEC 18004 value; 0 is valid.</p>
+            </div>
+            <div class="member" data-text="public int? maskpattern { get; init; } pin one of the eight iso/iec 18004 data mask patterns (0-7) instead of the automatic penalty-scored selection. null (the default) selects the lowest-penalty pattern. any pattern yields a valid, decodable symbol; the automatic choice merely optimizes scan reliability. for reproducing a symbol produced elsewhere byte-for-byte (the pattern another encoder chose is reported by maskpattern ), and for exercising a decoder against all eight patterns. like version , an invalid value is an argument error and is rejected here rather than when a generator reads it.">
+              <code>public int? MaskPattern { get; init; }</code>
+              <p class="doc">Pin one of the eight ISO/IEC 18004 data mask patterns (0-7) instead of the automatic penalty-scored selection. null (the default) selects the lowest-penalty pattern. Any pattern yields a valid, decodable symbol; the automatic choice merely optimizes scan reliability.</p>
+              <details class="notes" data-text="for reproducing a symbol produced elsewhere byte-for-byte (the pattern another encoder chose is reported by maskpattern ), and for exercising a decoder against all eight patterns. like version , an invalid value is an argument error and is rejected here rather than when a generator reads it.">
+                <summary>Notes</summary>
+                <p class="doc remarks">For reproducing a symbol produced elsewhere byte-for-byte (the pattern another encoder chose is reported by MaskPattern ), and for exercising a decoder against all eight patterns. Like Version , an invalid value is an argument error and is rejected here rather than when a generator reads it.</p>
+              </details>
+            </div>
+            <div class="member" data-text="public static qrcodegeneratoroptions default { get; } the default configuration, identical to default. ">
+              <code>public static QRCodeGeneratorOptions Default { get; }</code>
+              <p class="doc">The default configuration, identical to default.</p>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.QRCodeRenderer" data-name="skiasharp.qrcode.qrcoderenderer" data-text="skiasharp.qrcode.qrcoderenderer public static class qrcoderenderer provides low-level rendering capabilities for qr codes to skiasharp canvases. offers fine-grained control over appearance, including colors, shapes, gradients, and icon overlays.  public static skrect getfinderpatternrect(qrcodedata data, int patternindex, skrect renderarea); gets the rectangle area for a specified finder pattern in the rendered qr code area. the finder patterns are the large squares typically located at three corners of a qr code. this method calculates their positions based on the qr code's size and quiet zone, ensuring accurate placement within the specified rendering area. public static valuetuple&lt;skrect, skrect&gt; geticonrects(qrcodedata data, skrect area, icondata icondata); calculates icon and border rectangles for the given qr code area. when iconsizemodules is set, sizing is module-based and percent/pixel values are ignored. module-based icons are validated against qr size and core occupancy at render time. icon rectangles are snapped to the module grid; even module sizes cannot be geometrically centered on an odd qr matrix. public static void render(skcanvas canvas, skrect area, microqrcodedata data, skcolor? codecolor, skcolor? backgroundcolor, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); render the specified micro qr data into the given area of the target canvas. micro qr has a single finder pattern and no error-correction headroom for overlays, so the standard qr options for icons and custom finder pattern shapes are intentionally not available. see render for the module-run merge behavior shared with standard qr. public static void render(skcanvas canvas, skrect area, qrcodedata data, skcolor? codecolor, skcolor? backgroundcolor, icondata? icondata = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null, finderpatternshape? finderpatternshape = null); render the specified data into the given area of the target canvas. with the default rectangle shape at modulesizepercent 1.0, horizontal runs of dark modules are drawn as single merged rectangles (fewer native draw calls). merged and per-module rendering are pixel-identical under axis-preserving canvas transforms (translation/scale); under rotation, shared-edge rounding may differ at sub-pixel level. any custom module shape or a module size below 1.0 falls back to per-module drawing. public static void render(skcanvas canvas, skrect area, rmqrcodedata data, skcolor? codecolor, skcolor? backgroundcolor, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); renders an rmqr code onto the canvas. the rectangular symbol (quiet zone included) is drawn with a uniform module scale and centered in area (letterbox); the whole area receives the background. rmqr has one finder pattern and no error-correction headroom for overlays, so there are no icon or finder-shape options. module runs are merged as for the other symbologies (see render ).">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeRenderer" aria-label="Link to SkiaSharp.QrCode.QRCodeRenderer">#</a><code>public static class QRCodeRenderer</code></h3>
+          <p class="doc">Provides low-level rendering capabilities for QR codes to SkiaSharp canvases. Offers fine-grained control over appearance, including colors, shapes, gradients, and icon overlays.</p>
+          <div class="members">
+            <div class="member" data-text="public static skrect getfinderpatternrect(qrcodedata data, int patternindex, skrect renderarea); gets the rectangle area for a specified finder pattern in the rendered qr code area. the finder patterns are the large squares typically located at three corners of a qr code. this method calculates their positions based on the qr code's size and quiet zone, ensuring accurate placement within the specified rendering area.">
+              <code>public static SKRect GetFinderPatternRect(QRCodeData data, int patternIndex, SKRect renderArea);</code>
+              <p class="doc">Gets the rectangle area for a specified finder pattern in the rendered QR code area.</p>
+              <details class="notes" data-text="the finder patterns are the large squares typically located at three corners of a qr code. this method calculates their positions based on the qr code's size and quiet zone, ensuring accurate placement within the specified rendering area.">
+                <summary>Notes</summary>
+                <p class="doc remarks">The finder patterns are the large squares typically located at three corners of a QR code. This method calculates their positions based on the QR code's size and quiet zone, ensuring accurate placement within the specified rendering area.</p>
+              </details>
+            </div>
+            <div class="member" data-text="public static valuetuple&lt;skrect, skrect&gt; geticonrects(qrcodedata data, skrect area, icondata icondata); calculates icon and border rectangles for the given qr code area. when iconsizemodules is set, sizing is module-based and percent/pixel values are ignored. module-based icons are validated against qr size and core occupancy at render time. icon rectangles are snapped to the module grid; even module sizes cannot be geometrically centered on an odd qr matrix.">
+              <code>public static ValueTuple&lt;SKRect, SKRect&gt; GetIconRects(QRCodeData data, SKRect area, IconData iconData);</code>
+              <p class="doc">Calculates icon and border rectangles for the given QR code area.</p>
+              <details class="notes" data-text="when iconsizemodules is set, sizing is module-based and percent/pixel values are ignored. module-based icons are validated against qr size and core occupancy at render time. icon rectangles are snapped to the module grid; even module sizes cannot be geometrically centered on an odd qr matrix.">
+                <summary>Notes</summary>
+                <p class="doc remarks">When IconSizeModules is set, sizing is module-based and percent/pixel values are ignored. Module-based icons are validated against QR size and core occupancy at render time. Icon rectangles are snapped to the module grid; even module sizes cannot be geometrically centered on an odd QR matrix.</p>
+              </details>
+            </div>
+            <div class="member" data-text="public static void render(skcanvas canvas, skrect area, microqrcodedata data, skcolor? codecolor, skcolor? backgroundcolor, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); render the specified micro qr data into the given area of the target canvas. micro qr has a single finder pattern and no error-correction headroom for overlays, so the standard qr options for icons and custom finder pattern shapes are intentionally not available. see render for the module-run merge behavior shared with standard qr.">
+              <code>public static void Render(SKCanvas canvas, SKRect area, MicroQRCodeData data, SKColor? codeColor, SKColor? backgroundColor, ModuleShape? moduleShape = null, float moduleSizePercent = 1, GradientOptions? gradientOptions = null);</code>
+              <p class="doc">Render the specified Micro QR data into the given area of the target canvas.</p>
+              <details class="notes" data-text="micro qr has a single finder pattern and no error-correction headroom for overlays, so the standard qr options for icons and custom finder pattern shapes are intentionally not available. see render for the module-run merge behavior shared with standard qr.">
+                <summary>Notes</summary>
+                <p class="doc remarks">Micro QR has a single finder pattern and no error-correction headroom for overlays, so the Standard QR options for icons and custom finder pattern shapes are intentionally not available. See Render for the module-run merge behavior shared with Standard QR.</p>
+              </details>
+            </div>
+            <div class="member" data-text="public static void render(skcanvas canvas, skrect area, qrcodedata data, skcolor? codecolor, skcolor? backgroundcolor, icondata? icondata = null, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null, finderpatternshape? finderpatternshape = null); render the specified data into the given area of the target canvas. with the default rectangle shape at modulesizepercent 1.0, horizontal runs of dark modules are drawn as single merged rectangles (fewer native draw calls). merged and per-module rendering are pixel-identical under axis-preserving canvas transforms (translation/scale); under rotation, shared-edge rounding may differ at sub-pixel level. any custom module shape or a module size below 1.0 falls back to per-module drawing.">
+              <code>public static void Render(SKCanvas canvas, SKRect area, QRCodeData data, SKColor? codeColor, SKColor? backgroundColor, IconData? iconData = null, ModuleShape? moduleShape = null, float moduleSizePercent = 1, GradientOptions? gradientOptions = null, FinderPatternShape? finderPatternShape = null);</code>
+              <p class="doc">Render the specified data into the given area of the target canvas.</p>
+              <details class="notes" data-text="with the default rectangle shape at modulesizepercent 1.0, horizontal runs of dark modules are drawn as single merged rectangles (fewer native draw calls). merged and per-module rendering are pixel-identical under axis-preserving canvas transforms (translation/scale); under rotation, shared-edge rounding may differ at sub-pixel level. any custom module shape or a module size below 1.0 falls back to per-module drawing.">
+                <summary>Notes</summary>
+                <p class="doc remarks">With the default rectangle shape at moduleSizePercent 1.0, horizontal runs of dark modules are drawn as single merged rectangles (fewer native draw calls). Merged and per-module rendering are pixel-identical under axis-preserving canvas transforms (translation/scale); under rotation, shared-edge rounding may differ at sub-pixel level. Any custom module shape or a module size below 1.0 falls back to per-module drawing.</p>
+              </details>
+            </div>
+            <div class="member" data-text="public static void render(skcanvas canvas, skrect area, rmqrcodedata data, skcolor? codecolor, skcolor? backgroundcolor, moduleshape? moduleshape = null, float modulesizepercent = 1, gradientoptions? gradientoptions = null); renders an rmqr code onto the canvas. the rectangular symbol (quiet zone included) is drawn with a uniform module scale and centered in area (letterbox); the whole area receives the background. rmqr has one finder pattern and no error-correction headroom for overlays, so there are no icon or finder-shape options. module runs are merged as for the other symbologies (see render ).">
+              <code>public static void Render(SKCanvas canvas, SKRect area, RmQRCodeData data, SKColor? codeColor, SKColor? backgroundColor, ModuleShape? moduleShape = null, float moduleSizePercent = 1, GradientOptions? gradientOptions = null);</code>
+              <p class="doc">Renders an rMQR code onto the canvas. The rectangular symbol (quiet zone included) is drawn with a uniform module scale and centered in area (letterbox); the whole area receives the background.</p>
+              <details class="notes" data-text="rmqr has one finder pattern and no error-correction headroom for overlays, so there are no icon or finder-shape options. module runs are merged as for the other symbologies (see render ).">
+                <summary>Notes</summary>
+                <p class="doc remarks">rMQR has one finder pattern and no error-correction headroom for overlays, so there are no icon or finder-shape options. Module runs are merged as for the other symbologies (see Render ).</p>
+              </details>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.QRCodeSegmentation" data-name="skiasharp.qrcode.qrcodesegmentation" data-text="skiasharp.qrcode.qrcodesegmentation public enum qrcodesegmentation : int how qrcodegenerator splits the content into encoding-mode segments. mixed content (for example a url prefix followed by a long numeric identifier) packs into fewer bits when each run is encoded in its densest mode, which can drop the symbol by one or more versions.  single = 0, one segment in the single mode that can represent the whole content (numeric, else alphanumeric, else byte). the default, and the cheapest to encode.  optimal = 1, the mixed-mode split with the fewest total bits. never selects a larger version than single , emits the single bit stream verbatim when a split would not shrink the symbol, and additionally encodes content that overflows every version in a single mode — unless the minimal-bit plan would be misread on decode (a relocated byte order mark), in which case it reports &quot;does not fit&quot; rather than emitting a stream that decodes differently. opt-in because it searches candidate versions; the search itself allocates nothing for typical content and rents pooled buffers for long content. when utf8bom would actually write a byte order mark (a utf-8 byte-mode stream), the split is disabled and the single stream is emitted: the bom is a stream-level prefix, and a split would relocate it into the middle of the decoded text. content whose single mode is numeric or alphanumeric never carries a bom and still splits. size buffers with the same segmentation you encode with, the two can select different versions.">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeSegmentation" aria-label="Link to SkiaSharp.QrCode.QRCodeSegmentation">#</a><code>public enum QRCodeSegmentation : int</code></h3>
+          <p class="doc">How QRCodeGenerator splits the content into encoding-mode segments. Mixed content (for example a URL prefix followed by a long numeric identifier) packs into fewer bits when each run is encoded in its densest mode, which can drop the symbol by one or more versions.</p>
+          <div class="members">
+            <div class="member" data-text="single = 0, one segment in the single mode that can represent the whole content (numeric, else alphanumeric, else byte). the default, and the cheapest to encode. ">
+              <code>Single = 0,</code>
+              <p class="doc">One segment in the single mode that can represent the whole content (Numeric, else Alphanumeric, else Byte). The default, and the cheapest to encode.</p>
+            </div>
+            <div class="member" data-text="optimal = 1, the mixed-mode split with the fewest total bits. never selects a larger version than single , emits the single bit stream verbatim when a split would not shrink the symbol, and additionally encodes content that overflows every version in a single mode — unless the minimal-bit plan would be misread on decode (a relocated byte order mark), in which case it reports &quot;does not fit&quot; rather than emitting a stream that decodes differently. opt-in because it searches candidate versions; the search itself allocates nothing for typical content and rents pooled buffers for long content. when utf8bom would actually write a byte order mark (a utf-8 byte-mode stream), the split is disabled and the single stream is emitted: the bom is a stream-level prefix, and a split would relocate it into the middle of the decoded text. content whose single mode is numeric or alphanumeric never carries a bom and still splits. size buffers with the same segmentation you encode with, the two can select different versions.">
+              <code>Optimal = 1,</code>
+              <p class="doc">The mixed-mode split with the fewest total bits. Never selects a larger version than Single , emits the Single bit stream verbatim when a split would not shrink the symbol, and additionally encodes content that overflows every version in a single mode — unless the minimal-bit plan would be misread on decode (a relocated byte order mark), in which case it reports &quot;does not fit&quot; rather than emitting a stream that decodes differently.</p>
+              <details class="notes" data-text="opt-in because it searches candidate versions; the search itself allocates nothing for typical content and rents pooled buffers for long content. when utf8bom would actually write a byte order mark (a utf-8 byte-mode stream), the split is disabled and the single stream is emitted: the bom is a stream-level prefix, and a split would relocate it into the middle of the decoded text. content whose single mode is numeric or alphanumeric never carries a bom and still splits. size buffers with the same segmentation you encode with, the two can select different versions.">
+                <summary>Notes</summary>
+                <p class="doc remarks">Opt-in because it searches candidate versions; the search itself allocates nothing for typical content and rents pooled buffers for long content. When Utf8BOM would actually write a byte order mark (a UTF-8 Byte-mode stream), the split is disabled and the Single stream is emitted: the BOM is a stream-level prefix, and a split would relocate it into the middle of the decoded text. Content whose single mode is Numeric or Alphanumeric never carries a BOM and still splits. Size buffers with the same segmentation you encode with, the two can select different versions.</p>
+              </details>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.QRCodeVersionRange" data-name="skiasharp.qrcode.qrcodeversionrange" data-text="skiasharp.qrcode.qrcodeversionrange public readonly struct qrcodeversionrange : iequatable&lt;qrcodeversionrange&gt; the standard qr versions a generator may choose from: the smallest one in the range that holds the content is used. a fixed version is exactly , the degenerate case, rather than a separate setting. both bounds are inclusive, unlike range whose end is exclusive. that is why 1..40 is not usable here: it would read as 1 to 40 and mean 1 to 39. public const int maxversion; the highest version defined by iso/iec 18004.  public const int minversion; the lowest version defined by iso/iec 18004.  public qrcodeversionrange(int min, int max); an inclusive range from min to max .  public bool isany { get; } whether this range constrains nothing (the default).  public bool isexact { get; } whether this range pins a single version.  public int max { get; } the highest permitted version (40 when unbounded above).  public int min { get; } the lowest permitted version (1 when unbounded below).  public static qrcodeversionrange any { get; } every version, 1 to 40. identical to default.  public bool contains(int version); whether version falls inside this range.  public override string tostring();  public static qrcodeversionrange atleast(int version); version or larger.  public static qrcodeversionrange atmost(int version); version or smaller.  public static qrcodeversionrange between(int min, int max); an inclusive range from min to max .  public static qrcodeversionrange exactly(int version); exactly version , with no automatic selection.  public static qrcodeversionrange op_implicit(int version); a single version, as exactly . lets an option set read version = 15.  public static qrcodeversionrange op_implicit(int? version); a single version, or any when there is none. lets a caller whose version is optional pass it through without branching. -1 is not accepted as a second spelling of any : a mistyped or defaulted value must fail rather than silently produce an automatically sized symbol.">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.QRCodeVersionRange" aria-label="Link to SkiaSharp.QrCode.QRCodeVersionRange">#</a><code>public readonly struct QRCodeVersionRange : IEquatable&lt;QRCodeVersionRange&gt;</code></h3>
+          <p class="doc">The Standard QR versions a generator may choose from: the smallest one in the range that holds the content is used. A fixed version is Exactly , the degenerate case, rather than a separate setting.</p>
+          <details class="notes" data-text="both bounds are inclusive, unlike range whose end is exclusive. that is why 1..40 is not usable here: it would read as 1 to 40 and mean 1 to 39.">
+            <summary>Notes</summary>
+            <p class="doc remarks">Both bounds are inclusive, unlike Range whose end is exclusive. That is why 1..40 is not usable here: it would read as 1 to 40 and mean 1 to 39.</p>
+          </details>
+          <div class="members">
+            <div class="member" data-text="public const int maxversion; the highest version defined by iso/iec 18004. ">
+              <code>public const int MaxVersion;</code>
+              <p class="doc">The highest version defined by ISO/IEC 18004.</p>
+            </div>
+            <div class="member" data-text="public const int minversion; the lowest version defined by iso/iec 18004. ">
+              <code>public const int MinVersion;</code>
+              <p class="doc">The lowest version defined by ISO/IEC 18004.</p>
+            </div>
+            <div class="member" data-text="public qrcodeversionrange(int min, int max); an inclusive range from min to max . ">
+              <code>public QRCodeVersionRange(int min, int max);</code>
+              <p class="doc">An inclusive range from min to max .</p>
+            </div>
+            <div class="member" data-text="public bool isany { get; } whether this range constrains nothing (the default). ">
+              <code>public bool IsAny { get; }</code>
+              <p class="doc">Whether this range constrains nothing (the default).</p>
+            </div>
+            <div class="member" data-text="public bool isexact { get; } whether this range pins a single version. ">
+              <code>public bool IsExact { get; }</code>
+              <p class="doc">Whether this range pins a single version.</p>
+            </div>
+            <div class="member" data-text="public int max { get; } the highest permitted version (40 when unbounded above). ">
+              <code>public int Max { get; }</code>
+              <p class="doc">The highest permitted version (40 when unbounded above).</p>
+            </div>
+            <div class="member" data-text="public int min { get; } the lowest permitted version (1 when unbounded below). ">
+              <code>public int Min { get; }</code>
+              <p class="doc">The lowest permitted version (1 when unbounded below).</p>
+            </div>
+            <div class="member" data-text="public static qrcodeversionrange any { get; } every version, 1 to 40. identical to default. ">
+              <code>public static QRCodeVersionRange Any { get; }</code>
+              <p class="doc">Every version, 1 to 40. Identical to default.</p>
+            </div>
+            <div class="member" data-text="public bool contains(int version); whether version falls inside this range. ">
+              <code>public bool Contains(int version);</code>
+              <p class="doc">Whether version falls inside this range.</p>
+            </div>
+            <div class="member" data-text="public override string tostring(); ">
+              <code>public override string ToString();</code>
+            </div>
+            <div class="member" data-text="public static qrcodeversionrange atleast(int version); version or larger. ">
+              <code>public static QRCodeVersionRange AtLeast(int version);</code>
+              <p class="doc">version or larger.</p>
+            </div>
+            <div class="member" data-text="public static qrcodeversionrange atmost(int version); version or smaller. ">
+              <code>public static QRCodeVersionRange AtMost(int version);</code>
+              <p class="doc">version or smaller.</p>
+            </div>
+            <div class="member" data-text="public static qrcodeversionrange between(int min, int max); an inclusive range from min to max . ">
+              <code>public static QRCodeVersionRange Between(int min, int max);</code>
+              <p class="doc">An inclusive range from min to max .</p>
+            </div>
+            <div class="member" data-text="public static qrcodeversionrange exactly(int version); exactly version , with no automatic selection. ">
+              <code>public static QRCodeVersionRange Exactly(int version);</code>
+              <p class="doc">Exactly version , with no automatic selection.</p>
+            </div>
+            <div class="member" data-text="public static qrcodeversionrange op_implicit(int version); a single version, as exactly . lets an option set read version = 15. ">
+              <code>public static QRCodeVersionRange op_Implicit(int version);</code>
+              <p class="doc">A single version, as Exactly . Lets an option set read Version = 15.</p>
+            </div>
+            <div class="member" data-text="public static qrcodeversionrange op_implicit(int? version); a single version, or any when there is none. lets a caller whose version is optional pass it through without branching. -1 is not accepted as a second spelling of any : a mistyped or defaulted value must fail rather than silently produce an automatically sized symbol.">
+              <code>public static QRCodeVersionRange op_Implicit(int? version);</code>
+              <p class="doc">A single version, or Any when there is none.</p>
+              <details class="notes" data-text="lets a caller whose version is optional pass it through without branching. -1 is not accepted as a second spelling of any : a mistyped or defaulted value must fail rather than silently produce an automatically sized symbol.">
+                <summary>Notes</summary>
+                <p class="doc remarks">Lets a caller whose version is optional pass it through without branching. -1 is not accepted as a second spelling of Any : a mistyped or defaulted value must fail rather than silently produce an automatically sized symbol.</p>
+              </details>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.RmQRCodeCalculatedSize" data-name="skiasharp.qrcode.rmqrcodecalculatedsize" data-text="skiasharp.qrcode.rmqrcodecalculatedsize public readonly struct rmqrcodecalculatedsize result of trygetrequiredbuffersize : the byte count of the byte-per-module matrix, its dimensions (quiet zone included) and the version that will be used.  public rmqrversion version { get; } the rmqr version that will be generated (requested or automatically selected).  public int buffersize { get; } required destination size in bytes ( width × height ).  public int height { get; } matrix height in modules, quiet zone included.  public int width { get; } matrix width in modules, quiet zone included. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.RmQRCodeCalculatedSize" aria-label="Link to SkiaSharp.QrCode.RmQRCodeCalculatedSize">#</a><code>public readonly struct RmQRCodeCalculatedSize</code></h3>
+          <p class="doc">Result of TryGetRequiredBufferSize : the byte count of the byte-per-module matrix, its dimensions (quiet zone included) and the version that will be used.</p>
+          <div class="members">
+            <div class="member" data-text="public rmqrversion version { get; } the rmqr version that will be generated (requested or automatically selected). ">
+              <code>public RmQRVersion Version { get; }</code>
+              <p class="doc">The rMQR version that will be generated (requested or automatically selected).</p>
+            </div>
+            <div class="member" data-text="public int buffersize { get; } required destination size in bytes ( width × height ). ">
+              <code>public int BufferSize { get; }</code>
+              <p class="doc">Required destination size in bytes ( Width × Height ).</p>
+            </div>
+            <div class="member" data-text="public int height { get; } matrix height in modules, quiet zone included. ">
+              <code>public int Height { get; }</code>
+              <p class="doc">Matrix height in modules, quiet zone included.</p>
+            </div>
+            <div class="member" data-text="public int width { get; } matrix width in modules, quiet zone included. ">
+              <code>public int Width { get; }</code>
+              <p class="doc">Matrix width in modules, quiet zone included.</p>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.RmQRCodeData" data-name="skiasharp.qrcode.rmqrcodedata" data-text="skiasharp.qrcode.rmqrcodedata public class rmqrcodedata represents rmqr code data as a 2d boolean matrix (versions r7x43-r17x139, rectangular: 7-17 modules high, 27-139 modules wide). storage mirrors microqrcodedata : core modules only (no quiet zone), bit-packed msb-first in flat row-major order; the quiet zone is virtual and always reads light. serialization uses the &quot;qrx&quot; container: &quot;qrx&quot; + symbol type (1 byte, 2 = rmqr) + width (1 byte) + height (1 byte) + packed core bits. micro qr (symbol type 1) and the legacy standard qr &quot;qrr&quot; streams are rejected. public rmqrcodedata(readonlyspan&lt;byte&gt; rawdata, int quietzonesize);  public rmqrcodedata(rmqrversion version, int quietzonesize); initializes an empty (all light) matrix for the specified version.  public rmqrcodedata(byte[] rawdata, int quietzonesize); deserializes rmqr data previously produced by getrawdata .  public rmqrversion version { get; } gets the rmqr version (r7x43-r17x139).  public bool this[int row, int col] { get; } gets the module state at the specified position (quiet zone included). quiet zone positions always read false.  public int height { get; } gets the matrix height in modules, including the quiet zone.  public int width { get; } gets the matrix width in modules, including the quiet zone.  public modulerect[] getmodulerectangles(); gets the dark modules as merged rectangles in module coordinates, for rendering with any graphics api without skiasharp (svg path data, draw calls, vector output). coordinates use the same space as the indexer (this[row, col]): one unit is one module, origin at the top-left including the quiet zone, x is the column and y is the row. consumers scale by the pixel size of one module; width and height give the total extent in modules. three properties are contractual: rectangles never overlap, cover only dark modules, and cover every dark module. the decomposition shape and ordering are unspecified and may change between versions (currently maximal horizontal runs in row-major order, the same merge the built-in renderer draws). public bool trygetmodulerectangles(span&lt;modulerect&gt; destination, out int written); writes the dark modules as merged rectangles into a caller-provided buffer. same contract as getmodulerectangles without allocations.  public byte[] getrawdata(); serializes the core modules (quiet zone excluded) to a new byte array.  public int getmodulerectanglesmaxcount(); gets an upper bound on the number of rectangles getmodulerectangles can return, suitable for sizing a pooled buffer for trygetmodulerectangles . o(1), no matrix scan.  public int getrawdata(ibufferwriter&lt;byte&gt; writer); writes the serialized data to the specified buffer writer without intermediate allocation.  public int getrawdatasize(); gets the serialized size in bytes (&quot;qrx&quot; header + packed core bits). ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.RmQRCodeData" aria-label="Link to SkiaSharp.QrCode.RmQRCodeData">#</a><code>public class RmQRCodeData</code></h3>
+          <p class="doc">Represents rMQR code data as a 2D boolean matrix (versions R7x43-R17x139, rectangular: 7-17 modules high, 27-139 modules wide).</p>
+          <details class="notes" data-text="storage mirrors microqrcodedata : core modules only (no quiet zone), bit-packed msb-first in flat row-major order; the quiet zone is virtual and always reads light. serialization uses the &quot;qrx&quot; container: &quot;qrx&quot; + symbol type (1 byte, 2 = rmqr) + width (1 byte) + height (1 byte) + packed core bits. micro qr (symbol type 1) and the legacy standard qr &quot;qrr&quot; streams are rejected.">
+            <summary>Notes</summary>
+            <p class="doc remarks">Storage mirrors MicroQRCodeData : core modules only (no quiet zone), bit-packed MSB-first in flat row-major order; the quiet zone is virtual and always reads light. Serialization uses the &quot;QRX&quot; container: &quot;QRX&quot; + symbol type (1 byte, 2 = rMQR) + width (1 byte) + height (1 byte) + packed core bits. Micro QR (symbol type 1) and the legacy Standard QR &quot;QRR&quot; streams are rejected.</p>
+          </details>
+          <div class="members">
+            <div class="member" data-text="public rmqrcodedata(readonlyspan&lt;byte&gt; rawdata, int quietzonesize); ">
+              <code>public RmQRCodeData(ReadOnlySpan&lt;byte&gt; rawData, int quietZoneSize);</code>
+            </div>
+            <div class="member" data-text="public rmqrcodedata(rmqrversion version, int quietzonesize); initializes an empty (all light) matrix for the specified version. ">
+              <code>public RmQRCodeData(RmQRVersion version, int quietZoneSize);</code>
+              <p class="doc">Initializes an empty (all light) matrix for the specified version.</p>
+            </div>
+            <div class="member" data-text="public rmqrcodedata(byte[] rawdata, int quietzonesize); deserializes rmqr data previously produced by getrawdata . ">
+              <code>public RmQRCodeData(byte[] rawData, int quietZoneSize);</code>
+              <p class="doc">Deserializes rMQR data previously produced by GetRawData .</p>
+            </div>
+            <div class="member" data-text="public rmqrversion version { get; } gets the rmqr version (r7x43-r17x139). ">
+              <code>public RmQRVersion Version { get; }</code>
+              <p class="doc">Gets the rMQR version (R7x43-R17x139).</p>
+            </div>
+            <div class="member" data-text="public bool this[int row, int col] { get; } gets the module state at the specified position (quiet zone included). quiet zone positions always read false. ">
+              <code>public bool this[int row, int col] { get; }</code>
+              <p class="doc">Gets the module state at the specified position (quiet zone included). Quiet zone positions always read false.</p>
+            </div>
+            <div class="member" data-text="public int height { get; } gets the matrix height in modules, including the quiet zone. ">
+              <code>public int Height { get; }</code>
+              <p class="doc">Gets the matrix height in modules, including the quiet zone.</p>
+            </div>
+            <div class="member" data-text="public int width { get; } gets the matrix width in modules, including the quiet zone. ">
+              <code>public int Width { get; }</code>
+              <p class="doc">Gets the matrix width in modules, including the quiet zone.</p>
+            </div>
+            <div class="member" data-text="public modulerect[] getmodulerectangles(); gets the dark modules as merged rectangles in module coordinates, for rendering with any graphics api without skiasharp (svg path data, draw calls, vector output). coordinates use the same space as the indexer (this[row, col]): one unit is one module, origin at the top-left including the quiet zone, x is the column and y is the row. consumers scale by the pixel size of one module; width and height give the total extent in modules. three properties are contractual: rectangles never overlap, cover only dark modules, and cover every dark module. the decomposition shape and ordering are unspecified and may change between versions (currently maximal horizontal runs in row-major order, the same merge the built-in renderer draws).">
+              <code>public ModuleRect[] GetModuleRectangles();</code>
+              <p class="doc">Gets the dark modules as merged rectangles in module coordinates, for rendering with any graphics API without SkiaSharp (SVG path data, draw calls, vector output).</p>
+              <details class="notes" data-text="coordinates use the same space as the indexer (this[row, col]): one unit is one module, origin at the top-left including the quiet zone, x is the column and y is the row. consumers scale by the pixel size of one module; width and height give the total extent in modules. three properties are contractual: rectangles never overlap, cover only dark modules, and cover every dark module. the decomposition shape and ordering are unspecified and may change between versions (currently maximal horizontal runs in row-major order, the same merge the built-in renderer draws).">
+                <summary>Notes</summary>
+                <p class="doc remarks">Coordinates use the same space as the indexer (this[row, col]): one unit is one module, origin at the top-left including the quiet zone, X is the column and Y is the row. Consumers scale by the pixel size of one module; Width and Height give the total extent in modules. Three properties are contractual: rectangles never overlap, cover only dark modules, and cover every dark module. The decomposition shape and ordering are unspecified and may change between versions (currently maximal horizontal runs in row-major order, the same merge the built-in renderer draws).</p>
+              </details>
+            </div>
+            <div class="member" data-text="public bool trygetmodulerectangles(span&lt;modulerect&gt; destination, out int written); writes the dark modules as merged rectangles into a caller-provided buffer. same contract as getmodulerectangles without allocations. ">
+              <code>public bool TryGetModuleRectangles(Span&lt;ModuleRect&gt; destination, out int written);</code>
+              <p class="doc">Writes the dark modules as merged rectangles into a caller-provided buffer. Same contract as GetModuleRectangles without allocations.</p>
+            </div>
+            <div class="member" data-text="public byte[] getrawdata(); serializes the core modules (quiet zone excluded) to a new byte array. ">
+              <code>public byte[] GetRawData();</code>
+              <p class="doc">Serializes the core modules (quiet zone excluded) to a new byte array.</p>
+            </div>
+            <div class="member" data-text="public int getmodulerectanglesmaxcount(); gets an upper bound on the number of rectangles getmodulerectangles can return, suitable for sizing a pooled buffer for trygetmodulerectangles . o(1), no matrix scan. ">
+              <code>public int GetModuleRectanglesMaxCount();</code>
+              <p class="doc">Gets an upper bound on the number of rectangles GetModuleRectangles can return, suitable for sizing a pooled buffer for TryGetModuleRectangles . O(1), no matrix scan.</p>
+            </div>
+            <div class="member" data-text="public int getrawdata(ibufferwriter&lt;byte&gt; writer); writes the serialized data to the specified buffer writer without intermediate allocation. ">
+              <code>public int GetRawData(IBufferWriter&lt;byte&gt; writer);</code>
+              <p class="doc">Writes the serialized data to the specified buffer writer without intermediate allocation.</p>
+            </div>
+            <div class="member" data-text="public int getrawdatasize(); gets the serialized size in bytes (&quot;qrx&quot; header + packed core bits). ">
+              <code>public int GetRawDataSize();</code>
+              <p class="doc">Gets the serialized size in bytes (&quot;QRX&quot; header + packed core bits).</p>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.RmQRCodeDecodeInfo" data-name="skiasharp.qrcode.rmqrcodedecodeinfo" data-text="skiasharp.qrcode.rmqrcodedecodeinfo public readonly struct rmqrcodedecodeinfo diagnostic information from an rmqr decode attempt ( rmqrcodedecoder ): status, and when the format information could be read, the version and ecc level plus the number of reed-solomon codeword corrections applied. rmqr has a single data mask, so there is no mask pattern to report.  public qrcodedecodestatus status { get; } decode outcome; success when text was produced.  public rmqrecclevel ecclevel { get; } the ecc level read from the format information (valid once the format decoded).  public rmqrversion version { get; } the symbol version (from the physical dimensions), or 0 when the input is not an rmqr matrix.  public int errorscorrected { get; } total reed-solomon codeword corrections across all blocks (0 for a clean symbol). ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.RmQRCodeDecodeInfo" aria-label="Link to SkiaSharp.QrCode.RmQRCodeDecodeInfo">#</a><code>public readonly struct RmQRCodeDecodeInfo</code></h3>
+          <p class="doc">Diagnostic information from an rMQR decode attempt ( RmQRCodeDecoder ): status, and when the format information could be read, the version and ECC level plus the number of Reed-Solomon codeword corrections applied. rMQR has a single data mask, so there is no mask pattern to report.</p>
+          <div class="members">
+            <div class="member" data-text="public qrcodedecodestatus status { get; } decode outcome; success when text was produced. ">
+              <code>public QRCodeDecodeStatus Status { get; }</code>
+              <p class="doc">Decode outcome; Success when text was produced.</p>
+            </div>
+            <div class="member" data-text="public rmqrecclevel ecclevel { get; } the ecc level read from the format information (valid once the format decoded). ">
+              <code>public RmQREccLevel EccLevel { get; }</code>
+              <p class="doc">The ECC level read from the format information (valid once the format decoded).</p>
+            </div>
+            <div class="member" data-text="public rmqrversion version { get; } the symbol version (from the physical dimensions), or 0 when the input is not an rmqr matrix. ">
+              <code>public RmQRVersion Version { get; }</code>
+              <p class="doc">The symbol version (from the physical dimensions), or 0 when the input is not an rMQR matrix.</p>
+            </div>
+            <div class="member" data-text="public int errorscorrected { get; } total reed-solomon codeword corrections across all blocks (0 for a clean symbol). ">
+              <code>public int ErrorsCorrected { get; }</code>
+              <p class="doc">Total Reed-Solomon codeword corrections across all blocks (0 for a clean symbol).</p>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.RmQRCodeDecoder" data-name="skiasharp.qrcode.rmqrcodedecoder" data-text="skiasharp.qrcode.rmqrcodedecoder public static class rmqrcodedecoder rmqr code (iso/iec 23941) decoder: module matrix → text. sibling of qrcodedecoder and microqrcodedecoder ; explicitly typed so standard qr scanning stays unaffected. matrix-level and image-level decoding ( trydecode / trydecodeimage ). every overload accepts an rmqr matrix with or without a light quiet zone: the dark bounding box (finder corner top-left, sub-finder corner bottom-right, timing patterns on all four edges) locates the core, so uniform and asymmetric borders are stripped automatically. reed-solomon corrections are applied at full block strength (⌊ecc/2⌋ per block) and reported in errorscorrected . numeric, alphanumeric and byte segments (iso-8859-1 / utf-8, with or without eci) are supported, plus kanji segments decoded as jis x 0208; the generator never emits kanji, so it is a read-only mode here. a kanji cell outside the jis x 0208 repertoire fails the whole symbol with unmappedcharacter rather than substituting a replacement character. public static bool trydecode(readonlyspan&lt;byte&gt; modules, int width, int height, span&lt;char&gt; destination, out int charswritten, out rmqrcodedecodeinfo info); decodes the text content from a module matrix into a caller-provided buffer without per-call heap allocation.  public static bool trydecode(readonlyspan&lt;byte&gt; modules, int width, int height, out string text, out rmqrcodedecodeinfo info); decodes the text content from a module matrix.  public static bool trydecode(rmqrcodedata data, out string text); decodes the text content of an rmqrcodedata matrix.  public static bool trydecode(rmqrcodedata data, out string text, out rmqrcodedecodeinfo info); decodes the text content of an rmqrcodedata matrix with diagnostics.  public static bool trydecode(skbitmap bitmap, out string text); detects and decodes an rmqr code from a bitmap image. targets clean, well-lit images such as screenshots, rendered symbols and scans: arbitrary rotation, mirroring, reflectance reversal (light-on-dark), uniform or non-uniform scaling, translation and mild perspective distortion are handled. strong perspective, uneven lighting and blur are out of scope. public static bool trydecode(skbitmap bitmap, out string text, out rmqrcodedecodeinfo info); detects and decodes an rmqr code from a bitmap image, with diagnostic information. see trydecode for the supported image envelope. public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, span&lt;char&gt; destination, out int charswritten, out rmqrcodedecodeinfo info); detects and decodes an rmqr code from grayscale image pixels into a caller-provided buffer without per-call heap allocation.  public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, out string text, out rmqrcodedecodeinfo info); detects and decodes an rmqr code from grayscale image pixels.  public static int getmaxdecodedlength(rmqrversion version); calculates the maximum possible decoded character count for an rmqr version, across ecc levels and encoding modes. use to size the destination buffer for the allocation-free trydecode overload. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.RmQRCodeDecoder" aria-label="Link to SkiaSharp.QrCode.RmQRCodeDecoder">#</a><code>public static class RmQRCodeDecoder</code></h3>
+          <p class="doc">rMQR Code (ISO/IEC 23941) decoder: module matrix → text. Sibling of QRCodeDecoder and MicroQRCodeDecoder ; explicitly typed so Standard QR scanning stays unaffected. Matrix-level and image-level decoding ( TryDecode / TryDecodeImage ).</p>
+          <details class="notes" data-text="every overload accepts an rmqr matrix with or without a light quiet zone: the dark bounding box (finder corner top-left, sub-finder corner bottom-right, timing patterns on all four edges) locates the core, so uniform and asymmetric borders are stripped automatically. reed-solomon corrections are applied at full block strength (⌊ecc/2⌋ per block) and reported in errorscorrected . numeric, alphanumeric and byte segments (iso-8859-1 / utf-8, with or without eci) are supported, plus kanji segments decoded as jis x 0208; the generator never emits kanji, so it is a read-only mode here. a kanji cell outside the jis x 0208 repertoire fails the whole symbol with unmappedcharacter rather than substituting a replacement character.">
+            <summary>Notes</summary>
+            <p class="doc remarks">Every overload accepts an rMQR matrix with or without a light quiet zone: the dark bounding box (finder corner top-left, sub-finder corner bottom-right, timing patterns on all four edges) locates the core, so uniform and asymmetric borders are stripped automatically. Reed-Solomon corrections are applied at full block strength (⌊ecc/2⌋ per block) and reported in ErrorsCorrected . Numeric, Alphanumeric and Byte segments (ISO-8859-1 / UTF-8, with or without ECI) are supported, plus Kanji segments decoded as JIS X 0208; the generator never emits Kanji, so it is a read-only mode here. A Kanji cell outside the JIS X 0208 repertoire fails the whole symbol with UnmappedCharacter rather than substituting a replacement character.</p>
+          </details>
+          <div class="members">
+            <div class="member" data-text="public static bool trydecode(readonlyspan&lt;byte&gt; modules, int width, int height, span&lt;char&gt; destination, out int charswritten, out rmqrcodedecodeinfo info); decodes the text content from a module matrix into a caller-provided buffer without per-call heap allocation. ">
+              <code>public static bool TryDecode(ReadOnlySpan&lt;byte&gt; modules, int width, int height, Span&lt;char&gt; destination, out int charsWritten, out RmQRCodeDecodeInfo info);</code>
+              <p class="doc">Decodes the text content from a module matrix into a caller-provided buffer without per-call heap allocation.</p>
+            </div>
+            <div class="member" data-text="public static bool trydecode(readonlyspan&lt;byte&gt; modules, int width, int height, out string text, out rmqrcodedecodeinfo info); decodes the text content from a module matrix. ">
+              <code>public static bool TryDecode(ReadOnlySpan&lt;byte&gt; modules, int width, int height, out string text, out RmQRCodeDecodeInfo info);</code>
+              <p class="doc">Decodes the text content from a module matrix.</p>
+            </div>
+            <div class="member" data-text="public static bool trydecode(rmqrcodedata data, out string text); decodes the text content of an rmqrcodedata matrix. ">
+              <code>public static bool TryDecode(RmQRCodeData data, out string text);</code>
+              <p class="doc">Decodes the text content of an RmQRCodeData matrix.</p>
+            </div>
+            <div class="member" data-text="public static bool trydecode(rmqrcodedata data, out string text, out rmqrcodedecodeinfo info); decodes the text content of an rmqrcodedata matrix with diagnostics. ">
+              <code>public static bool TryDecode(RmQRCodeData data, out string text, out RmQRCodeDecodeInfo info);</code>
+              <p class="doc">Decodes the text content of an RmQRCodeData matrix with diagnostics.</p>
+            </div>
+            <div class="member" data-text="public static bool trydecode(skbitmap bitmap, out string text); detects and decodes an rmqr code from a bitmap image. targets clean, well-lit images such as screenshots, rendered symbols and scans: arbitrary rotation, mirroring, reflectance reversal (light-on-dark), uniform or non-uniform scaling, translation and mild perspective distortion are handled. strong perspective, uneven lighting and blur are out of scope.">
+              <code>public static bool TryDecode(SKBitmap bitmap, out string text);</code>
+              <p class="doc">Detects and decodes an rMQR Code from a bitmap image.</p>
+              <details class="notes" data-text="targets clean, well-lit images such as screenshots, rendered symbols and scans: arbitrary rotation, mirroring, reflectance reversal (light-on-dark), uniform or non-uniform scaling, translation and mild perspective distortion are handled. strong perspective, uneven lighting and blur are out of scope.">
+                <summary>Notes</summary>
+                <p class="doc remarks">Targets clean, well-lit images such as screenshots, rendered symbols and scans: arbitrary rotation, mirroring, reflectance reversal (light-on-dark), uniform or non-uniform scaling, translation and mild perspective distortion are handled. Strong perspective, uneven lighting and blur are out of scope.</p>
+              </details>
+            </div>
+            <div class="member" data-text="public static bool trydecode(skbitmap bitmap, out string text, out rmqrcodedecodeinfo info); detects and decodes an rmqr code from a bitmap image, with diagnostic information. see trydecode for the supported image envelope.">
+              <code>public static bool TryDecode(SKBitmap bitmap, out string text, out RmQRCodeDecodeInfo info);</code>
+              <p class="doc">Detects and decodes an rMQR Code from a bitmap image, with diagnostic information.</p>
+              <details class="notes" data-text="see trydecode for the supported image envelope.">
+                <summary>Notes</summary>
+                <p class="doc remarks">See TryDecode for the supported image envelope.</p>
+              </details>
+            </div>
+            <div class="member" data-text="public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, span&lt;char&gt; destination, out int charswritten, out rmqrcodedecodeinfo info); detects and decodes an rmqr code from grayscale image pixels into a caller-provided buffer without per-call heap allocation. ">
+              <code>public static bool TryDecodeImage(ReadOnlySpan&lt;byte&gt; luminance, int width, int height, Span&lt;char&gt; destination, out int charsWritten, out RmQRCodeDecodeInfo info);</code>
+              <p class="doc">Detects and decodes an rMQR Code from grayscale image pixels into a caller-provided buffer without per-call heap allocation.</p>
+            </div>
+            <div class="member" data-text="public static bool trydecodeimage(readonlyspan&lt;byte&gt; luminance, int width, int height, out string text, out rmqrcodedecodeinfo info); detects and decodes an rmqr code from grayscale image pixels. ">
+              <code>public static bool TryDecodeImage(ReadOnlySpan&lt;byte&gt; luminance, int width, int height, out string text, out RmQRCodeDecodeInfo info);</code>
+              <p class="doc">Detects and decodes an rMQR Code from grayscale image pixels.</p>
+            </div>
+            <div class="member" data-text="public static int getmaxdecodedlength(rmqrversion version); calculates the maximum possible decoded character count for an rmqr version, across ecc levels and encoding modes. use to size the destination buffer for the allocation-free trydecode overload. ">
+              <code>public static int GetMaxDecodedLength(RmQRVersion version);</code>
+              <p class="doc">Calculates the maximum possible decoded character count for an rMQR version, across ECC levels and encoding modes. Use to size the destination buffer for the allocation-free TryDecode overload.</p>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.RmQRCodeGenerator" data-name="skiasharp.qrcode.rmqrcodegenerator" data-text="skiasharp.qrcode.rmqrcodegenerator public static class rmqrcodegenerator rmqr code (iso/iec 23941, r7x43-r17x139) generator: text → rectangular module matrix. sibling of qrcodegenerator and microqrcodegenerator with rmqr-typed version, ecc and fit parameters. version selection: an exact rmqrversion , or automatic fit among the versions that hold the content by rmqrfitstrategy (default minimizearea : fewest modules, the choice both reference encoders make; note it can prefer a taller, narrower symbol, e.g. 12 digits at m give r11x27 (297 modules) rather than r7x43 (301); use minimizeheight or a fixed rmqrheight for the flattest symbol), optionally restricted to one height. modes: numeric, alphanumeric and byte. byte mode emits eci assignment 3 for iso-8859-1 and assignment 26 for utf-8 (automatically selected by default, or explicitly requested). kanji is not written, use utf-8 instead; rmqrcodedecoder does read the kanji segments other encoders produce, so the two directions are deliberately asymmetric. the quiet zone defaults to the iso/iec 23941 value of 2 modules. public static rmqrcodedata creatermqrcode(readonlyspan&lt;char&gt; textspan, rmqrecclevel ecclevel, in rmqrcodegeneratoroptions options = null);  public static rmqrcodedata creatermqrcode(string plaintext, rmqrecclevel ecclevel, in rmqrcodegeneratoroptions options = null); creates an rmqr code from the provided plain text.  public static bool trygetrequiredbuffersize(readonlyspan&lt;char&gt; text, rmqrecclevel ecclevel, out rmqrcodecalculatedsize size, in rmqrcodegeneratoroptions options = null); calculates the required buffer size, dimensions and version for encoding the specified text as an rmqr code, reporting a content overflow as false rather than as an exception. false means the content does not fit, and nothing else: argument errors throw (rationale: specs/rmqr-encoder.md). rmqr holds 5-150 bytes, so an overflow is an ordinary answer here rather than a defect, which is why this is the only sizing method on this type. pass the same options you will encode with: segmentation and eci can select different versions, so a buffer sized for one can be too small for the other. public static int creatermqrcode(readonlyspan&lt;char&gt; textspan, rmqrecclevel ecclevel, span&lt;byte&gt; destination, in rmqrcodegeneratoroptions options = null); creates an rmqr code and writes the module matrix into the caller-provided buffer without per-call heap allocation. output format matches the other generators: one byte per module (0 = light, 1 = dark), flat row-major over the full width, quiet zone included. use trygetrequiredbuffersize to size the destination.">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.RmQRCodeGenerator" aria-label="Link to SkiaSharp.QrCode.RmQRCodeGenerator">#</a><code>public static class RmQRCodeGenerator</code></h3>
+          <p class="doc">rMQR Code (ISO/IEC 23941, R7x43-R17x139) generator: text → rectangular module matrix. Sibling of QRCodeGenerator and MicroQRCodeGenerator with rMQR-typed version, ECC and fit parameters.</p>
+          <details class="notes" data-text="version selection: an exact rmqrversion , or automatic fit among the versions that hold the content by rmqrfitstrategy (default minimizearea : fewest modules, the choice both reference encoders make; note it can prefer a taller, narrower symbol, e.g. 12 digits at m give r11x27 (297 modules) rather than r7x43 (301); use minimizeheight or a fixed rmqrheight for the flattest symbol), optionally restricted to one height. modes: numeric, alphanumeric and byte. byte mode emits eci assignment 3 for iso-8859-1 and assignment 26 for utf-8 (automatically selected by default, or explicitly requested). kanji is not written, use utf-8 instead; rmqrcodedecoder does read the kanji segments other encoders produce, so the two directions are deliberately asymmetric. the quiet zone defaults to the iso/iec 23941 value of 2 modules.">
+            <summary>Notes</summary>
+            <p class="doc remarks">Version selection: an exact RmQRVersion , or automatic fit among the versions that hold the content by RmQRFitStrategy (default MinimizeArea : fewest modules, the choice both reference encoders make; note it can prefer a taller, narrower symbol, e.g. 12 digits at M give R11x27 (297 modules) rather than R7x43 (301); use MinimizeHeight or a fixed RmQRHeight for the flattest symbol), optionally restricted to one height. Modes: Numeric, Alphanumeric and Byte. Byte mode emits ECI assignment 3 for ISO-8859-1 and assignment 26 for UTF-8 (automatically selected by default, or explicitly requested). Kanji is not written, use UTF-8 instead; RmQRCodeDecoder does read the Kanji segments other encoders produce, so the two directions are deliberately asymmetric. The quiet zone defaults to the ISO/IEC 23941 value of 2 modules.</p>
+          </details>
+          <div class="members">
+            <div class="member" data-text="public static rmqrcodedata creatermqrcode(readonlyspan&lt;char&gt; textspan, rmqrecclevel ecclevel, in rmqrcodegeneratoroptions options = null); ">
+              <code>public static RmQRCodeData CreateRmQRCode(ReadOnlySpan&lt;char&gt; textSpan, RmQREccLevel eccLevel, in RmQRCodeGeneratorOptions options = null);</code>
+            </div>
+            <div class="member" data-text="public static rmqrcodedata creatermqrcode(string plaintext, rmqrecclevel ecclevel, in rmqrcodegeneratoroptions options = null); creates an rmqr code from the provided plain text. ">
+              <code>public static RmQRCodeData CreateRmQRCode(string plainText, RmQREccLevel eccLevel, in RmQRCodeGeneratorOptions options = null);</code>
+              <p class="doc">Creates an rMQR code from the provided plain text.</p>
+            </div>
+            <div class="member" data-text="public static bool trygetrequiredbuffersize(readonlyspan&lt;char&gt; text, rmqrecclevel ecclevel, out rmqrcodecalculatedsize size, in rmqrcodegeneratoroptions options = null); calculates the required buffer size, dimensions and version for encoding the specified text as an rmqr code, reporting a content overflow as false rather than as an exception. false means the content does not fit, and nothing else: argument errors throw (rationale: specs/rmqr-encoder.md). rmqr holds 5-150 bytes, so an overflow is an ordinary answer here rather than a defect, which is why this is the only sizing method on this type. pass the same options you will encode with: segmentation and eci can select different versions, so a buffer sized for one can be too small for the other.">
+              <code>public static bool TryGetRequiredBufferSize(ReadOnlySpan&lt;char&gt; text, RmQREccLevel eccLevel, out RmQRCodeCalculatedSize size, in RmQRCodeGeneratorOptions options = null);</code>
+              <p class="doc">Calculates the required buffer size, dimensions and version for encoding the specified text as an rMQR code, reporting a content overflow as false rather than as an exception.</p>
+              <details class="notes" data-text="false means the content does not fit, and nothing else: argument errors throw (rationale: specs/rmqr-encoder.md). rmqr holds 5-150 bytes, so an overflow is an ordinary answer here rather than a defect, which is why this is the only sizing method on this type. pass the same options you will encode with: segmentation and eci can select different versions, so a buffer sized for one can be too small for the other.">
+                <summary>Notes</summary>
+                <p class="doc remarks">false means the content does not fit, and nothing else: argument errors throw (rationale: specs/rmqr-encoder.md). rMQR holds 5-150 bytes, so an overflow is an ordinary answer here rather than a defect, which is why this is the only sizing method on this type. Pass the same options you will encode with: segmentation and ECI can select different versions, so a buffer sized for one can be too small for the other.</p>
+              </details>
+            </div>
+            <div class="member" data-text="public static int creatermqrcode(readonlyspan&lt;char&gt; textspan, rmqrecclevel ecclevel, span&lt;byte&gt; destination, in rmqrcodegeneratoroptions options = null); creates an rmqr code and writes the module matrix into the caller-provided buffer without per-call heap allocation. output format matches the other generators: one byte per module (0 = light, 1 = dark), flat row-major over the full width, quiet zone included. use trygetrequiredbuffersize to size the destination.">
+              <code>public static int CreateRmQRCode(ReadOnlySpan&lt;char&gt; textSpan, RmQREccLevel eccLevel, Span&lt;byte&gt; destination, in RmQRCodeGeneratorOptions options = null);</code>
+              <p class="doc">Creates an rMQR code and writes the module matrix into the caller-provided buffer without per-call heap allocation.</p>
+              <details class="notes" data-text="output format matches the other generators: one byte per module (0 = light, 1 = dark), flat row-major over the full width, quiet zone included. use trygetrequiredbuffersize to size the destination.">
+                <summary>Notes</summary>
+                <p class="doc remarks">Output format matches the other generators: one byte per module (0 = light, 1 = dark), flat row-major over the full width, quiet zone included. Use TryGetRequiredBufferSize to size the destination.</p>
+              </details>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.RmQRCodeGeneratorOptions" data-name="skiasharp.qrcode.rmqrcodegeneratoroptions" data-text="skiasharp.qrcode.rmqrcodegeneratoroptions public readonly struct rmqrcodegeneratoroptions : iequatable&lt;rmqrcodegeneratoroptions&gt; optional settings for rmqrcodegenerator . default is the complete default configuration and is what an omitted argument sends, so the shortest correct call is creatermqrcode(text, ecclevel). rmqr specific rather than shared: version is a different type in each symbology, quietzonesize has a different specified default, and fitstrategy , height and segmentation have no meaning outside rmqr. there is no version range here because rmqr's 32 versions are not totally ordered; fit is constrained by strategy and height instead. public ecimode ecimode { get; init; } character encoding declaration. the default auto-detects ascii (no eci), iso-8859-1 (assignment 3) or utf-8 (assignment 26) from the content. only default , iso8859_1 and utf8 are accepted. declaring latin-1 over content it cannot represent throws rather than silently re-encoding. public rmqrfitstrategy fitstrategy { get; init; } how to choose among the versions that hold the content. defaults to minimizearea , the choice both reference encoders make.  public rmqrheight? height { get; init; } restrict automatic fitting to one symbol height, or null (the default) to consider every height. must agree with version when both are set.  public rmqrsegmentation segmentation { get; init; } whether to split the content into mixed-mode segments. defaults to single . size a destination buffer with the same value you encode with: the two modes can select different versions.  public rmqrversion? version { get; init; } a specific version, or null (the default) to fit one automatically by fitstrategy and height .  public int quietzonesize { get; init; } quiet zone width in modules. defaults to 2, the iso/iec 23941 value; 0 is valid.  public static rmqrcodegeneratoroptions default { get; } the default configuration, identical to default. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.RmQRCodeGeneratorOptions" aria-label="Link to SkiaSharp.QrCode.RmQRCodeGeneratorOptions">#</a><code>public readonly struct RmQRCodeGeneratorOptions : IEquatable&lt;RmQRCodeGeneratorOptions&gt;</code></h3>
+          <p class="doc">Optional settings for RmQRCodeGenerator . default is the complete default configuration and is what an omitted argument sends, so the shortest correct call is CreateRmQRCode(text, eccLevel).</p>
+          <details class="notes" data-text="rmqr specific rather than shared: version is a different type in each symbology, quietzonesize has a different specified default, and fitstrategy , height and segmentation have no meaning outside rmqr. there is no version range here because rmqr's 32 versions are not totally ordered; fit is constrained by strategy and height instead.">
+            <summary>Notes</summary>
+            <p class="doc remarks">rMQR specific rather than shared: Version is a different type in each symbology, QuietZoneSize has a different specified default, and FitStrategy , Height and Segmentation have no meaning outside rMQR. There is no version range here because rMQR's 32 versions are not totally ordered; fit is constrained by strategy and height instead.</p>
+          </details>
+          <div class="members">
+            <div class="member" data-text="public ecimode ecimode { get; init; } character encoding declaration. the default auto-detects ascii (no eci), iso-8859-1 (assignment 3) or utf-8 (assignment 26) from the content. only default , iso8859_1 and utf8 are accepted. declaring latin-1 over content it cannot represent throws rather than silently re-encoding.">
+              <code>public EciMode EciMode { get; init; }</code>
+              <p class="doc">Character encoding declaration. The default auto-detects ASCII (no ECI), ISO-8859-1 (assignment 3) or UTF-8 (assignment 26) from the content.</p>
+              <details class="notes" data-text="only default , iso8859_1 and utf8 are accepted. declaring latin-1 over content it cannot represent throws rather than silently re-encoding.">
+                <summary>Notes</summary>
+                <p class="doc remarks">Only Default , Iso8859_1 and Utf8 are accepted. Declaring Latin-1 over content it cannot represent throws rather than silently re-encoding.</p>
+              </details>
+            </div>
+            <div class="member" data-text="public rmqrfitstrategy fitstrategy { get; init; } how to choose among the versions that hold the content. defaults to minimizearea , the choice both reference encoders make. ">
+              <code>public RmQRFitStrategy FitStrategy { get; init; }</code>
+              <p class="doc">How to choose among the versions that hold the content. Defaults to MinimizeArea , the choice both reference encoders make.</p>
+            </div>
+            <div class="member" data-text="public rmqrheight? height { get; init; } restrict automatic fitting to one symbol height, or null (the default) to consider every height. must agree with version when both are set. ">
+              <code>public RmQRHeight? Height { get; init; }</code>
+              <p class="doc">Restrict automatic fitting to one symbol height, or null (the default) to consider every height. Must agree with Version when both are set.</p>
+            </div>
+            <div class="member" data-text="public rmqrsegmentation segmentation { get; init; } whether to split the content into mixed-mode segments. defaults to single . size a destination buffer with the same value you encode with: the two modes can select different versions. ">
+              <code>public RmQRSegmentation Segmentation { get; init; }</code>
+              <p class="doc">Whether to split the content into mixed-mode segments. Defaults to Single . Size a destination buffer with the same value you encode with: the two modes can select different versions.</p>
+            </div>
+            <div class="member" data-text="public rmqrversion? version { get; init; } a specific version, or null (the default) to fit one automatically by fitstrategy and height . ">
+              <code>public RmQRVersion? Version { get; init; }</code>
+              <p class="doc">A specific version, or null (the default) to fit one automatically by FitStrategy and Height .</p>
+            </div>
+            <div class="member" data-text="public int quietzonesize { get; init; } quiet zone width in modules. defaults to 2, the iso/iec 23941 value; 0 is valid. ">
+              <code>public int QuietZoneSize { get; init; }</code>
+              <p class="doc">Quiet zone width in modules. Defaults to 2, the ISO/IEC 23941 value; 0 is valid.</p>
+            </div>
+            <div class="member" data-text="public static rmqrcodegeneratoroptions default { get; } the default configuration, identical to default. ">
+              <code>public static RmQRCodeGeneratorOptions Default { get; }</code>
+              <p class="doc">The default configuration, identical to default.</p>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.RmQREccLevel" data-name="skiasharp.qrcode.rmqrecclevel" data-text="skiasharp.qrcode.rmqrecclevel public enum rmqrecclevel : int rmqr code error correction level (iso/iec 23941). rmqr defines only two levels; the numeric value is the ecc bit carried in the format information.  m = 0, medium: about 15% of codewords recoverable.  h = 1, high: about 30% of codewords recoverable. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.RmQREccLevel" aria-label="Link to SkiaSharp.QrCode.RmQREccLevel">#</a><code>public enum RmQREccLevel : int</code></h3>
+          <p class="doc">rMQR Code error correction level (ISO/IEC 23941). rMQR defines only two levels; the numeric value is the ECC bit carried in the format information.</p>
+          <div class="members">
+            <div class="member" data-text="m = 0, medium: about 15% of codewords recoverable. ">
+              <code>M = 0,</code>
+              <p class="doc">Medium: about 15% of codewords recoverable.</p>
+            </div>
+            <div class="member" data-text="h = 1, high: about 30% of codewords recoverable. ">
+              <code>H = 1,</code>
+              <p class="doc">High: about 30% of codewords recoverable.</p>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.RmQRFitStrategy" data-name="skiasharp.qrcode.rmqrfitstrategy" data-text="skiasharp.qrcode.rmqrfitstrategy public enum rmqrfitstrategy : int how rmqrcodegenerator chooses among the rmqr versions that can hold the content when no exact version is requested. rmqr sizes are two-dimensional, so &quot;smallest&quot; is a policy: fewest modules, narrowest, or shortest.  minimizearea = 0, fewest modules (height × width); ties prefer the smaller height, i.e. the wider symbol. the default.  minimizewidth = 1, smallest width; ties prefer the smaller height.  minimizeheight = 2, smallest height; ties prefer the smaller width. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.RmQRFitStrategy" aria-label="Link to SkiaSharp.QrCode.RmQRFitStrategy">#</a><code>public enum RmQRFitStrategy : int</code></h3>
+          <p class="doc">How RmQRCodeGenerator chooses among the rMQR versions that can hold the content when no exact version is requested. rMQR sizes are two-dimensional, so &quot;smallest&quot; is a policy: fewest modules, narrowest, or shortest.</p>
+          <div class="members">
+            <div class="member" data-text="minimizearea = 0, fewest modules (height × width); ties prefer the smaller height, i.e. the wider symbol. the default. ">
+              <code>MinimizeArea = 0,</code>
+              <p class="doc">Fewest modules (height × width); ties prefer the smaller height, i.e. the wider symbol. The default.</p>
+            </div>
+            <div class="member" data-text="minimizewidth = 1, smallest width; ties prefer the smaller height. ">
+              <code>MinimizeWidth = 1,</code>
+              <p class="doc">Smallest width; ties prefer the smaller height.</p>
+            </div>
+            <div class="member" data-text="minimizeheight = 2, smallest height; ties prefer the smaller width. ">
+              <code>MinimizeHeight = 2,</code>
+              <p class="doc">Smallest height; ties prefer the smaller width.</p>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.RmQRHeight" data-name="skiasharp.qrcode.rmqrheight" data-text="skiasharp.qrcode.rmqrheight public enum rmqrheight : int fixed rmqr symbol height in modules for automatic width selection (&quot;fixed height, automatic width&quot;): the generator only considers the versions of this height and picks among them by rmqrfitstrategy . values are the module heights themselves.  h7 = 7, 7 modules high (widths 43-139).  h9 = 9, 9 modules high (widths 43-139).  h11 = 11, 11 modules high (widths 27-139).  h13 = 13, 13 modules high (widths 27-139).  h15 = 15, 15 modules high (widths 43-139).  h17 = 17, 17 modules high (widths 43-139). ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.RmQRHeight" aria-label="Link to SkiaSharp.QrCode.RmQRHeight">#</a><code>public enum RmQRHeight : int</code></h3>
+          <p class="doc">Fixed rMQR symbol height in modules for automatic width selection (&quot;fixed height, automatic width&quot;): the generator only considers the versions of this height and picks among them by RmQRFitStrategy . Values are the module heights themselves.</p>
+          <div class="members">
+            <div class="member" data-text="h7 = 7, 7 modules high (widths 43-139). ">
+              <code>H7 = 7,</code>
+              <p class="doc">7 modules high (widths 43-139).</p>
+            </div>
+            <div class="member" data-text="h9 = 9, 9 modules high (widths 43-139). ">
+              <code>H9 = 9,</code>
+              <p class="doc">9 modules high (widths 43-139).</p>
+            </div>
+            <div class="member" data-text="h11 = 11, 11 modules high (widths 27-139). ">
+              <code>H11 = 11,</code>
+              <p class="doc">11 modules high (widths 27-139).</p>
+            </div>
+            <div class="member" data-text="h13 = 13, 13 modules high (widths 27-139). ">
+              <code>H13 = 13,</code>
+              <p class="doc">13 modules high (widths 27-139).</p>
+            </div>
+            <div class="member" data-text="h15 = 15, 15 modules high (widths 43-139). ">
+              <code>H15 = 15,</code>
+              <p class="doc">15 modules high (widths 43-139).</p>
+            </div>
+            <div class="member" data-text="h17 = 17, 17 modules high (widths 43-139). ">
+              <code>H17 = 17,</code>
+              <p class="doc">17 modules high (widths 43-139).</p>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.RmQRSegmentation" data-name="skiasharp.qrcode.rmqrsegmentation" data-text="skiasharp.qrcode.rmqrsegmentation public enum rmqrsegmentation : int how rmqrcodegenerator splits the content into encoding-mode segments. rmqr capacities are small, so mixing modes (for example a byte prefix followed by a numeric tail) can drop the symbol by one or more versions.  single = 0, one segment in the single mode that can represent the whole content (numeric, else alphanumeric, else byte). the default, and the cheapest to encode.  optimal = 1, the mixed-mode split with the fewest total bits. never selects a symbol with more core modules than single , emits the single bit stream verbatim when a split would not shrink it, and additionally encodes content that overflows every version in a single mode — unless the minimal-bit plan would be misread on decode (a relocated byte order mark), in which case it reports &quot;does not fit&quot; rather than emitting a stream that decodes differently. opt-in because it searches candidate versions; the search itself allocates nothing, and content no split can help is ruled out before it starts. fewer core modules is not the same as a smaller image: rmqrfitstrategy ranks by core modules while the quiet zone adds to each dimension, so a flatter symbol can render onto a larger grid. size buffers with the same segmentation you encode with.">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.RmQRSegmentation" aria-label="Link to SkiaSharp.QrCode.RmQRSegmentation">#</a><code>public enum RmQRSegmentation : int</code></h3>
+          <p class="doc">How RmQRCodeGenerator splits the content into encoding-mode segments. rMQR capacities are small, so mixing modes (for example a Byte prefix followed by a Numeric tail) can drop the symbol by one or more versions.</p>
+          <div class="members">
+            <div class="member" data-text="single = 0, one segment in the single mode that can represent the whole content (numeric, else alphanumeric, else byte). the default, and the cheapest to encode. ">
+              <code>Single = 0,</code>
+              <p class="doc">One segment in the single mode that can represent the whole content (Numeric, else Alphanumeric, else Byte). The default, and the cheapest to encode.</p>
+            </div>
+            <div class="member" data-text="optimal = 1, the mixed-mode split with the fewest total bits. never selects a symbol with more core modules than single , emits the single bit stream verbatim when a split would not shrink it, and additionally encodes content that overflows every version in a single mode — unless the minimal-bit plan would be misread on decode (a relocated byte order mark), in which case it reports &quot;does not fit&quot; rather than emitting a stream that decodes differently. opt-in because it searches candidate versions; the search itself allocates nothing, and content no split can help is ruled out before it starts. fewer core modules is not the same as a smaller image: rmqrfitstrategy ranks by core modules while the quiet zone adds to each dimension, so a flatter symbol can render onto a larger grid. size buffers with the same segmentation you encode with.">
+              <code>Optimal = 1,</code>
+              <p class="doc">The mixed-mode split with the fewest total bits. Never selects a symbol with more core modules than Single , emits the Single bit stream verbatim when a split would not shrink it, and additionally encodes content that overflows every version in a single mode — unless the minimal-bit plan would be misread on decode (a relocated byte order mark), in which case it reports &quot;does not fit&quot; rather than emitting a stream that decodes differently.</p>
+              <details class="notes" data-text="opt-in because it searches candidate versions; the search itself allocates nothing, and content no split can help is ruled out before it starts. fewer core modules is not the same as a smaller image: rmqrfitstrategy ranks by core modules while the quiet zone adds to each dimension, so a flatter symbol can render onto a larger grid. size buffers with the same segmentation you encode with.">
+                <summary>Notes</summary>
+                <p class="doc remarks">Opt-in because it searches candidate versions; the search itself allocates nothing, and content no split can help is ruled out before it starts. Fewer core modules is not the same as a smaller image: RmQRFitStrategy ranks by core modules while the quiet zone adds to each dimension, so a flatter symbol can render onto a larger grid. Size buffers with the same segmentation you encode with.</p>
+              </details>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.RmQRVersion" data-name="skiasharp.qrcode.rmqrversion" data-text="skiasharp.qrcode.rmqrversion public enum rmqrversion : int rmqr code symbol version (iso/iec 23941): 32 rectangular sizes named r{height}x{width}. values follow the iso version index (height-major order) plus one, so (int)version - 1 is the 5-bit version index carried in the format information and (int)version is libzint's rmqr version number.  r7x43 = 1, 7 × 43 modules.  r7x59 = 2, 7 × 59 modules.  r7x77 = 3, 7 × 77 modules.  r7x99 = 4, 7 × 99 modules.  r7x139 = 5, 7 × 139 modules.  r9x43 = 6, 9 × 43 modules.  r9x59 = 7, 9 × 59 modules.  r9x77 = 8, 9 × 77 modules.  r9x99 = 9, 9 × 99 modules.  r9x139 = 10, 9 × 139 modules.  r11x27 = 11, 11 × 27 modules.  r11x43 = 12, 11 × 43 modules.  r11x59 = 13, 11 × 59 modules.  r11x77 = 14, 11 × 77 modules.  r11x99 = 15, 11 × 99 modules.  r11x139 = 16, 11 × 139 modules.  r13x27 = 17, 13 × 27 modules.  r13x43 = 18, 13 × 43 modules.  r13x59 = 19, 13 × 59 modules.  r13x77 = 20, 13 × 77 modules.  r13x99 = 21, 13 × 99 modules.  r13x139 = 22, 13 × 139 modules.  r15x43 = 23, 15 × 43 modules.  r15x59 = 24, 15 × 59 modules.  r15x77 = 25, 15 × 77 modules.  r15x99 = 26, 15 × 99 modules.  r15x139 = 27, 15 × 139 modules.  r17x43 = 28, 17 × 43 modules.  r17x59 = 29, 17 × 59 modules.  r17x77 = 30, 17 × 77 modules.  r17x99 = 31, 17 × 99 modules.  r17x139 = 32, 17 × 139 modules. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.RmQRVersion" aria-label="Link to SkiaSharp.QrCode.RmQRVersion">#</a><code>public enum RmQRVersion : int</code></h3>
+          <p class="doc">rMQR Code symbol version (ISO/IEC 23941): 32 rectangular sizes named R{height}x{width}. Values follow the ISO version index (height-major order) plus one, so (int)version - 1 is the 5-bit version index carried in the format information and (int)version is libzint's rMQR version number.</p>
+          <div class="members">
+            <div class="member" data-text="r7x43 = 1, 7 × 43 modules. ">
+              <code>R7x43 = 1,</code>
+              <p class="doc">7 × 43 modules.</p>
+            </div>
+            <div class="member" data-text="r7x59 = 2, 7 × 59 modules. ">
+              <code>R7x59 = 2,</code>
+              <p class="doc">7 × 59 modules.</p>
+            </div>
+            <div class="member" data-text="r7x77 = 3, 7 × 77 modules. ">
+              <code>R7x77 = 3,</code>
+              <p class="doc">7 × 77 modules.</p>
+            </div>
+            <div class="member" data-text="r7x99 = 4, 7 × 99 modules. ">
+              <code>R7x99 = 4,</code>
+              <p class="doc">7 × 99 modules.</p>
+            </div>
+            <div class="member" data-text="r7x139 = 5, 7 × 139 modules. ">
+              <code>R7x139 = 5,</code>
+              <p class="doc">7 × 139 modules.</p>
+            </div>
+            <div class="member" data-text="r9x43 = 6, 9 × 43 modules. ">
+              <code>R9x43 = 6,</code>
+              <p class="doc">9 × 43 modules.</p>
+            </div>
+            <div class="member" data-text="r9x59 = 7, 9 × 59 modules. ">
+              <code>R9x59 = 7,</code>
+              <p class="doc">9 × 59 modules.</p>
+            </div>
+            <div class="member" data-text="r9x77 = 8, 9 × 77 modules. ">
+              <code>R9x77 = 8,</code>
+              <p class="doc">9 × 77 modules.</p>
+            </div>
+            <div class="member" data-text="r9x99 = 9, 9 × 99 modules. ">
+              <code>R9x99 = 9,</code>
+              <p class="doc">9 × 99 modules.</p>
+            </div>
+            <div class="member" data-text="r9x139 = 10, 9 × 139 modules. ">
+              <code>R9x139 = 10,</code>
+              <p class="doc">9 × 139 modules.</p>
+            </div>
+            <div class="member" data-text="r11x27 = 11, 11 × 27 modules. ">
+              <code>R11x27 = 11,</code>
+              <p class="doc">11 × 27 modules.</p>
+            </div>
+            <div class="member" data-text="r11x43 = 12, 11 × 43 modules. ">
+              <code>R11x43 = 12,</code>
+              <p class="doc">11 × 43 modules.</p>
+            </div>
+            <div class="member" data-text="r11x59 = 13, 11 × 59 modules. ">
+              <code>R11x59 = 13,</code>
+              <p class="doc">11 × 59 modules.</p>
+            </div>
+            <div class="member" data-text="r11x77 = 14, 11 × 77 modules. ">
+              <code>R11x77 = 14,</code>
+              <p class="doc">11 × 77 modules.</p>
+            </div>
+            <div class="member" data-text="r11x99 = 15, 11 × 99 modules. ">
+              <code>R11x99 = 15,</code>
+              <p class="doc">11 × 99 modules.</p>
+            </div>
+            <div class="member" data-text="r11x139 = 16, 11 × 139 modules. ">
+              <code>R11x139 = 16,</code>
+              <p class="doc">11 × 139 modules.</p>
+            </div>
+            <div class="member" data-text="r13x27 = 17, 13 × 27 modules. ">
+              <code>R13x27 = 17,</code>
+              <p class="doc">13 × 27 modules.</p>
+            </div>
+            <div class="member" data-text="r13x43 = 18, 13 × 43 modules. ">
+              <code>R13x43 = 18,</code>
+              <p class="doc">13 × 43 modules.</p>
+            </div>
+            <div class="member" data-text="r13x59 = 19, 13 × 59 modules. ">
+              <code>R13x59 = 19,</code>
+              <p class="doc">13 × 59 modules.</p>
+            </div>
+            <div class="member" data-text="r13x77 = 20, 13 × 77 modules. ">
+              <code>R13x77 = 20,</code>
+              <p class="doc">13 × 77 modules.</p>
+            </div>
+            <div class="member" data-text="r13x99 = 21, 13 × 99 modules. ">
+              <code>R13x99 = 21,</code>
+              <p class="doc">13 × 99 modules.</p>
+            </div>
+            <div class="member" data-text="r13x139 = 22, 13 × 139 modules. ">
+              <code>R13x139 = 22,</code>
+              <p class="doc">13 × 139 modules.</p>
+            </div>
+            <div class="member" data-text="r15x43 = 23, 15 × 43 modules. ">
+              <code>R15x43 = 23,</code>
+              <p class="doc">15 × 43 modules.</p>
+            </div>
+            <div class="member" data-text="r15x59 = 24, 15 × 59 modules. ">
+              <code>R15x59 = 24,</code>
+              <p class="doc">15 × 59 modules.</p>
+            </div>
+            <div class="member" data-text="r15x77 = 25, 15 × 77 modules. ">
+              <code>R15x77 = 25,</code>
+              <p class="doc">15 × 77 modules.</p>
+            </div>
+            <div class="member" data-text="r15x99 = 26, 15 × 99 modules. ">
+              <code>R15x99 = 26,</code>
+              <p class="doc">15 × 99 modules.</p>
+            </div>
+            <div class="member" data-text="r15x139 = 27, 15 × 139 modules. ">
+              <code>R15x139 = 27,</code>
+              <p class="doc">15 × 139 modules.</p>
+            </div>
+            <div class="member" data-text="r17x43 = 28, 17 × 43 modules. ">
+              <code>R17x43 = 28,</code>
+              <p class="doc">17 × 43 modules.</p>
+            </div>
+            <div class="member" data-text="r17x59 = 29, 17 × 59 modules. ">
+              <code>R17x59 = 29,</code>
+              <p class="doc">17 × 59 modules.</p>
+            </div>
+            <div class="member" data-text="r17x77 = 30, 17 × 77 modules. ">
+              <code>R17x77 = 30,</code>
+              <p class="doc">17 × 77 modules.</p>
+            </div>
+            <div class="member" data-text="r17x99 = 31, 17 × 99 modules. ">
+              <code>R17x99 = 31,</code>
+              <p class="doc">17 × 99 modules.</p>
+            </div>
+            <div class="member" data-text="r17x139 = 32, 17 × 139 modules. ">
+              <code>R17x139 = 32,</code>
+              <p class="doc">17 × 139 modules.</p>
+            </div>
+          </div>
+        </article>
+      </section>
+      <section class="ns">
+        <h2>namespace SkiaSharp.QrCode.Image</h2>
+        <article class="type" id="SkiaSharp.QrCode.Image.CircleFinderPatternShape" data-name="skiasharp.qrcode.image.circlefinderpatternshape" data-text="skiasharp.qrcode.image.circlefinderpatternshape public sealed class circlefinderpatternshape : finderpatternshape circular finder pattern. (three nested circles, 7x7, 5x5, 3x3)  public static readonly circlefinderpatternshape default; gets the default instance.  public bool requiresantialiasing { get; } requires antialiasing to prevent jagged edges on curves.  public override void draw(skcanvas canvas, skrect rect, skpaint paint);  public override void draw(skcanvas canvas, skrect rect, skpaint paint, skcolor backgroundcolor);  public override void draw(skcanvas canvas, skrect rect, skpaint paint, skpaint backgroundpaint); ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.CircleFinderPatternShape" aria-label="Link to SkiaSharp.QrCode.Image.CircleFinderPatternShape">#</a><code>public sealed class CircleFinderPatternShape : FinderPatternShape</code></h3>
+          <p class="doc">Circular finder pattern. (three nested circles, 7x7, 5x5, 3x3)</p>
+          <div class="members">
+            <div class="member" data-text="public static readonly circlefinderpatternshape default; gets the default instance. ">
+              <code>public static readonly CircleFinderPatternShape Default;</code>
+              <p class="doc">Gets the default instance.</p>
+            </div>
+            <div class="member" data-text="public bool requiresantialiasing { get; } requires antialiasing to prevent jagged edges on curves. ">
+              <code>public bool RequiresAntialiasing { get; }</code>
+              <p class="doc">Requires antialiasing to prevent jagged edges on curves.</p>
+            </div>
+            <div class="member" data-text="public override void draw(skcanvas canvas, skrect rect, skpaint paint); ">
+              <code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint);</code>
+            </div>
+            <div class="member" data-text="public override void draw(skcanvas canvas, skrect rect, skpaint paint, skcolor backgroundcolor); ">
+              <code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint, SKColor backgroundColor);</code>
+            </div>
+            <div class="member" data-text="public override void draw(skcanvas canvas, skrect rect, skpaint paint, skpaint backgroundpaint); ">
+              <code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint, SKPaint backgroundPaint);</code>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.Image.CircleModuleShape" data-name="skiasharp.qrcode.image.circlemoduleshape" data-text="skiasharp.qrcode.image.circlemoduleshape public sealed class circlemoduleshape : moduleshape draws modules as circles.  public static readonly circlemoduleshape default; gets the default instance.  public bool requiresantialiasing { get; } requires antialiasing to prevent jagged edges on curves.  public override void draw(skcanvas canvas, skrect rect, skpaint paint); ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.CircleModuleShape" aria-label="Link to SkiaSharp.QrCode.Image.CircleModuleShape">#</a><code>public sealed class CircleModuleShape : ModuleShape</code></h3>
+          <p class="doc">Draws modules as circles.</p>
+          <div class="members">
+            <div class="member" data-text="public static readonly circlemoduleshape default; gets the default instance. ">
+              <code>public static readonly CircleModuleShape Default;</code>
+              <p class="doc">Gets the default instance.</p>
+            </div>
+            <div class="member" data-text="public bool requiresantialiasing { get; } requires antialiasing to prevent jagged edges on curves. ">
+              <code>public bool RequiresAntialiasing { get; }</code>
+              <p class="doc">Requires antialiasing to prevent jagged edges on curves.</p>
+            </div>
+            <div class="member" data-text="public override void draw(skcanvas canvas, skrect rect, skpaint paint); ">
+              <code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint);</code>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.Image.FinderPatternShape" data-name="skiasharp.qrcode.image.finderpatternshape" data-text="skiasharp.qrcode.image.finderpatternshape public abstract class finderpatternshape defines the shape of qr code finder pattern (position detection patterns).  protected finderpatternshape();  public bool requiresantialiasing { get; } gets whether this shape requires antialiasing for smooth rendering. curved shapes such as circles and rounded rectangles should return true ; straight-edged shapes such as rectangles can return false .  public abstract void draw(skcanvas canvas, skrect rect, skpaint paint); draw a finder pattern at the specified location.  public virtual void draw(skcanvas canvas, skrect rect, skpaint paint, skcolor backgroundcolor); draw a finder pattern at the specified location with background color support.  public virtual void draw(skcanvas canvas, skrect rect, skpaint paint, skpaint backgroundpaint); draw a finder pattern at the specified location using an existing background paint. the default implementation preserves compatibility with custom finder shapes that override the color-based overload. built-in shapes override this overload so the renderer can reuse its background paint. the renderer may set the paint's blend mode to clear while drawing on an isolated layer so transparent and translucent light modules reveal the background rendered beneath the finder pattern. implementations should therefore draw with this paint directly instead of copying only its color. the renderer owns backgroundpaint and may reuse it across calls; implementations must not modify or dispose it. custom shapes should override this overload when they need to reuse the renderer's configured background paint or when they must support non-opaque backgrounds (blend modes). existing custom shapes may continue to override draw , but that overload cannot use the renderer's blend mode.">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.FinderPatternShape" aria-label="Link to SkiaSharp.QrCode.Image.FinderPatternShape">#</a><code>public abstract class FinderPatternShape</code></h3>
+          <p class="doc">Defines the shape of QR code finder pattern (position detection patterns).</p>
+          <div class="members">
+            <div class="member" data-text="protected finderpatternshape(); ">
+              <code>protected FinderPatternShape();</code>
+            </div>
+            <div class="member" data-text="public bool requiresantialiasing { get; } gets whether this shape requires antialiasing for smooth rendering. curved shapes such as circles and rounded rectangles should return true ; straight-edged shapes such as rectangles can return false . ">
+              <code>public bool RequiresAntialiasing { get; }</code>
+              <p class="doc">Gets whether this shape requires antialiasing for smooth rendering. Curved shapes such as circles and rounded rectangles should return true ; straight-edged shapes such as rectangles can return false .</p>
+            </div>
+            <div class="member" data-text="public abstract void draw(skcanvas canvas, skrect rect, skpaint paint); draw a finder pattern at the specified location. ">
+              <code>public abstract void Draw(SKCanvas canvas, SKRect rect, SKPaint paint);</code>
+              <p class="doc">Draw a finder pattern at the specified location.</p>
+            </div>
+            <div class="member" data-text="public virtual void draw(skcanvas canvas, skrect rect, skpaint paint, skcolor backgroundcolor); draw a finder pattern at the specified location with background color support. ">
+              <code>public virtual void Draw(SKCanvas canvas, SKRect rect, SKPaint paint, SKColor backgroundColor);</code>
+              <p class="doc">Draw a finder pattern at the specified location with background color support.</p>
+            </div>
+            <div class="member" data-text="public virtual void draw(skcanvas canvas, skrect rect, skpaint paint, skpaint backgroundpaint); draw a finder pattern at the specified location using an existing background paint. the default implementation preserves compatibility with custom finder shapes that override the color-based overload. built-in shapes override this overload so the renderer can reuse its background paint. the renderer may set the paint's blend mode to clear while drawing on an isolated layer so transparent and translucent light modules reveal the background rendered beneath the finder pattern. implementations should therefore draw with this paint directly instead of copying only its color. the renderer owns backgroundpaint and may reuse it across calls; implementations must not modify or dispose it. custom shapes should override this overload when they need to reuse the renderer's configured background paint or when they must support non-opaque backgrounds (blend modes). existing custom shapes may continue to override draw , but that overload cannot use the renderer's blend mode.">
+              <code>public virtual void Draw(SKCanvas canvas, SKRect rect, SKPaint paint, SKPaint backgroundPaint);</code>
+              <p class="doc">Draw a finder pattern at the specified location using an existing background paint.</p>
+              <details class="notes" data-text="the default implementation preserves compatibility with custom finder shapes that override the color-based overload. built-in shapes override this overload so the renderer can reuse its background paint. the renderer may set the paint's blend mode to clear while drawing on an isolated layer so transparent and translucent light modules reveal the background rendered beneath the finder pattern. implementations should therefore draw with this paint directly instead of copying only its color. the renderer owns backgroundpaint and may reuse it across calls; implementations must not modify or dispose it. custom shapes should override this overload when they need to reuse the renderer's configured background paint or when they must support non-opaque backgrounds (blend modes). existing custom shapes may continue to override draw , but that overload cannot use the renderer's blend mode.">
+                <summary>Notes</summary>
+                <p class="doc remarks">The default implementation preserves compatibility with custom finder shapes that override the color-based overload. Built-in shapes override this overload so the renderer can reuse its background paint. The renderer may set the paint's blend mode to Clear while drawing on an isolated layer so transparent and translucent light modules reveal the background rendered beneath the finder pattern. Implementations should therefore draw with this paint directly instead of copying only its color. The renderer owns backgroundPaint and may reuse it across calls; implementations must not modify or dispose it. Custom shapes should override this overload when they need to reuse the renderer's configured background paint or when they must support non-opaque backgrounds (blend modes). Existing custom shapes may continue to override Draw , but that overload cannot use the renderer's blend mode.</p>
+              </details>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.Image.GradientDirection" data-name="skiasharp.qrcode.image.gradientdirection" data-text="skiasharp.qrcode.image.gradientdirection public enum gradientdirection : int defines the direction of gradient flow for qr code rendering. linear gradients flow in a straight line across the entire qr code area. the direction determines the start and end points of the gradient. common use cases: lefttoright or toptobottom : simple horizontal/vertical gradients toplefttobottomright : diagonal gradients for dynamic appearance none : use when solid color is desired (disables gradient) none = 0, no gradient. use solid color specified in qr code rendering options. however, if solid is required, it's better to omit gradient options entirely.  lefttoright = 1, gradient flows from left edge to right edge horizontally.  righttoleft = 2, gradient flows from right edge to left edge horizontally.  toptobottom = 3, gradient flows from top edge to bottom edge vertically.  bottomtotop = 4, gradient flows from bottom edge to top edge vertically.  toplefttobottomright = 5, gradient flows diagonally from top-left corner to bottom-right corner.  toprighttobottomleft = 6, gradient flows diagonally from top-right corner to bottom-left corner.  bottomlefttotopright = 7, gradient flows diagonally from bottom-left corner to top-right corner.  bottomrighttotopleft = 8, gradient flows diagonally from bottom-right corner to top-left corner. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.GradientDirection" aria-label="Link to SkiaSharp.QrCode.Image.GradientDirection">#</a><code>public enum GradientDirection : int</code></h3>
+          <p class="doc">Defines the direction of gradient flow for QR code rendering.</p>
+          <details class="notes" data-text="linear gradients flow in a straight line across the entire qr code area. the direction determines the start and end points of the gradient. common use cases: lefttoright or toptobottom : simple horizontal/vertical gradients toplefttobottomright : diagonal gradients for dynamic appearance none : use when solid color is desired (disables gradient)">
+            <summary>Notes</summary>
+            <p class="doc remarks">Linear gradients flow in a straight line across the entire QR code area. The direction determines the start and end points of the gradient. Common Use Cases: LeftToRight or TopToBottom : Simple horizontal/vertical gradients TopLeftToBottomRight : Diagonal gradients for dynamic appearance None : Use when solid color is desired (disables gradient)</p>
+          </details>
+          <div class="members">
+            <div class="member" data-text="none = 0, no gradient. use solid color specified in qr code rendering options. however, if solid is required, it's better to omit gradient options entirely. ">
+              <code>None = 0,</code>
+              <p class="doc">No gradient. Use solid color specified in QR code rendering options. However, if solid is required, it's better to omit gradient options entirely.</p>
+            </div>
+            <div class="member" data-text="lefttoright = 1, gradient flows from left edge to right edge horizontally. ">
+              <code>LeftToRight = 1,</code>
+              <p class="doc">Gradient flows from left edge to right edge horizontally.</p>
+            </div>
+            <div class="member" data-text="righttoleft = 2, gradient flows from right edge to left edge horizontally. ">
+              <code>RightToLeft = 2,</code>
+              <p class="doc">Gradient flows from right edge to left edge horizontally.</p>
+            </div>
+            <div class="member" data-text="toptobottom = 3, gradient flows from top edge to bottom edge vertically. ">
+              <code>TopToBottom = 3,</code>
+              <p class="doc">Gradient flows from top edge to bottom edge vertically.</p>
+            </div>
+            <div class="member" data-text="bottomtotop = 4, gradient flows from bottom edge to top edge vertically. ">
+              <code>BottomToTop = 4,</code>
+              <p class="doc">Gradient flows from bottom edge to top edge vertically.</p>
+            </div>
+            <div class="member" data-text="toplefttobottomright = 5, gradient flows diagonally from top-left corner to bottom-right corner. ">
+              <code>TopLeftToBottomRight = 5,</code>
+              <p class="doc">Gradient flows diagonally from top-left corner to bottom-right corner.</p>
+            </div>
+            <div class="member" data-text="toprighttobottomleft = 6, gradient flows diagonally from top-right corner to bottom-left corner. ">
+              <code>TopRightToBottomLeft = 6,</code>
+              <p class="doc">Gradient flows diagonally from top-right corner to bottom-left corner.</p>
+            </div>
+            <div class="member" data-text="bottomlefttotopright = 7, gradient flows diagonally from bottom-left corner to top-right corner. ">
+              <code>BottomLeftToTopRight = 7,</code>
+              <p class="doc">Gradient flows diagonally from bottom-left corner to top-right corner.</p>
+            </div>
+            <div class="member" data-text="bottomrighttotopleft = 8, gradient flows diagonally from bottom-right corner to top-left corner. ">
+              <code>BottomRightToTopLeft = 8,</code>
+              <p class="doc">Gradient flows diagonally from bottom-right corner to top-left corner.</p>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.Image.GradientOptions" data-name="skiasharp.qrcode.image.gradientoptions" data-text="skiasharp.qrcode.image.gradientoptions public class gradientoptions : iequatable&lt;gradientoptions&gt; defines gradient configuration for qr code rendering. this record configures linear gradients that are applied across the entire qr code. gradients can flow in various directions (horizontal, vertical, diagonal). for simple two-color gradients, specify two colors in colors . for multi-color gradients, provide additional colors and optionally specify colorpositions . public static readonly gradientoptions default; a ready-made gradient: dark orange to firebrick, running from the top-left corner to the bottom-right. use it when you want a gradient without choosing colors.  public gradientoptions(skcolor[] colors, gradientdirection direction = 1, float[]? colorpositions = null); initializes a new instance of the gradientoptions record.  public gradientdirection direction { get; init; } the gradient direction. determines the start and end points of the gradient across the qr code area. public skcolor[] colors { get; init; } gradient colors for multi-color gradients. at least 2 colors are required. the gradient flows from the first color to the last color in the direction specified by direction . public float[]? colorpositions { get; init; } optional color stops (0.0 to 1.0) for the gradient. if null, colors are evenly distributed across the gradient. if specified, the array length must match colors length. values must be in ascending order from 0.0 (start) to 1.0 (end). for example: [0.0f, 0.3f, 1.0f] for three colors.">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.GradientOptions" aria-label="Link to SkiaSharp.QrCode.Image.GradientOptions">#</a><code>public class GradientOptions : IEquatable&lt;GradientOptions&gt;</code></h3>
+          <p class="doc">Defines gradient configuration for QR code rendering.</p>
+          <details class="notes" data-text="this record configures linear gradients that are applied across the entire qr code. gradients can flow in various directions (horizontal, vertical, diagonal). for simple two-color gradients, specify two colors in colors . for multi-color gradients, provide additional colors and optionally specify colorpositions .">
+            <summary>Notes</summary>
+            <p class="doc remarks">This record configures linear gradients that are applied across the entire QR code. Gradients can flow in various directions (horizontal, vertical, diagonal). For simple two-color gradients, specify two colors in Colors . For multi-color gradients, provide additional colors and optionally specify ColorPositions .</p>
+          </details>
+          <div class="members">
+            <div class="member" data-text="public static readonly gradientoptions default; a ready-made gradient: dark orange to firebrick, running from the top-left corner to the bottom-right. use it when you want a gradient without choosing colors. ">
+              <code>public static readonly GradientOptions Default;</code>
+              <p class="doc">A ready-made gradient: dark orange to firebrick, running from the top-left corner to the bottom-right. Use it when you want a gradient without choosing colors.</p>
+            </div>
+            <div class="member" data-text="public gradientoptions(skcolor[] colors, gradientdirection direction = 1, float[]? colorpositions = null); initializes a new instance of the gradientoptions record. ">
+              <code>public GradientOptions(SKColor[] colors, GradientDirection direction = 1, float[]? colorPositions = null);</code>
+              <p class="doc">Initializes a new instance of the GradientOptions record.</p>
+            </div>
+            <div class="member" data-text="public gradientdirection direction { get; init; } the gradient direction. determines the start and end points of the gradient across the qr code area.">
+              <code>public GradientDirection Direction { get; init; }</code>
+              <p class="doc">The gradient direction.</p>
+              <details class="notes" data-text="determines the start and end points of the gradient across the qr code area.">
+                <summary>Notes</summary>
+                <p class="doc remarks">Determines the start and end points of the gradient across the QR code area.</p>
+              </details>
+            </div>
+            <div class="member" data-text="public skcolor[] colors { get; init; } gradient colors for multi-color gradients. at least 2 colors are required. the gradient flows from the first color to the last color in the direction specified by direction .">
+              <code>public SKColor[] Colors { get; init; }</code>
+              <p class="doc">Gradient colors for multi-color gradients.</p>
+              <details class="notes" data-text="at least 2 colors are required. the gradient flows from the first color to the last color in the direction specified by direction .">
+                <summary>Notes</summary>
+                <p class="doc remarks">At least 2 colors are required. The gradient flows from the first color to the last color in the direction specified by Direction .</p>
+              </details>
+            </div>
+            <div class="member" data-text="public float[]? colorpositions { get; init; } optional color stops (0.0 to 1.0) for the gradient. if null, colors are evenly distributed across the gradient. if specified, the array length must match colors length. values must be in ascending order from 0.0 (start) to 1.0 (end). for example: [0.0f, 0.3f, 1.0f] for three colors.">
+              <code>public float[]? ColorPositions { get; init; }</code>
+              <p class="doc">Optional color stops (0.0 to 1.0) for the gradient.</p>
+              <details class="notes" data-text="if null, colors are evenly distributed across the gradient. if specified, the array length must match colors length. values must be in ascending order from 0.0 (start) to 1.0 (end). for example: [0.0f, 0.3f, 1.0f] for three colors.">
+                <summary>Notes</summary>
+                <p class="doc remarks">If null, colors are evenly distributed across the gradient. If specified, the array length must match Colors length. Values must be in ascending order from 0.0 (start) to 1.0 (end). For example: [0.0f, 0.3f, 1.0f] for three colors.</p>
+              </details>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.Image.IconData" data-name="skiasharp.qrcode.image.icondata" data-text="skiasharp.qrcode.image.icondata public class icondata the logo or image drawn at the center of a qr code, and its size. the icon covers modules, so the symbol relies on error correction to stay readable. use the highest error correction level ( h ) and keep the icon small. when the size is given in modules, rendering throws if the icon and its border span more than maxcoreoccupancypercent percent of the core width; sizes given as a percentage of the image are not checked against the symbol at all. [obsolete] public icondata();  public iconshape icon { get; set; } the icon shape to overlay on the qr code.  public int iconborderwidth { get; set; } the border width around the icon in pixels. creates a background-colored padding around the icon. ignored when iconsizemodules is set.  public int iconsizepercent { get; set; } the size of the icon as a percentage of the qr code size (1-100). ignored when iconsizemodules is set.  public int maxcoreoccupancypercent { get; set; } maximum allowed icon occupancy of the qr core area, as a percentage (1-100). used only for module-based sizing. default is 30.  public int? iconbordermodules { get; set; } the border width around the icon in qr modules. when iconsizemodules is set and this is null, defaults to 1.  public int? iconsizemodules { get; set; } the size of the icon body in qr modules. when set, module-based sizing is used and iconsizepercent / iconborderwidth are ignored.  public static icondata fromimage(skbitmap image, int iconsizepercent = 10, int iconborderwidth = 2); create icondata from a bitmap image using percent/pixel sizing.  public static icondata fromimagebymodules(skbitmap image, int iconsizemodules, int iconbordermodules = 1, int maxcoreoccupancypercent = 30); create icondata from a bitmap image using module-based sizing. prefer combining this with withmodulepixelsize so each module maps to an integer pixel size. optional withsize can then set a larger canvas; content is centered and padded. validation against qr size/core occupancy happens at render time.">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.IconData" aria-label="Link to SkiaSharp.QrCode.Image.IconData">#</a><code>public class IconData</code></h3>
+          <p class="doc">The logo or image drawn at the center of a QR code, and its size.</p>
+          <details class="notes" data-text="the icon covers modules, so the symbol relies on error correction to stay readable. use the highest error correction level ( h ) and keep the icon small. when the size is given in modules, rendering throws if the icon and its border span more than maxcoreoccupancypercent percent of the core width; sizes given as a percentage of the image are not checked against the symbol at all.">
+            <summary>Notes</summary>
+            <p class="doc remarks">The icon covers modules, so the symbol relies on error correction to stay readable. Use the highest error correction level ( H ) and keep the icon small. When the size is given in modules, rendering throws if the icon and its border span more than MaxCoreOccupancyPercent percent of the core width; sizes given as a percentage of the image are not checked against the symbol at all.</p>
+          </details>
+          <div class="members">
+            <div class="member" data-text="public icondata(); ">
+              <code>public IconData();</code> <span class="tag">obsolete</span>
+            </div>
+            <div class="member" data-text="public iconshape icon { get; set; } the icon shape to overlay on the qr code. ">
+              <code>public IconShape Icon { get; set; }</code>
+              <p class="doc">The icon shape to overlay on the QR code.</p>
+            </div>
+            <div class="member" data-text="public int iconborderwidth { get; set; } the border width around the icon in pixels. creates a background-colored padding around the icon. ignored when iconsizemodules is set. ">
+              <code>public int IconBorderWidth { get; set; }</code>
+              <p class="doc">The border width around the icon in pixels. Creates a background-colored padding around the icon. Ignored when IconSizeModules is set.</p>
+            </div>
+            <div class="member" data-text="public int iconsizepercent { get; set; } the size of the icon as a percentage of the qr code size (1-100). ignored when iconsizemodules is set. ">
+              <code>public int IconSizePercent { get; set; }</code>
+              <p class="doc">The size of the icon as a percentage of the QR code size (1-100). Ignored when IconSizeModules is set.</p>
+            </div>
+            <div class="member" data-text="public int maxcoreoccupancypercent { get; set; } maximum allowed icon occupancy of the qr core area, as a percentage (1-100). used only for module-based sizing. default is 30. ">
+              <code>public int MaxCoreOccupancyPercent { get; set; }</code>
+              <p class="doc">Maximum allowed icon occupancy of the QR core area, as a percentage (1-100). Used only for module-based sizing. Default is 30.</p>
+            </div>
+            <div class="member" data-text="public int? iconbordermodules { get; set; } the border width around the icon in qr modules. when iconsizemodules is set and this is null, defaults to 1. ">
+              <code>public int? IconBorderModules { get; set; }</code>
+              <p class="doc">The border width around the icon in QR modules. When IconSizeModules is set and this is null, defaults to 1.</p>
+            </div>
+            <div class="member" data-text="public int? iconsizemodules { get; set; } the size of the icon body in qr modules. when set, module-based sizing is used and iconsizepercent / iconborderwidth are ignored. ">
+              <code>public int? IconSizeModules { get; set; }</code>
+              <p class="doc">The size of the icon body in QR modules. When set, module-based sizing is used and IconSizePercent / IconBorderWidth are ignored.</p>
+            </div>
+            <div class="member" data-text="public static icondata fromimage(skbitmap image, int iconsizepercent = 10, int iconborderwidth = 2); create icondata from a bitmap image using percent/pixel sizing. ">
+              <code>public static IconData FromImage(SKBitmap image, int iconSizePercent = 10, int iconBorderWidth = 2);</code>
+              <p class="doc">Create IconData from a bitmap image using percent/pixel sizing.</p>
+            </div>
+            <div class="member" data-text="public static icondata fromimagebymodules(skbitmap image, int iconsizemodules, int iconbordermodules = 1, int maxcoreoccupancypercent = 30); create icondata from a bitmap image using module-based sizing. prefer combining this with withmodulepixelsize so each module maps to an integer pixel size. optional withsize can then set a larger canvas; content is centered and padded. validation against qr size/core occupancy happens at render time.">
+              <code>public static IconData FromImageByModules(SKBitmap image, int iconSizeModules, int iconBorderModules = 1, int maxCoreOccupancyPercent = 30);</code>
+              <p class="doc">Create IconData from a bitmap image using module-based sizing.</p>
+              <details class="notes" data-text="prefer combining this with withmodulepixelsize so each module maps to an integer pixel size. optional withsize can then set a larger canvas; content is centered and padded. validation against qr size/core occupancy happens at render time.">
+                <summary>Notes</summary>
+                <p class="doc remarks">Prefer combining this with WithModulePixelSize so each module maps to an integer pixel size. Optional WithSize can then set a larger canvas; content is centered and padded. Validation against QR size/core occupancy happens at render time.</p>
+              </details>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.Image.IconShape" data-name="skiasharp.qrcode.image.iconshape" data-text="skiasharp.qrcode.image.iconshape public abstract class iconshape defines the shape and rendering behavior of a qr code center icon/logo.  protected iconshape();  public abstract void draw(skcanvas canvas, skrect rect, skrect borderrect, skcolor backgroundcolor); draw an icon bitmap at the specified location. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.IconShape" aria-label="Link to SkiaSharp.QrCode.Image.IconShape">#</a><code>public abstract class IconShape</code></h3>
+          <p class="doc">Defines the shape and rendering behavior of a QR code center icon/logo.</p>
+          <div class="members">
+            <div class="member" data-text="protected iconshape(); ">
+              <code>protected IconShape();</code>
+            </div>
+            <div class="member" data-text="public abstract void draw(skcanvas canvas, skrect rect, skrect borderrect, skcolor backgroundcolor); draw an icon bitmap at the specified location. ">
+              <code>public abstract void Draw(SKCanvas canvas, SKRect rect, SKRect borderRect, SKColor backgroundColor);</code>
+              <p class="doc">Draw an icon bitmap at the specified location.</p>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.Image.ImageIconShape" data-name="skiasharp.qrcode.image.imageiconshape" data-text="skiasharp.qrcode.image.imageiconshape public sealed class imageiconshape : iconshape icon shape that draws an image.  public imageiconshape(skbitmap image); creates an icon from an image.  public override void draw(skcanvas canvas, skrect rect, skrect borderrect, skcolor backgroundcolor); ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.ImageIconShape" aria-label="Link to SkiaSharp.QrCode.Image.ImageIconShape">#</a><code>public sealed class ImageIconShape : IconShape</code></h3>
+          <p class="doc">Icon shape that draws an image.</p>
+          <div class="members">
+            <div class="member" data-text="public imageiconshape(skbitmap image); creates an icon from an image. ">
+              <code>public ImageIconShape(SKBitmap image);</code>
+              <p class="doc">Creates an icon from an image.</p>
+            </div>
+            <div class="member" data-text="public override void draw(skcanvas canvas, skrect rect, skrect borderrect, skcolor backgroundcolor); ">
+              <code>public override void Draw(SKCanvas canvas, SKRect rect, SKRect borderRect, SKColor backgroundColor);</code>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.Image.ImageTextIconShape" data-name="skiasharp.qrcode.image.imagetexticonshape" data-text="skiasharp.qrcode.image.imagetexticonshape public sealed class imagetexticonshape : iconshape icon shape that draws an image with text positioned relative to it.  public imagetexticonshape(skbitmap image, string text, skcolor textcolor, skfont font, sktextalign horizontalalign = 1, textverticalalignment verticalalign = 0, int textpadding = 0); creates an icon shape that displays an image with text positioned relative to it.  public override void draw(skcanvas canvas, skrect rect, skrect borderrect, skcolor backgroundcolor); ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.ImageTextIconShape" aria-label="Link to SkiaSharp.QrCode.Image.ImageTextIconShape">#</a><code>public sealed class ImageTextIconShape : IconShape</code></h3>
+          <p class="doc">Icon shape that draws an image with text positioned relative to it.</p>
+          <div class="members">
+            <div class="member" data-text="public imagetexticonshape(skbitmap image, string text, skcolor textcolor, skfont font, sktextalign horizontalalign = 1, textverticalalignment verticalalign = 0, int textpadding = 0); creates an icon shape that displays an image with text positioned relative to it. ">
+              <code>public ImageTextIconShape(SKBitmap image, string text, SKColor textColor, SKFont font, SKTextAlign horizontalAlign = 1, TextVerticalAlignment verticalAlign = 0, int textPadding = 0);</code>
+              <p class="doc">Creates an icon shape that displays an image with text positioned relative to it.</p>
+            </div>
+            <div class="member" data-text="public override void draw(skcanvas canvas, skrect rect, skrect borderrect, skcolor backgroundcolor); ">
+              <code>public override void Draw(SKCanvas canvas, SKRect rect, SKRect borderRect, SKColor backgroundColor);</code>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.Image.MicroQRCodeImageBuilder" data-name="skiasharp.qrcode.image.microqrcodeimagebuilder" data-text="skiasharp.qrcode.image.microqrcodeimagebuilder public class microqrcodeimagebuilder : qrcodeimagebuilderbase&lt;microqrcodeimagebuilder&gt; high-level builder for creating micro qr code images with fluent configuration and static methods. this builder mirrors qrcodeimagebuilder for the micro qr symbology (iso/iec 18004, versions m1-m4). version and error correction use the micro qr-typed microqrversion / microqrecclevel , and the default quiet zone is the 2 modules the specification requires (standard qr uses 4). micro qr has a single finder pattern and no high error-correction headroom, so the standard qr styling options that depend on those (icon overlays and custom finder pattern shapes) are intentionally not offered. public microqrcodeimagebuilder(microqrcodedata microqrcodedata); starts a builder that draws a micro qr code you have already generated. the symbol is used exactly as given, so only the appearance options apply. every encoding option throws invalidoperationexception on a builder created this way.  public microqrcodeimagebuilder(string content); starts a builder that will encode content when you ask for an image. error correction, version and every other option keep their defaults until you set them.  public microqrcodeimagebuilder witherrorcorrection(microqrecclevel ecclevel); configure the error correction level for the micro qr code. legal combinations are version-dependent: m1 supports errordetectiononly only, m2/m3 support l and m, m4 supports l, m, and q. illegal combinations throw when the symbol is generated. public microqrcodeimagebuilder withmaskpattern(int? maskpattern); pin one of the four micro qr data mask patterns (0-3) instead of the automatic edge-score selection; see maskpattern .  public microqrcodeimagebuilder withsegmentation(microqrsegmentation segmentation); split the content into mixed-mode segments when that lowers the version (see microqrsegmentation ). defaults to single . never selects a larger version, and produces the identical symbol when a split would not shrink it.  public microqrcodeimagebuilder withversion(microqrversion version); configure the micro qr version to generate. the pinned-version case of the withversion overload. public microqrcodeimagebuilder withversion(microqrversionrange versionrange); configure the versions the generator may choose from, rather than a single one. see microqrversionrange for which empty ranges throw and which are a poor fit. public static byte[] getimagebytes(microqrcodedata microqrcodedata, skencodedimageformat format, int size = 512, int quality = 100); generate a micro qr code as image byte array with specified format.  public static byte[] getimagebytes(string content, skencodedimageformat format, microqrecclevel ecclevel = 2, int size = 512, int quality = 100); generate a micro qr code as image byte array with specified format.  public static byte[] getpngbytes(microqrcodedata microqrcodedata, int size = 512); generate a micro qr code as png byte array with default settings.  public static byte[] getpngbytes(string content, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code as png byte array with default settings.  public static byte[] getsvgbytes(microqrcodedata microqrcodedata, int size = 512); generate a micro qr code as svg (utf-8 encoded) byte array with default settings.  public static byte[] getsvgbytes(string content, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code as svg (utf-8 encoded) byte array with default settings.  public static string getsvgstring(microqrcodedata microqrcodedata, int size = 512); generate a micro qr code as svg document string with default settings.  public static string getsvgstring(string content, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code as svg document string with default settings.  public static void savepng(microqrcodedata microqrcodedata, stream output, int size = 512); generate a micro qr code and save to stream with default png settings.  public static void savepng(string content, stream output, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code and save to stream with default png settings.  public static void savesvg(microqrcodedata microqrcodedata, stream output, int size = 512); generate a micro qr code and save as svg to stream with default settings.  public static void savesvg(string content, stream output, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code and save as svg to stream with default settings.  public static void writeimage(microqrcodedata microqrcodedata, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, int size = 512, int quality = 100); generate a micro qr code and write to an ibufferwriter with specified format.  public static void writeimage(string content, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, microqrecclevel ecclevel = 2, int size = 512, int quality = 100); generate a micro qr code and write to an ibufferwriter with specified format.  public static void writepng(microqrcodedata microqrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate a micro qr code and write to an ibufferwriter with default png settings.  public static void writepng(string content, ibufferwriter&lt;byte&gt; writer, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code and write to an ibufferwriter with default png settings.  public static void writesvg(microqrcodedata microqrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate a micro qr code and write as svg (utf-8 encoded) to an ibufferwriter with default settings.  public static void writesvg(string content, ibufferwriter&lt;byte&gt; writer, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code and write as svg (utf-8 encoded) to an ibufferwriter with default settings. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.MicroQRCodeImageBuilder" aria-label="Link to SkiaSharp.QrCode.Image.MicroQRCodeImageBuilder">#</a><code>public class MicroQRCodeImageBuilder : QRCodeImageBuilderBase&lt;MicroQRCodeImageBuilder&gt;</code></h3>
+          <p class="doc">High-level builder for creating Micro QR code images with fluent configuration and static methods.</p>
+          <details class="notes" data-text="this builder mirrors qrcodeimagebuilder for the micro qr symbology (iso/iec 18004, versions m1-m4). version and error correction use the micro qr-typed microqrversion / microqrecclevel , and the default quiet zone is the 2 modules the specification requires (standard qr uses 4). micro qr has a single finder pattern and no high error-correction headroom, so the standard qr styling options that depend on those (icon overlays and custom finder pattern shapes) are intentionally not offered.">
+            <summary>Notes</summary>
+            <p class="doc remarks">This builder mirrors QRCodeImageBuilder for the Micro QR symbology (ISO/IEC 18004, versions M1-M4). Version and error correction use the Micro QR-typed MicroQRVersion / MicroQREccLevel , and the default quiet zone is the 2 modules the specification requires (Standard QR uses 4). Micro QR has a single finder pattern and no high error-correction headroom, so the Standard QR styling options that depend on those (icon overlays and custom finder pattern shapes) are intentionally not offered.</p>
+          </details>
+          <div class="members">
+            <div class="member" data-text="public microqrcodeimagebuilder(microqrcodedata microqrcodedata); starts a builder that draws a micro qr code you have already generated. the symbol is used exactly as given, so only the appearance options apply. every encoding option throws invalidoperationexception on a builder created this way. ">
+              <code>public MicroQRCodeImageBuilder(MicroQRCodeData microQrCodeData);</code>
+              <p class="doc">Starts a builder that draws a Micro QR code you have already generated. The symbol is used exactly as given, so only the appearance options apply. Every encoding option throws InvalidOperationException on a builder created this way.</p>
+            </div>
+            <div class="member" data-text="public microqrcodeimagebuilder(string content); starts a builder that will encode content when you ask for an image. error correction, version and every other option keep their defaults until you set them. ">
+              <code>public MicroQRCodeImageBuilder(string content);</code>
+              <p class="doc">Starts a builder that will encode content when you ask for an image. Error correction, version and every other option keep their defaults until you set them.</p>
+            </div>
+            <div class="member" data-text="public microqrcodeimagebuilder witherrorcorrection(microqrecclevel ecclevel); configure the error correction level for the micro qr code. legal combinations are version-dependent: m1 supports errordetectiononly only, m2/m3 support l and m, m4 supports l, m, and q. illegal combinations throw when the symbol is generated.">
+              <code>public MicroQRCodeImageBuilder WithErrorCorrection(MicroQREccLevel eccLevel);</code>
+              <p class="doc">Configure the error correction level for the Micro QR code.</p>
+              <details class="notes" data-text="legal combinations are version-dependent: m1 supports errordetectiononly only, m2/m3 support l and m, m4 supports l, m, and q. illegal combinations throw when the symbol is generated.">
+                <summary>Notes</summary>
+                <p class="doc remarks">Legal combinations are version-dependent: M1 supports ErrorDetectionOnly only, M2/M3 support L and M, M4 supports L, M, and Q. Illegal combinations throw when the symbol is generated.</p>
+              </details>
+            </div>
+            <div class="member" data-text="public microqrcodeimagebuilder withmaskpattern(int? maskpattern); pin one of the four micro qr data mask patterns (0-3) instead of the automatic edge-score selection; see maskpattern . ">
+              <code>public MicroQRCodeImageBuilder WithMaskPattern(int? maskPattern);</code>
+              <p class="doc">Pin one of the four Micro QR data mask patterns (0-3) instead of the automatic edge-score selection; see MaskPattern .</p>
+            </div>
+            <div class="member" data-text="public microqrcodeimagebuilder withsegmentation(microqrsegmentation segmentation); split the content into mixed-mode segments when that lowers the version (see microqrsegmentation ). defaults to single . never selects a larger version, and produces the identical symbol when a split would not shrink it. ">
+              <code>public MicroQRCodeImageBuilder WithSegmentation(MicroQRSegmentation segmentation);</code>
+              <p class="doc">Split the content into mixed-mode segments when that lowers the version (see MicroQRSegmentation ). Defaults to Single . Never selects a larger version, and produces the identical symbol when a split would not shrink it.</p>
+            </div>
+            <div class="member" data-text="public microqrcodeimagebuilder withversion(microqrversion version); configure the micro qr version to generate. the pinned-version case of the withversion overload.">
+              <code>public MicroQRCodeImageBuilder WithVersion(MicroQRVersion version);</code>
+              <p class="doc">Configure the Micro QR version to generate.</p>
+              <details class="notes" data-text="the pinned-version case of the withversion overload.">
+                <summary>Notes</summary>
+                <p class="doc remarks">The pinned-version case of the WithVersion overload.</p>
+              </details>
+            </div>
+            <div class="member" data-text="public microqrcodeimagebuilder withversion(microqrversionrange versionrange); configure the versions the generator may choose from, rather than a single one. see microqrversionrange for which empty ranges throw and which are a poor fit.">
+              <code>public MicroQRCodeImageBuilder WithVersion(MicroQRVersionRange versionRange);</code>
+              <p class="doc">Configure the versions the generator may choose from, rather than a single one.</p>
+              <details class="notes" data-text="see microqrversionrange for which empty ranges throw and which are a poor fit.">
+                <summary>Notes</summary>
+                <p class="doc remarks">See MicroQRVersionRange for which empty ranges throw and which are a poor fit.</p>
+              </details>
+            </div>
+            <div class="member" data-text="public static byte[] getimagebytes(microqrcodedata microqrcodedata, skencodedimageformat format, int size = 512, int quality = 100); generate a micro qr code as image byte array with specified format. ">
+              <code>public static byte[] GetImageBytes(MicroQRCodeData microQrCodeData, SKEncodedImageFormat format, int size = 512, int quality = 100);</code>
+              <p class="doc">Generate a Micro QR code as image byte array with specified format.</p>
+            </div>
+            <div class="member" data-text="public static byte[] getimagebytes(string content, skencodedimageformat format, microqrecclevel ecclevel = 2, int size = 512, int quality = 100); generate a micro qr code as image byte array with specified format. ">
+              <code>public static byte[] GetImageBytes(string content, SKEncodedImageFormat format, MicroQREccLevel eccLevel = 2, int size = 512, int quality = 100);</code>
+              <p class="doc">Generate a Micro QR code as image byte array with specified format.</p>
+            </div>
+            <div class="member" data-text="public static byte[] getpngbytes(microqrcodedata microqrcodedata, int size = 512); generate a micro qr code as png byte array with default settings. ">
+              <code>public static byte[] GetPngBytes(MicroQRCodeData microQrCodeData, int size = 512);</code>
+              <p class="doc">Generate a Micro QR code as PNG byte array with default settings.</p>
+            </div>
+            <div class="member" data-text="public static byte[] getpngbytes(string content, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code as png byte array with default settings. ">
+              <code>public static byte[] GetPngBytes(string content, MicroQREccLevel eccLevel = 2, int size = 512);</code>
+              <p class="doc">Generate a Micro QR code as PNG byte array with default settings.</p>
+            </div>
+            <div class="member" data-text="public static byte[] getsvgbytes(microqrcodedata microqrcodedata, int size = 512); generate a micro qr code as svg (utf-8 encoded) byte array with default settings. ">
+              <code>public static byte[] GetSvgBytes(MicroQRCodeData microQrCodeData, int size = 512);</code>
+              <p class="doc">Generate a Micro QR code as SVG (UTF-8 encoded) byte array with default settings.</p>
+            </div>
+            <div class="member" data-text="public static byte[] getsvgbytes(string content, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code as svg (utf-8 encoded) byte array with default settings. ">
+              <code>public static byte[] GetSvgBytes(string content, MicroQREccLevel eccLevel = 2, int size = 512);</code>
+              <p class="doc">Generate a Micro QR code as SVG (UTF-8 encoded) byte array with default settings.</p>
+            </div>
+            <div class="member" data-text="public static string getsvgstring(microqrcodedata microqrcodedata, int size = 512); generate a micro qr code as svg document string with default settings. ">
+              <code>public static string GetSvgString(MicroQRCodeData microQrCodeData, int size = 512);</code>
+              <p class="doc">Generate a Micro QR code as SVG document string with default settings.</p>
+            </div>
+            <div class="member" data-text="public static string getsvgstring(string content, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code as svg document string with default settings. ">
+              <code>public static string GetSvgString(string content, MicroQREccLevel eccLevel = 2, int size = 512);</code>
+              <p class="doc">Generate a Micro QR code as SVG document string with default settings.</p>
+            </div>
+            <div class="member" data-text="public static void savepng(microqrcodedata microqrcodedata, stream output, int size = 512); generate a micro qr code and save to stream with default png settings. ">
+              <code>public static void SavePng(MicroQRCodeData microQrCodeData, Stream output, int size = 512);</code>
+              <p class="doc">Generate a Micro QR code and save to stream with default PNG settings.</p>
+            </div>
+            <div class="member" data-text="public static void savepng(string content, stream output, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code and save to stream with default png settings. ">
+              <code>public static void SavePng(string content, Stream output, MicroQREccLevel eccLevel = 2, int size = 512);</code>
+              <p class="doc">Generate a Micro QR code and save to stream with default PNG settings.</p>
+            </div>
+            <div class="member" data-text="public static void savesvg(microqrcodedata microqrcodedata, stream output, int size = 512); generate a micro qr code and save as svg to stream with default settings. ">
+              <code>public static void SaveSvg(MicroQRCodeData microQrCodeData, Stream output, int size = 512);</code>
+              <p class="doc">Generate a Micro QR code and save as SVG to stream with default settings.</p>
+            </div>
+            <div class="member" data-text="public static void savesvg(string content, stream output, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code and save as svg to stream with default settings. ">
+              <code>public static void SaveSvg(string content, Stream output, MicroQREccLevel eccLevel = 2, int size = 512);</code>
+              <p class="doc">Generate a Micro QR code and save as SVG to stream with default settings.</p>
+            </div>
+            <div class="member" data-text="public static void writeimage(microqrcodedata microqrcodedata, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, int size = 512, int quality = 100); generate a micro qr code and write to an ibufferwriter with specified format. ">
+              <code>public static void WriteImage(MicroQRCodeData microQrCodeData, IBufferWriter&lt;byte&gt; writer, SKEncodedImageFormat format, int size = 512, int quality = 100);</code>
+              <p class="doc">Generate a Micro QR code and write to an IBufferWriter with specified format.</p>
+            </div>
+            <div class="member" data-text="public static void writeimage(string content, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, microqrecclevel ecclevel = 2, int size = 512, int quality = 100); generate a micro qr code and write to an ibufferwriter with specified format. ">
+              <code>public static void WriteImage(string content, IBufferWriter&lt;byte&gt; writer, SKEncodedImageFormat format, MicroQREccLevel eccLevel = 2, int size = 512, int quality = 100);</code>
+              <p class="doc">Generate a Micro QR code and write to an IBufferWriter with specified format.</p>
+            </div>
+            <div class="member" data-text="public static void writepng(microqrcodedata microqrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate a micro qr code and write to an ibufferwriter with default png settings. ">
+              <code>public static void WritePng(MicroQRCodeData microQrCodeData, IBufferWriter&lt;byte&gt; writer, int size = 512);</code>
+              <p class="doc">Generate a Micro QR code and write to an IBufferWriter with default PNG settings.</p>
+            </div>
+            <div class="member" data-text="public static void writepng(string content, ibufferwriter&lt;byte&gt; writer, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code and write to an ibufferwriter with default png settings. ">
+              <code>public static void WritePng(string content, IBufferWriter&lt;byte&gt; writer, MicroQREccLevel eccLevel = 2, int size = 512);</code>
+              <p class="doc">Generate a Micro QR code and write to an IBufferWriter with default PNG settings.</p>
+            </div>
+            <div class="member" data-text="public static void writesvg(microqrcodedata microqrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate a micro qr code and write as svg (utf-8 encoded) to an ibufferwriter with default settings. ">
+              <code>public static void WriteSvg(MicroQRCodeData microQrCodeData, IBufferWriter&lt;byte&gt; writer, int size = 512);</code>
+              <p class="doc">Generate a Micro QR code and write as SVG (UTF-8 encoded) to an IBufferWriter with default settings.</p>
+            </div>
+            <div class="member" data-text="public static void writesvg(string content, ibufferwriter&lt;byte&gt; writer, microqrecclevel ecclevel = 2, int size = 512); generate a micro qr code and write as svg (utf-8 encoded) to an ibufferwriter with default settings. ">
+              <code>public static void WriteSvg(string content, IBufferWriter&lt;byte&gt; writer, MicroQREccLevel eccLevel = 2, int size = 512);</code>
+              <p class="doc">Generate a Micro QR code and write as SVG (UTF-8 encoded) to an IBufferWriter with default settings.</p>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.Image.ModuleShape" data-name="skiasharp.qrcode.image.moduleshape" data-text="skiasharp.qrcode.image.moduleshape public abstract class moduleshape defines the shape of qr code modules  protected moduleshape();  public bool requiresantialiasing { get; } gets whether this shape requires antialiasing for smooth rendering.  public abstract void draw(skcanvas canvas, skrect rect, skpaint paint); draw a module at the specified location. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.ModuleShape" aria-label="Link to SkiaSharp.QrCode.Image.ModuleShape">#</a><code>public abstract class ModuleShape</code></h3>
+          <p class="doc">Defines the shape of QR code modules</p>
+          <div class="members">
+            <div class="member" data-text="protected moduleshape(); ">
+              <code>protected ModuleShape();</code>
+            </div>
+            <div class="member" data-text="public bool requiresantialiasing { get; } gets whether this shape requires antialiasing for smooth rendering. ">
+              <code>public bool RequiresAntialiasing { get; }</code>
+              <p class="doc">Gets whether this shape requires antialiasing for smooth rendering.</p>
+            </div>
+            <div class="member" data-text="public abstract void draw(skcanvas canvas, skrect rect, skpaint paint); draw a module at the specified location. ">
+              <code>public abstract void Draw(SKCanvas canvas, SKRect rect, SKPaint paint);</code>
+              <p class="doc">Draw a module at the specified location.</p>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.Image.QRCodeImageBuilder" data-name="skiasharp.qrcode.image.qrcodeimagebuilder" data-text="skiasharp.qrcode.image.qrcodeimagebuilder public class qrcodeimagebuilder : qrcodeimagebuilderbase&lt;qrcodeimagebuilder&gt; high-level builder for creating qr code images with fluent configuration and static methods. this builder provides both simple static methods for quick qr code generation and a fluent api for advanced customization. quick generation (static methods): use static methods like getpngbytes for one-liner qr code creation with default settings. advanced configuration (fluent api): chain the shared options ( qrcodeimagebuilderbase , qrcodeimagebuilderbase , qrcodeimagebuilderbase , qrcodeimagebuilderbase , qrcodeimagebuilderbase ) with the standard qr-specific options ( witherrorcorrection , withversion , withicon , withfinderpatternshape ) to customize appearance. public qrcodeimagebuilder(qrcodedata qrcodedata); starts a builder that draws a qr code you have already generated. the symbol is used exactly as given, so only the appearance options apply. most encoding options throw invalidoperationexception on a builder created this way; witherrorcorrection and withecimode are accepted and then ignored, because they shipped that way in 1.1.1.  public qrcodeimagebuilder(string content); starts a builder that will encode content when you ask for an image. error correction, version and every other option keep their defaults until you set them.  public qrcodeimagebuilder withecimode(ecimode ecimode); configure the eci (extended channel interpretation) mode for character encoding.  public qrcodeimagebuilder witherrorcorrection(ecclevel ecclevel); configure the error correction level for the qr code.  public qrcodeimagebuilder witherrorcorrectionboost(bool boostecclevel = true); raise the error correction level above the one configured with witherrorcorrection when the chosen version's capacity allows it, without changing the version or the symbol size. recommended together with withicon : the spare capacity absorbs the modules the icon covers.  public qrcodeimagebuilder withfinderpatternshape(finderpatternshape? finderpatternshape); configure the shape of the finder patterns.  public qrcodeimagebuilder withicon(icondata? icondata); configure an icon to overlay on the center of the qr code.  public qrcodeimagebuilder withmaskpattern(int? maskpattern); pin one of the eight data mask patterns (0-7) instead of the automatic penalty-scored selection; see maskpattern .  public qrcodeimagebuilder withsegmentation(qrcodesegmentation segmentation); split the content into mixed-mode segments when that lowers the version (see qrcodesegmentation ). defaults to single . never selects a larger version, and produces the identical symbol when a split would not shrink it.  public qrcodeimagebuilder withversion(qrcodeversionrange versionrange); configure the versions the generator may choose from, rather than a single one. for a symbol that must reach, or not exceed, a physical size. an int? converts implicitly, so an optional version needs no branch. public qrcodeimagebuilder withversion(int version); configure the qr code version to generate. the pinned case of withversion ; -1 is any . public static byte[] getimagebytes(qrcodedata qrcodedata, skencodedimageformat format, int size = 512, int quality = 100); generate a qr code as image byte array with specified format.  public static byte[] getimagebytes(string content, skencodedimageformat format, ecclevel ecclevel = 1, int size = 512, int quality = 100); generate a qr code as image byte array with specified format.  public static byte[] getpngbytes(qrcodedata qrcodedata, int size = 512); generate a qr code as png byte array with default settings.  public static byte[] getpngbytes(string content, ecclevel ecclevel = 1, int size = 512); generate a qr code as png byte array with default settings.  public static byte[] getsvgbytes(qrcodedata qrcodedata, int size = 512); generate a qr code as svg (utf-8 encoded) byte array with default settings.  public static byte[] getsvgbytes(string content, ecclevel ecclevel = 1, int size = 512); generate a qr code as svg (utf-8 encoded) byte array with default settings.  public static string getsvgstring(qrcodedata qrcodedata, int size = 512); generate a qr code as svg document string with default settings.  public static string getsvgstring(string content, ecclevel ecclevel = 1, int size = 512); generate a qr code as svg document string with default settings.  public static void savepng(qrcodedata qrcodedata, stream output, int size = 512); generate a qr code and save to stream with default png settings.  public static void savepng(string content, stream output, ecclevel ecclevel = 1, int size = 512); generate a qr code and save to stream with default png settings.  public static void savesvg(qrcodedata qrcodedata, stream output, int size = 512); generate a qr code and save as svg to stream with default settings.  public static void savesvg(string content, stream output, ecclevel ecclevel = 1, int size = 512); generate a qr code and save as svg to stream with default settings.  public static void writeimage(qrcodedata qrcodedata, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, int size = 512, int quality = 100); generate a qr code and write to an ibufferwriter with specified format.  public static void writeimage(string content, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, ecclevel ecclevel = 1, int size = 512, int quality = 100); generate a qr code and write to an ibufferwriter with specified format.  public static void writepng(qrcodedata qrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate a qr code and write to an ibufferwriter with default png settings.  public static void writepng(string content, ibufferwriter&lt;byte&gt; writer, ecclevel ecclevel = 1, int size = 512); generate a qr code and write to an ibufferwriter with default png settings.  public static void writesvg(qrcodedata qrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate a qr code and write as svg (utf-8 encoded) to an ibufferwriter with default settings.  public static void writesvg(string content, ibufferwriter&lt;byte&gt; writer, ecclevel ecclevel = 1, int size = 512); generate a qr code and write as svg (utf-8 encoded) to an ibufferwriter with default settings. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.QRCodeImageBuilder" aria-label="Link to SkiaSharp.QrCode.Image.QRCodeImageBuilder">#</a><code>public class QRCodeImageBuilder : QRCodeImageBuilderBase&lt;QRCodeImageBuilder&gt;</code></h3>
+          <p class="doc">High-level builder for creating QR code images with fluent configuration and static methods.</p>
+          <details class="notes" data-text="this builder provides both simple static methods for quick qr code generation and a fluent api for advanced customization. quick generation (static methods): use static methods like getpngbytes for one-liner qr code creation with default settings. advanced configuration (fluent api): chain the shared options ( qrcodeimagebuilderbase , qrcodeimagebuilderbase , qrcodeimagebuilderbase , qrcodeimagebuilderbase , qrcodeimagebuilderbase ) with the standard qr-specific options ( witherrorcorrection , withversion , withicon , withfinderpatternshape ) to customize appearance.">
+            <summary>Notes</summary>
+            <p class="doc remarks">This builder provides both simple static methods for quick QR code generation and a fluent API for advanced customization. Quick Generation (Static Methods): Use static methods like GetPngBytes for one-liner QR code creation with default settings. Advanced Configuration (Fluent API): Chain the shared options ( QRCodeImageBuilderBase , QRCodeImageBuilderBase , QRCodeImageBuilderBase , QRCodeImageBuilderBase , QRCodeImageBuilderBase ) with the Standard QR-specific options ( WithErrorCorrection , WithVersion , WithIcon , WithFinderPatternShape ) to customize appearance.</p>
+          </details>
+          <div class="members">
+            <div class="member" data-text="public qrcodeimagebuilder(qrcodedata qrcodedata); starts a builder that draws a qr code you have already generated. the symbol is used exactly as given, so only the appearance options apply. most encoding options throw invalidoperationexception on a builder created this way; witherrorcorrection and withecimode are accepted and then ignored, because they shipped that way in 1.1.1. ">
+              <code>public QRCodeImageBuilder(QRCodeData qrCodeData);</code>
+              <p class="doc">Starts a builder that draws a QR code you have already generated. The symbol is used exactly as given, so only the appearance options apply. Most encoding options throw InvalidOperationException on a builder created this way; WithErrorCorrection and WithEciMode are accepted and then ignored, because they shipped that way in 1.1.1.</p>
+            </div>
+            <div class="member" data-text="public qrcodeimagebuilder(string content); starts a builder that will encode content when you ask for an image. error correction, version and every other option keep their defaults until you set them. ">
+              <code>public QRCodeImageBuilder(string content);</code>
+              <p class="doc">Starts a builder that will encode content when you ask for an image. Error correction, version and every other option keep their defaults until you set them.</p>
+            </div>
+            <div class="member" data-text="public qrcodeimagebuilder withecimode(ecimode ecimode); configure the eci (extended channel interpretation) mode for character encoding. ">
+              <code>public QRCodeImageBuilder WithEciMode(EciMode eciMode);</code>
+              <p class="doc">Configure the ECI (Extended Channel Interpretation) mode for character encoding.</p>
+            </div>
+            <div class="member" data-text="public qrcodeimagebuilder witherrorcorrection(ecclevel ecclevel); configure the error correction level for the qr code. ">
+              <code>public QRCodeImageBuilder WithErrorCorrection(ECCLevel eccLevel);</code>
+              <p class="doc">Configure the error correction level for the QR code.</p>
+            </div>
+            <div class="member" data-text="public qrcodeimagebuilder witherrorcorrectionboost(bool boostecclevel = true); raise the error correction level above the one configured with witherrorcorrection when the chosen version's capacity allows it, without changing the version or the symbol size. recommended together with withicon : the spare capacity absorbs the modules the icon covers. ">
+              <code>public QRCodeImageBuilder WithErrorCorrectionBoost(bool boostEccLevel = true);</code>
+              <p class="doc">Raise the error correction level above the one configured with WithErrorCorrection when the chosen version's capacity allows it, without changing the version or the symbol size. Recommended together with WithIcon : the spare capacity absorbs the modules the icon covers.</p>
+            </div>
+            <div class="member" data-text="public qrcodeimagebuilder withfinderpatternshape(finderpatternshape? finderpatternshape); configure the shape of the finder patterns. ">
+              <code>public QRCodeImageBuilder WithFinderPatternShape(FinderPatternShape? finderPatternShape);</code>
+              <p class="doc">Configure the shape of the finder patterns.</p>
+            </div>
+            <div class="member" data-text="public qrcodeimagebuilder withicon(icondata? icondata); configure an icon to overlay on the center of the qr code. ">
+              <code>public QRCodeImageBuilder WithIcon(IconData? iconData);</code>
+              <p class="doc">Configure an icon to overlay on the center of the QR code.</p>
+            </div>
+            <div class="member" data-text="public qrcodeimagebuilder withmaskpattern(int? maskpattern); pin one of the eight data mask patterns (0-7) instead of the automatic penalty-scored selection; see maskpattern . ">
+              <code>public QRCodeImageBuilder WithMaskPattern(int? maskPattern);</code>
+              <p class="doc">Pin one of the eight data mask patterns (0-7) instead of the automatic penalty-scored selection; see MaskPattern .</p>
+            </div>
+            <div class="member" data-text="public qrcodeimagebuilder withsegmentation(qrcodesegmentation segmentation); split the content into mixed-mode segments when that lowers the version (see qrcodesegmentation ). defaults to single . never selects a larger version, and produces the identical symbol when a split would not shrink it. ">
+              <code>public QRCodeImageBuilder WithSegmentation(QRCodeSegmentation segmentation);</code>
+              <p class="doc">Split the content into mixed-mode segments when that lowers the version (see QRCodeSegmentation ). Defaults to Single . Never selects a larger version, and produces the identical symbol when a split would not shrink it.</p>
+            </div>
+            <div class="member" data-text="public qrcodeimagebuilder withversion(qrcodeversionrange versionrange); configure the versions the generator may choose from, rather than a single one. for a symbol that must reach, or not exceed, a physical size. an int? converts implicitly, so an optional version needs no branch.">
+              <code>public QRCodeImageBuilder WithVersion(QRCodeVersionRange versionRange);</code>
+              <p class="doc">Configure the versions the generator may choose from, rather than a single one.</p>
+              <details class="notes" data-text="for a symbol that must reach, or not exceed, a physical size. an int? converts implicitly, so an optional version needs no branch.">
+                <summary>Notes</summary>
+                <p class="doc remarks">For a symbol that must reach, or not exceed, a physical size. An int? converts implicitly, so an optional version needs no branch.</p>
+              </details>
+            </div>
+            <div class="member" data-text="public qrcodeimagebuilder withversion(int version); configure the qr code version to generate. the pinned case of withversion ; -1 is any .">
+              <code>public QRCodeImageBuilder WithVersion(int version);</code>
+              <p class="doc">Configure the QR code version to generate.</p>
+              <details class="notes" data-text="the pinned case of withversion ; -1 is any .">
+                <summary>Notes</summary>
+                <p class="doc remarks">The pinned case of WithVersion ; -1 is Any .</p>
+              </details>
+            </div>
+            <div class="member" data-text="public static byte[] getimagebytes(qrcodedata qrcodedata, skencodedimageformat format, int size = 512, int quality = 100); generate a qr code as image byte array with specified format. ">
+              <code>public static byte[] GetImageBytes(QRCodeData qrCodeData, SKEncodedImageFormat format, int size = 512, int quality = 100);</code>
+              <p class="doc">Generate a QR code as image byte array with specified format.</p>
+            </div>
+            <div class="member" data-text="public static byte[] getimagebytes(string content, skencodedimageformat format, ecclevel ecclevel = 1, int size = 512, int quality = 100); generate a qr code as image byte array with specified format. ">
+              <code>public static byte[] GetImageBytes(string content, SKEncodedImageFormat format, ECCLevel eccLevel = 1, int size = 512, int quality = 100);</code>
+              <p class="doc">Generate a QR code as image byte array with specified format.</p>
+            </div>
+            <div class="member" data-text="public static byte[] getpngbytes(qrcodedata qrcodedata, int size = 512); generate a qr code as png byte array with default settings. ">
+              <code>public static byte[] GetPngBytes(QRCodeData qrCodeData, int size = 512);</code>
+              <p class="doc">Generate a QR code as PNG byte array with default settings.</p>
+            </div>
+            <div class="member" data-text="public static byte[] getpngbytes(string content, ecclevel ecclevel = 1, int size = 512); generate a qr code as png byte array with default settings. ">
+              <code>public static byte[] GetPngBytes(string content, ECCLevel eccLevel = 1, int size = 512);</code>
+              <p class="doc">Generate a QR code as PNG byte array with default settings.</p>
+            </div>
+            <div class="member" data-text="public static byte[] getsvgbytes(qrcodedata qrcodedata, int size = 512); generate a qr code as svg (utf-8 encoded) byte array with default settings. ">
+              <code>public static byte[] GetSvgBytes(QRCodeData qrCodeData, int size = 512);</code>
+              <p class="doc">Generate a QR code as SVG (UTF-8 encoded) byte array with default settings.</p>
+            </div>
+            <div class="member" data-text="public static byte[] getsvgbytes(string content, ecclevel ecclevel = 1, int size = 512); generate a qr code as svg (utf-8 encoded) byte array with default settings. ">
+              <code>public static byte[] GetSvgBytes(string content, ECCLevel eccLevel = 1, int size = 512);</code>
+              <p class="doc">Generate a QR code as SVG (UTF-8 encoded) byte array with default settings.</p>
+            </div>
+            <div class="member" data-text="public static string getsvgstring(qrcodedata qrcodedata, int size = 512); generate a qr code as svg document string with default settings. ">
+              <code>public static string GetSvgString(QRCodeData qrCodeData, int size = 512);</code>
+              <p class="doc">Generate a QR code as SVG document string with default settings.</p>
+            </div>
+            <div class="member" data-text="public static string getsvgstring(string content, ecclevel ecclevel = 1, int size = 512); generate a qr code as svg document string with default settings. ">
+              <code>public static string GetSvgString(string content, ECCLevel eccLevel = 1, int size = 512);</code>
+              <p class="doc">Generate a QR code as SVG document string with default settings.</p>
+            </div>
+            <div class="member" data-text="public static void savepng(qrcodedata qrcodedata, stream output, int size = 512); generate a qr code and save to stream with default png settings. ">
+              <code>public static void SavePng(QRCodeData qrCodeData, Stream output, int size = 512);</code>
+              <p class="doc">Generate a QR code and save to stream with default PNG settings.</p>
+            </div>
+            <div class="member" data-text="public static void savepng(string content, stream output, ecclevel ecclevel = 1, int size = 512); generate a qr code and save to stream with default png settings. ">
+              <code>public static void SavePng(string content, Stream output, ECCLevel eccLevel = 1, int size = 512);</code>
+              <p class="doc">Generate a QR code and save to stream with default PNG settings.</p>
+            </div>
+            <div class="member" data-text="public static void savesvg(qrcodedata qrcodedata, stream output, int size = 512); generate a qr code and save as svg to stream with default settings. ">
+              <code>public static void SaveSvg(QRCodeData qrCodeData, Stream output, int size = 512);</code>
+              <p class="doc">Generate a QR code and save as SVG to stream with default settings.</p>
+            </div>
+            <div class="member" data-text="public static void savesvg(string content, stream output, ecclevel ecclevel = 1, int size = 512); generate a qr code and save as svg to stream with default settings. ">
+              <code>public static void SaveSvg(string content, Stream output, ECCLevel eccLevel = 1, int size = 512);</code>
+              <p class="doc">Generate a QR code and save as SVG to stream with default settings.</p>
+            </div>
+            <div class="member" data-text="public static void writeimage(qrcodedata qrcodedata, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, int size = 512, int quality = 100); generate a qr code and write to an ibufferwriter with specified format. ">
+              <code>public static void WriteImage(QRCodeData qrCodeData, IBufferWriter&lt;byte&gt; writer, SKEncodedImageFormat format, int size = 512, int quality = 100);</code>
+              <p class="doc">Generate a QR code and write to an IBufferWriter with specified format.</p>
+            </div>
+            <div class="member" data-text="public static void writeimage(string content, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, ecclevel ecclevel = 1, int size = 512, int quality = 100); generate a qr code and write to an ibufferwriter with specified format. ">
+              <code>public static void WriteImage(string content, IBufferWriter&lt;byte&gt; writer, SKEncodedImageFormat format, ECCLevel eccLevel = 1, int size = 512, int quality = 100);</code>
+              <p class="doc">Generate a QR code and write to an IBufferWriter with specified format.</p>
+            </div>
+            <div class="member" data-text="public static void writepng(qrcodedata qrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate a qr code and write to an ibufferwriter with default png settings. ">
+              <code>public static void WritePng(QRCodeData qrCodeData, IBufferWriter&lt;byte&gt; writer, int size = 512);</code>
+              <p class="doc">Generate a QR code and write to an IBufferWriter with default PNG settings.</p>
+            </div>
+            <div class="member" data-text="public static void writepng(string content, ibufferwriter&lt;byte&gt; writer, ecclevel ecclevel = 1, int size = 512); generate a qr code and write to an ibufferwriter with default png settings. ">
+              <code>public static void WritePng(string content, IBufferWriter&lt;byte&gt; writer, ECCLevel eccLevel = 1, int size = 512);</code>
+              <p class="doc">Generate a QR code and write to an IBufferWriter with default PNG settings.</p>
+            </div>
+            <div class="member" data-text="public static void writesvg(qrcodedata qrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate a qr code and write as svg (utf-8 encoded) to an ibufferwriter with default settings. ">
+              <code>public static void WriteSvg(QRCodeData qrCodeData, IBufferWriter&lt;byte&gt; writer, int size = 512);</code>
+              <p class="doc">Generate a QR code and write as SVG (UTF-8 encoded) to an IBufferWriter with default settings.</p>
+            </div>
+            <div class="member" data-text="public static void writesvg(string content, ibufferwriter&lt;byte&gt; writer, ecclevel ecclevel = 1, int size = 512); generate a qr code and write as svg (utf-8 encoded) to an ibufferwriter with default settings. ">
+              <code>public static void WriteSvg(string content, IBufferWriter&lt;byte&gt; writer, ECCLevel eccLevel = 1, int size = 512);</code>
+              <p class="doc">Generate a QR code and write as SVG (UTF-8 encoded) to an IBufferWriter with default settings.</p>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.Image.QRCodeImageBuilderBase" data-name="skiasharp.qrcode.image.qrcodeimagebuilderbase" data-text="skiasharp.qrcode.image.qrcodeimagebuilderbase public abstract class qrcodeimagebuilderbase&lt;tself&gt; shared implementation for the symbology-specific qr image builders ( qrcodeimagebuilder , microqrcodeimagebuilder ): the fluent options every symbology supports, canvas layout, and the complete raster/svg output surface. symbology-specific concerns, error correction and version types, icon overlays, finder pattern styling, live on the derived builders. the self-referential type parameter keeps fluent chains typed to the concrete builder, so shared and symbology-specific options mix freely without casts: new microqrcodeimagebuilder(&quot;...&quot;).withsize(256, 256).withversion(microqrversion.m4). deriving from this class outside the library is not supported: the abstract hooks that connect a symbology's data model to the shared output pipeline are private protected. public qrcodeimagebuilderbase.tself withcolors(skcolor? codecolor = null, skcolor? backgroundcolor = null, skcolor? clearcolor = null); configure the colors used in the image.  public qrcodeimagebuilderbase.tself withformat(skencodedimageformat format, int quality = 100); configure the output image format and quality.  public qrcodeimagebuilderbase.tself withgradient(gradientoptions? gradientoptions); configure gradient options for the modules.  public qrcodeimagebuilderbase.tself withmodulepixelsize(int modulepixelsize); configure content size from pixels-per-module. sets each module to an exact integer pixel size. content side length is matrixsize * modulepixelsize. used alone, the output image matches the content size. used with qrcodeimagebuilderbase , the content is centered on the larger canvas and padded with clearcolor. if the canvas is smaller than the content, rendering throws. public qrcodeimagebuilderbase.tself withmoduleshape(moduleshape? moduleshape, float sizepercent = 1); configure the shape of the modules. note: custom module shapes reduce scan margin; sizes below 0.8 may affect readability. on standard qr they also affect finder patterns unless a custom finder pattern shape is explicitly set via its withfinderpatternshape option. public qrcodeimagebuilderbase.tself withquietzone(int size); configure the quiet zone size (light border) around the symbol. when not called, the builder uses its symbology's specification default: 4 modules for standard qr, 2 for micro qr and rmqr. ignored when the builder was given pre-built symbol data (the data already carries its quiet zone). public qrcodeimagebuilderbase.tself withsize(int width, int height); configure the output image size in absolute pixels. used alone, this sets an exact canvas size. for the square symbologies the module pixel size then becomes imagesize / matrixsize, which may be fractional and can change when the version changes; the rectangular rmqr builder fits the symbol into the canvas with a uniform module scale instead (letterbox, the leftover pad keeps clearcolor). used with qrcodeimagebuilderbase , this sets the canvas size while module pixels define the content size (matrixsize * modulepixelsize). the canvas must be at least as large as the content on both sides; extra space is padded and the content is centered. padding uses clearcolor from qrcodeimagebuilderbase . public skbitmap tobitmap(); generate the symbol image and return as skbitmap.  public skimage toimage(); generate the symbol image and return as skimage.  public byte[] tobytearray(); generate the symbol image and return as byte array.  public string tosvgstring(); generate the symbol and return as svg document string. see qrcodeimagebuilderbase for rendering behavior. public void saveto(ibufferwriter&lt;byte&gt; writer); generate the symbol image and write to an ibufferwriter. this is more efficient than saveto(stream) as it avoids intermediate buffering.  public void saveto(stream output); generate the symbol image and save to stream.  public void savetosvg(ibufferwriter&lt;byte&gt; writer); generate the symbol and write as svg document to an ibufferwriter. see qrcodeimagebuilderbase for rendering behavior. data is written in writer-provided segments, so segmented writers (e.g. pipewriter) work without a single contiguous buffer for the whole document. public void savetosvg(stream output); generate the symbol and save as svg document to stream. the symbol is drawn as vector shapes via sksvgcanvas , so the output scales without quality loss. all builder options apply. the root element carries a viewbox, so the document scales its content when embedded at a different size (img element, css). for plain rectangular modules, shape-rendering=&quot;crispedges&quot; is added to avoid antialiasing seams between modules; custom shapes keep antialiasing for smooth curves. qrcodeimagebuilderbase is ignored, svg is a vector format, not an skencodedimageformat . size options ( qrcodeimagebuilderbase , qrcodeimagebuilderbase , or the symbology's default canvas) define the svg viewport in units. the stream is left open after writing.">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.QRCodeImageBuilderBase" aria-label="Link to SkiaSharp.QrCode.Image.QRCodeImageBuilderBase">#</a><code>public abstract class QRCodeImageBuilderBase&lt;TSelf&gt;</code></h3>
+          <p class="doc">Shared implementation for the symbology-specific QR image builders ( QRCodeImageBuilder , MicroQRCodeImageBuilder ): the fluent options every symbology supports, canvas layout, and the complete raster/SVG output surface. Symbology-specific concerns, error correction and version types, icon overlays, finder pattern styling, live on the derived builders.</p>
+          <details class="notes" data-text="the self-referential type parameter keeps fluent chains typed to the concrete builder, so shared and symbology-specific options mix freely without casts: new microqrcodeimagebuilder(&quot;...&quot;).withsize(256, 256).withversion(microqrversion.m4). deriving from this class outside the library is not supported: the abstract hooks that connect a symbology's data model to the shared output pipeline are private protected.">
+            <summary>Notes</summary>
+            <p class="doc remarks">The self-referential type parameter keeps fluent chains typed to the concrete builder, so shared and symbology-specific options mix freely without casts: new MicroQRCodeImageBuilder(&quot;...&quot;).WithSize(256, 256).WithVersion(MicroQRVersion.M4). Deriving from this class outside the library is not supported: the abstract hooks that connect a symbology's data model to the shared output pipeline are private protected.</p>
+          </details>
+          <div class="members">
+            <div class="member" data-text="public qrcodeimagebuilderbase.tself withcolors(skcolor? codecolor = null, skcolor? backgroundcolor = null, skcolor? clearcolor = null); configure the colors used in the image. ">
+              <code>public QRCodeImageBuilderBase.TSelf WithColors(SKColor? codeColor = null, SKColor? backgroundColor = null, SKColor? clearColor = null);</code>
+              <p class="doc">Configure the colors used in the image.</p>
+            </div>
+            <div class="member" data-text="public qrcodeimagebuilderbase.tself withformat(skencodedimageformat format, int quality = 100); configure the output image format and quality. ">
+              <code>public QRCodeImageBuilderBase.TSelf WithFormat(SKEncodedImageFormat format, int quality = 100);</code>
+              <p class="doc">Configure the output image format and quality.</p>
+            </div>
+            <div class="member" data-text="public qrcodeimagebuilderbase.tself withgradient(gradientoptions? gradientoptions); configure gradient options for the modules. ">
+              <code>public QRCodeImageBuilderBase.TSelf WithGradient(GradientOptions? gradientOptions);</code>
+              <p class="doc">Configure gradient options for the modules.</p>
+            </div>
+            <div class="member" data-text="public qrcodeimagebuilderbase.tself withmodulepixelsize(int modulepixelsize); configure content size from pixels-per-module. sets each module to an exact integer pixel size. content side length is matrixsize * modulepixelsize. used alone, the output image matches the content size. used with qrcodeimagebuilderbase , the content is centered on the larger canvas and padded with clearcolor. if the canvas is smaller than the content, rendering throws.">
+              <code>public QRCodeImageBuilderBase.TSelf WithModulePixelSize(int modulePixelSize);</code>
+              <p class="doc">Configure content size from pixels-per-module.</p>
+              <details class="notes" data-text="sets each module to an exact integer pixel size. content side length is matrixsize * modulepixelsize. used alone, the output image matches the content size. used with qrcodeimagebuilderbase , the content is centered on the larger canvas and padded with clearcolor. if the canvas is smaller than the content, rendering throws.">
+                <summary>Notes</summary>
+                <p class="doc remarks">Sets each module to an exact integer pixel size. Content side length is matrixSize * modulePixelSize. Used alone, the output image matches the content size. Used with QRCodeImageBuilderBase , the content is centered on the larger canvas and padded with clearColor. If the canvas is smaller than the content, rendering throws.</p>
+              </details>
+            </div>
+            <div class="member" data-text="public qrcodeimagebuilderbase.tself withmoduleshape(moduleshape? moduleshape, float sizepercent = 1); configure the shape of the modules. note: custom module shapes reduce scan margin; sizes below 0.8 may affect readability. on standard qr they also affect finder patterns unless a custom finder pattern shape is explicitly set via its withfinderpatternshape option.">
+              <code>public QRCodeImageBuilderBase.TSelf WithModuleShape(ModuleShape? moduleShape, float sizePercent = 1);</code>
+              <p class="doc">Configure the shape of the modules.</p>
+              <details class="notes" data-text="note: custom module shapes reduce scan margin; sizes below 0.8 may affect readability. on standard qr they also affect finder patterns unless a custom finder pattern shape is explicitly set via its withfinderpatternshape option.">
+                <summary>Notes</summary>
+                <p class="doc remarks">Note: Custom module shapes reduce scan margin; sizes below 0.8 may affect readability. On Standard QR they also affect finder patterns unless a custom finder pattern shape is explicitly set via its WithFinderPatternShape option.</p>
+              </details>
+            </div>
+            <div class="member" data-text="public qrcodeimagebuilderbase.tself withquietzone(int size); configure the quiet zone size (light border) around the symbol. when not called, the builder uses its symbology's specification default: 4 modules for standard qr, 2 for micro qr and rmqr. ignored when the builder was given pre-built symbol data (the data already carries its quiet zone).">
+              <code>public QRCodeImageBuilderBase.TSelf WithQuietZone(int size);</code>
+              <p class="doc">Configure the quiet zone size (light border) around the symbol.</p>
+              <details class="notes" data-text="when not called, the builder uses its symbology's specification default: 4 modules for standard qr, 2 for micro qr and rmqr. ignored when the builder was given pre-built symbol data (the data already carries its quiet zone).">
+                <summary>Notes</summary>
+                <p class="doc remarks">When not called, the builder uses its symbology's specification default: 4 modules for Standard QR, 2 for Micro QR and rMQR. Ignored when the builder was given pre-built symbol data (the data already carries its quiet zone).</p>
+              </details>
+            </div>
+            <div class="member" data-text="public qrcodeimagebuilderbase.tself withsize(int width, int height); configure the output image size in absolute pixels. used alone, this sets an exact canvas size. for the square symbologies the module pixel size then becomes imagesize / matrixsize, which may be fractional and can change when the version changes; the rectangular rmqr builder fits the symbol into the canvas with a uniform module scale instead (letterbox, the leftover pad keeps clearcolor). used with qrcodeimagebuilderbase , this sets the canvas size while module pixels define the content size (matrixsize * modulepixelsize). the canvas must be at least as large as the content on both sides; extra space is padded and the content is centered. padding uses clearcolor from qrcodeimagebuilderbase .">
+              <code>public QRCodeImageBuilderBase.TSelf WithSize(int width, int height);</code>
+              <p class="doc">Configure the output image size in absolute pixels.</p>
+              <details class="notes" data-text="used alone, this sets an exact canvas size. for the square symbologies the module pixel size then becomes imagesize / matrixsize, which may be fractional and can change when the version changes; the rectangular rmqr builder fits the symbol into the canvas with a uniform module scale instead (letterbox, the leftover pad keeps clearcolor). used with qrcodeimagebuilderbase , this sets the canvas size while module pixels define the content size (matrixsize * modulepixelsize). the canvas must be at least as large as the content on both sides; extra space is padded and the content is centered. padding uses clearcolor from qrcodeimagebuilderbase .">
+                <summary>Notes</summary>
+                <p class="doc remarks">Used alone, this sets an exact canvas size. For the square symbologies the module pixel size then becomes imageSize / matrixSize, which may be fractional and can change when the version changes; the rectangular rMQR builder fits the symbol into the canvas with a uniform module scale instead (letterbox, the leftover pad keeps clearColor). Used with QRCodeImageBuilderBase , this sets the canvas size while module pixels define the content size (matrixSize * modulePixelSize). The canvas must be at least as large as the content on both sides; extra space is padded and the content is centered. Padding uses clearColor from QRCodeImageBuilderBase .</p>
+              </details>
+            </div>
+            <div class="member" data-text="public skbitmap tobitmap(); generate the symbol image and return as skbitmap. ">
+              <code>public SKBitmap ToBitmap();</code>
+              <p class="doc">Generate the symbol image and return as SKBitmap.</p>
+            </div>
+            <div class="member" data-text="public skimage toimage(); generate the symbol image and return as skimage. ">
+              <code>public SKImage ToImage();</code>
+              <p class="doc">Generate the symbol image and return as SKImage.</p>
+            </div>
+            <div class="member" data-text="public byte[] tobytearray(); generate the symbol image and return as byte array. ">
+              <code>public byte[] ToByteArray();</code>
+              <p class="doc">Generate the symbol image and return as byte array.</p>
+            </div>
+            <div class="member" data-text="public string tosvgstring(); generate the symbol and return as svg document string. see qrcodeimagebuilderbase for rendering behavior.">
+              <code>public string ToSvgString();</code>
+              <p class="doc">Generate the symbol and return as SVG document string.</p>
+              <details class="notes" data-text="see qrcodeimagebuilderbase for rendering behavior.">
+                <summary>Notes</summary>
+                <p class="doc remarks">See QRCodeImageBuilderBase for rendering behavior.</p>
+              </details>
+            </div>
+            <div class="member" data-text="public void saveto(ibufferwriter&lt;byte&gt; writer); generate the symbol image and write to an ibufferwriter. this is more efficient than saveto(stream) as it avoids intermediate buffering. ">
+              <code>public void SaveTo(IBufferWriter&lt;byte&gt; writer);</code>
+              <p class="doc">Generate the symbol image and write to an IBufferWriter. This is more efficient than SaveTo(Stream) as it avoids intermediate buffering.</p>
+            </div>
+            <div class="member" data-text="public void saveto(stream output); generate the symbol image and save to stream. ">
+              <code>public void SaveTo(Stream output);</code>
+              <p class="doc">Generate the symbol image and save to stream.</p>
+            </div>
+            <div class="member" data-text="public void savetosvg(ibufferwriter&lt;byte&gt; writer); generate the symbol and write as svg document to an ibufferwriter. see qrcodeimagebuilderbase for rendering behavior. data is written in writer-provided segments, so segmented writers (e.g. pipewriter) work without a single contiguous buffer for the whole document.">
+              <code>public void SaveToSvg(IBufferWriter&lt;byte&gt; writer);</code>
+              <p class="doc">Generate the symbol and write as SVG document to an IBufferWriter.</p>
+              <details class="notes" data-text="see qrcodeimagebuilderbase for rendering behavior. data is written in writer-provided segments, so segmented writers (e.g. pipewriter) work without a single contiguous buffer for the whole document.">
+                <summary>Notes</summary>
+                <p class="doc remarks">See QRCodeImageBuilderBase for rendering behavior. Data is written in writer-provided segments, so segmented writers (e.g. PipeWriter) work without a single contiguous buffer for the whole document.</p>
+              </details>
+            </div>
+            <div class="member" data-text="public void savetosvg(stream output); generate the symbol and save as svg document to stream. the symbol is drawn as vector shapes via sksvgcanvas , so the output scales without quality loss. all builder options apply. the root element carries a viewbox, so the document scales its content when embedded at a different size (img element, css). for plain rectangular modules, shape-rendering=&quot;crispedges&quot; is added to avoid antialiasing seams between modules; custom shapes keep antialiasing for smooth curves. qrcodeimagebuilderbase is ignored, svg is a vector format, not an skencodedimageformat . size options ( qrcodeimagebuilderbase , qrcodeimagebuilderbase , or the symbology's default canvas) define the svg viewport in units. the stream is left open after writing.">
+              <code>public void SaveToSvg(Stream output);</code>
+              <p class="doc">Generate the symbol and save as SVG document to stream.</p>
+              <details class="notes" data-text="the symbol is drawn as vector shapes via sksvgcanvas , so the output scales without quality loss. all builder options apply. the root element carries a viewbox, so the document scales its content when embedded at a different size (img element, css). for plain rectangular modules, shape-rendering=&quot;crispedges&quot; is added to avoid antialiasing seams between modules; custom shapes keep antialiasing for smooth curves. qrcodeimagebuilderbase is ignored, svg is a vector format, not an skencodedimageformat . size options ( qrcodeimagebuilderbase , qrcodeimagebuilderbase , or the symbology's default canvas) define the svg viewport in units. the stream is left open after writing.">
+                <summary>Notes</summary>
+                <p class="doc remarks">The symbol is drawn as vector shapes via SKSvgCanvas , so the output scales without quality loss. All builder options apply. The root element carries a viewBox, so the document scales its content when embedded at a different size (img element, CSS). For plain rectangular modules, shape-rendering=&quot;crispEdges&quot; is added to avoid antialiasing seams between modules; custom shapes keep antialiasing for smooth curves. QRCodeImageBuilderBase is ignored, SVG is a vector format, not an SKEncodedImageFormat . Size options ( QRCodeImageBuilderBase , QRCodeImageBuilderBase , or the symbology's default canvas) define the SVG viewport in units. The stream is left open after writing.</p>
+              </details>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.Image.RectangleFinderPatternShape" data-name="skiasharp.qrcode.image.rectanglefinderpatternshape" data-text="skiasharp.qrcode.image.rectanglefinderpatternshape public sealed class rectanglefinderpatternshape : finderpatternshape standard qr code finder pattern (three nested squares, 7x7, 5x5, 3x3).  public static readonly rectanglefinderpatternshape default; gets the default instance.  public bool requiresantialiasing { get; } antialiasing disabled; straight-edged rectangles render cleanly without it.  public override void draw(skcanvas canvas, skrect rect, skpaint paint);  public override void draw(skcanvas canvas, skrect rect, skpaint paint, skcolor backgroundcolor);  public override void draw(skcanvas canvas, skrect rect, skpaint paint, skpaint backgroundpaint); ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.RectangleFinderPatternShape" aria-label="Link to SkiaSharp.QrCode.Image.RectangleFinderPatternShape">#</a><code>public sealed class RectangleFinderPatternShape : FinderPatternShape</code></h3>
+          <p class="doc">Standard QR code finder pattern (three nested squares, 7x7, 5x5, 3x3).</p>
+          <div class="members">
+            <div class="member" data-text="public static readonly rectanglefinderpatternshape default; gets the default instance. ">
+              <code>public static readonly RectangleFinderPatternShape Default;</code>
+              <p class="doc">Gets the default instance.</p>
+            </div>
+            <div class="member" data-text="public bool requiresantialiasing { get; } antialiasing disabled; straight-edged rectangles render cleanly without it. ">
+              <code>public bool RequiresAntialiasing { get; }</code>
+              <p class="doc">Antialiasing disabled; straight-edged rectangles render cleanly without it.</p>
+            </div>
+            <div class="member" data-text="public override void draw(skcanvas canvas, skrect rect, skpaint paint); ">
+              <code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint);</code>
+            </div>
+            <div class="member" data-text="public override void draw(skcanvas canvas, skrect rect, skpaint paint, skcolor backgroundcolor); ">
+              <code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint, SKColor backgroundColor);</code>
+            </div>
+            <div class="member" data-text="public override void draw(skcanvas canvas, skrect rect, skpaint paint, skpaint backgroundpaint); ">
+              <code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint, SKPaint backgroundPaint);</code>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.Image.RectangleModuleShape" data-name="skiasharp.qrcode.image.rectanglemoduleshape" data-text="skiasharp.qrcode.image.rectanglemoduleshape public sealed class rectanglemoduleshape : moduleshape draw modules as rectangles.  public static readonly rectanglemoduleshape default; gets the default instance.  public bool requiresantialiasing { get; } antialiasing disabled to prevent gray borders between modules.  public override void draw(skcanvas canvas, skrect rect, skpaint paint); ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.RectangleModuleShape" aria-label="Link to SkiaSharp.QrCode.Image.RectangleModuleShape">#</a><code>public sealed class RectangleModuleShape : ModuleShape</code></h3>
+          <p class="doc">Draw modules as rectangles.</p>
+          <div class="members">
+            <div class="member" data-text="public static readonly rectanglemoduleshape default; gets the default instance. ">
+              <code>public static readonly RectangleModuleShape Default;</code>
+              <p class="doc">Gets the default instance.</p>
+            </div>
+            <div class="member" data-text="public bool requiresantialiasing { get; } antialiasing disabled to prevent gray borders between modules. ">
+              <code>public bool RequiresAntialiasing { get; }</code>
+              <p class="doc">Antialiasing disabled to prevent gray borders between modules.</p>
+            </div>
+            <div class="member" data-text="public override void draw(skcanvas canvas, skrect rect, skpaint paint); ">
+              <code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint);</code>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.Image.RmQRCodeImageBuilder" data-name="skiasharp.qrcode.image.rmqrcodeimagebuilder" data-text="skiasharp.qrcode.image.rmqrcodeimagebuilder public class rmqrcodeimagebuilder : qrcodeimagebuilderbase&lt;rmqrcodeimagebuilder&gt; high-level builder for creating rmqr code images with fluent configuration and static methods. this builder mirrors qrcodeimagebuilder / microqrcodeimagebuilder for the rmqr symbology (iso/iec 23941, r7x43-r17x139). version, error correction and fit use the rmqr-typed rmqrversion / rmqrecclevel / rmqrfitstrategy / rmqrheight , and the default quiet zone is the 2 modules the specification requires. rmqr symbols are rectangular. with qrcodeimagebuilderbase the image is exactly the matrix at that scale; with qrcodeimagebuilderbase the symbol is fitted into the canvas with a uniform module scale and centered (letterbox, never stretched); with withwidth (the static helpers' size, and the 512-pixel default when nothing is configured) the image is that wide, the height follows the symbol aspect ratio rounded to whole pixels, the background covers the whole image and the symbol is drawn at a uniform module scale inside it (the height rounding can leave a few pixels of background at the sides on the widest versions; there is no clear-colour pad, so an opaque background gives an opaque image). rmqr has a single finder pattern and no error-correction headroom for overlays, so the standard qr styling options that depend on those (icon overlays and custom finder pattern shapes) are intentionally not offered. public rmqrcodeimagebuilder(rmqrcodedata rmqrcodedata); starts a builder that draws an rmqr code you have already generated. the symbol is used exactly as given, so only the appearance options apply. every encoding option throws invalidoperationexception on a builder created this way.  public rmqrcodeimagebuilder(string content); starts a builder that will encode content when you ask for an image. error correction, version and fit keep their defaults until you set them.  public rmqrcodeimagebuilder withecimode(ecimode ecimode); configure the eci character encoding declaration.  public rmqrcodeimagebuilder witherrorcorrection(rmqrecclevel ecclevel); configure the error correction level (m or h).  public rmqrcodeimagebuilder withfitstrategy(rmqrfitstrategy fitstrategy); configure how the version is chosen among those that hold the content (default minimizearea , fewest modules; note it may prefer a taller, narrower symbol, use minimizeheight or withheight for the flattest fit).  public rmqrcodeimagebuilder withheight(rmqrheight height); restrict automatic version selection to one symbol height (fixed height, automatic width). must agree with withversion when both are used.  public rmqrcodeimagebuilder withsegmentation(rmqrsegmentation segmentation); split the content into mixed-mode segments when that lowers the module count (see rmqrsegmentation ). defaults to single . fewer modules is not the same as a smaller image: a flatter, wider symbol can render onto a larger grid.  public rmqrcodeimagebuilder withversion(rmqrversion version); configure the exact rmqr version to generate.  public rmqrcodeimagebuilder withwidth(int width); configure the image width in pixels; the height follows the symbol aspect ratio (rounded to whole pixels), the background covers the whole image and the symbol is drawn at a uniform module scale inside it. this is the static helpers' sizing rule and the default (512) when no size is configured. qrcodeimagebuilderbase (letterbox into an exact canvas) or qrcodeimagebuilderbase (exact matrix) take precedence when also called.  public static byte[] getimagebytes(rmqrcodedata rmqrcodedata, skencodedimageformat format, int size = 512, int quality = 100); generate an rmqr code as image byte array with specified format.  public static byte[] getimagebytes(string content, skencodedimageformat format, rmqrecclevel ecclevel = 0, int size = 512, int quality = 100); generate an rmqr code as image byte array with specified format.  public static byte[] getpngbytes(rmqrcodedata rmqrcodedata, int size = 512); generate an rmqr code as png byte array with default settings.  public static byte[] getpngbytes(string content, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code as png byte array with default settings.  public static byte[] getsvgbytes(rmqrcodedata rmqrcodedata, int size = 512); generate an rmqr code as svg byte array.  public static byte[] getsvgbytes(string content, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code as svg byte array.  public static string getsvgstring(rmqrcodedata rmqrcodedata, int size = 512); generate an rmqr code as svg string.  public static string getsvgstring(string content, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code as svg string.  public static void savepng(rmqrcodedata rmqrcodedata, stream output, int size = 512); generate an rmqr code and save as png to stream.  public static void savepng(string content, stream output, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code and save as png to stream.  public static void savesvg(rmqrcodedata rmqrcodedata, stream output, int size = 512); generate an rmqr code and save as svg to stream.  public static void savesvg(string content, stream output, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code and save as svg to stream.  public static void writeimage(rmqrcodedata rmqrcodedata, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, int size = 512, int quality = 100); generate an rmqr code and write encoded image bytes to a buffer writer.  public static void writeimage(string content, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, rmqrecclevel ecclevel = 0, int size = 512, int quality = 100); generate an rmqr code and write encoded image bytes to a buffer writer.  public static void writepng(rmqrcodedata rmqrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate an rmqr code and write png bytes to a buffer writer.  public static void writepng(string content, ibufferwriter&lt;byte&gt; writer, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code and write png bytes to a buffer writer.  public static void writesvg(rmqrcodedata rmqrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate an rmqr code and write the svg document to a buffer writer.  public static void writesvg(string content, ibufferwriter&lt;byte&gt; writer, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code and write the svg document to a buffer writer. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.RmQRCodeImageBuilder" aria-label="Link to SkiaSharp.QrCode.Image.RmQRCodeImageBuilder">#</a><code>public class RmQRCodeImageBuilder : QRCodeImageBuilderBase&lt;RmQRCodeImageBuilder&gt;</code></h3>
+          <p class="doc">High-level builder for creating rMQR code images with fluent configuration and static methods.</p>
+          <details class="notes" data-text="this builder mirrors qrcodeimagebuilder / microqrcodeimagebuilder for the rmqr symbology (iso/iec 23941, r7x43-r17x139). version, error correction and fit use the rmqr-typed rmqrversion / rmqrecclevel / rmqrfitstrategy / rmqrheight , and the default quiet zone is the 2 modules the specification requires. rmqr symbols are rectangular. with qrcodeimagebuilderbase the image is exactly the matrix at that scale; with qrcodeimagebuilderbase the symbol is fitted into the canvas with a uniform module scale and centered (letterbox, never stretched); with withwidth (the static helpers' size, and the 512-pixel default when nothing is configured) the image is that wide, the height follows the symbol aspect ratio rounded to whole pixels, the background covers the whole image and the symbol is drawn at a uniform module scale inside it (the height rounding can leave a few pixels of background at the sides on the widest versions; there is no clear-colour pad, so an opaque background gives an opaque image). rmqr has a single finder pattern and no error-correction headroom for overlays, so the standard qr styling options that depend on those (icon overlays and custom finder pattern shapes) are intentionally not offered.">
+            <summary>Notes</summary>
+            <p class="doc remarks">This builder mirrors QRCodeImageBuilder / MicroQRCodeImageBuilder for the rMQR symbology (ISO/IEC 23941, R7x43-R17x139). Version, error correction and fit use the rMQR-typed RmQRVersion / RmQREccLevel / RmQRFitStrategy / RmQRHeight , and the default quiet zone is the 2 modules the specification requires. rMQR symbols are rectangular. With QRCodeImageBuilderBase the image is exactly the matrix at that scale; with QRCodeImageBuilderBase the symbol is fitted into the canvas with a uniform module scale and centered (letterbox, never stretched); with WithWidth (the static helpers' size, and the 512-pixel default when nothing is configured) the image is that wide, the height follows the symbol aspect ratio rounded to whole pixels, the background covers the whole image and the symbol is drawn at a uniform module scale inside it (the height rounding can leave a few pixels of background at the sides on the widest versions; there is no clear-colour pad, so an opaque background gives an opaque image). rMQR has a single finder pattern and no error-correction headroom for overlays, so the Standard QR styling options that depend on those (icon overlays and custom finder pattern shapes) are intentionally not offered.</p>
+          </details>
+          <div class="members">
+            <div class="member" data-text="public rmqrcodeimagebuilder(rmqrcodedata rmqrcodedata); starts a builder that draws an rmqr code you have already generated. the symbol is used exactly as given, so only the appearance options apply. every encoding option throws invalidoperationexception on a builder created this way. ">
+              <code>public RmQRCodeImageBuilder(RmQRCodeData rmQrCodeData);</code>
+              <p class="doc">Starts a builder that draws an rMQR code you have already generated. The symbol is used exactly as given, so only the appearance options apply. Every encoding option throws InvalidOperationException on a builder created this way.</p>
+            </div>
+            <div class="member" data-text="public rmqrcodeimagebuilder(string content); starts a builder that will encode content when you ask for an image. error correction, version and fit keep their defaults until you set them. ">
+              <code>public RmQRCodeImageBuilder(string content);</code>
+              <p class="doc">Starts a builder that will encode content when you ask for an image. Error correction, version and fit keep their defaults until you set them.</p>
+            </div>
+            <div class="member" data-text="public rmqrcodeimagebuilder withecimode(ecimode ecimode); configure the eci character encoding declaration. ">
+              <code>public RmQRCodeImageBuilder WithEciMode(EciMode eciMode);</code>
+              <p class="doc">Configure the ECI character encoding declaration.</p>
+            </div>
+            <div class="member" data-text="public rmqrcodeimagebuilder witherrorcorrection(rmqrecclevel ecclevel); configure the error correction level (m or h). ">
+              <code>public RmQRCodeImageBuilder WithErrorCorrection(RmQREccLevel eccLevel);</code>
+              <p class="doc">Configure the error correction level (M or H).</p>
+            </div>
+            <div class="member" data-text="public rmqrcodeimagebuilder withfitstrategy(rmqrfitstrategy fitstrategy); configure how the version is chosen among those that hold the content (default minimizearea , fewest modules; note it may prefer a taller, narrower symbol, use minimizeheight or withheight for the flattest fit). ">
+              <code>public RmQRCodeImageBuilder WithFitStrategy(RmQRFitStrategy fitStrategy);</code>
+              <p class="doc">Configure how the version is chosen among those that hold the content (default MinimizeArea , fewest modules; note it may prefer a taller, narrower symbol, use MinimizeHeight or WithHeight for the flattest fit).</p>
+            </div>
+            <div class="member" data-text="public rmqrcodeimagebuilder withheight(rmqrheight height); restrict automatic version selection to one symbol height (fixed height, automatic width). must agree with withversion when both are used. ">
+              <code>public RmQRCodeImageBuilder WithHeight(RmQRHeight height);</code>
+              <p class="doc">Restrict automatic version selection to one symbol height (fixed height, automatic width). Must agree with WithVersion when both are used.</p>
+            </div>
+            <div class="member" data-text="public rmqrcodeimagebuilder withsegmentation(rmqrsegmentation segmentation); split the content into mixed-mode segments when that lowers the module count (see rmqrsegmentation ). defaults to single . fewer modules is not the same as a smaller image: a flatter, wider symbol can render onto a larger grid. ">
+              <code>public RmQRCodeImageBuilder WithSegmentation(RmQRSegmentation segmentation);</code>
+              <p class="doc">Split the content into mixed-mode segments when that lowers the module count (see RmQRSegmentation ). Defaults to Single . Fewer modules is not the same as a smaller image: a flatter, wider symbol can render onto a larger grid.</p>
+            </div>
+            <div class="member" data-text="public rmqrcodeimagebuilder withversion(rmqrversion version); configure the exact rmqr version to generate. ">
+              <code>public RmQRCodeImageBuilder WithVersion(RmQRVersion version);</code>
+              <p class="doc">Configure the exact rMQR version to generate.</p>
+            </div>
+            <div class="member" data-text="public rmqrcodeimagebuilder withwidth(int width); configure the image width in pixels; the height follows the symbol aspect ratio (rounded to whole pixels), the background covers the whole image and the symbol is drawn at a uniform module scale inside it. this is the static helpers' sizing rule and the default (512) when no size is configured. qrcodeimagebuilderbase (letterbox into an exact canvas) or qrcodeimagebuilderbase (exact matrix) take precedence when also called. ">
+              <code>public RmQRCodeImageBuilder WithWidth(int width);</code>
+              <p class="doc">Configure the image width in pixels; the height follows the symbol aspect ratio (rounded to whole pixels), the background covers the whole image and the symbol is drawn at a uniform module scale inside it. This is the static helpers' sizing rule and the default (512) when no size is configured. QRCodeImageBuilderBase (letterbox into an exact canvas) or QRCodeImageBuilderBase (exact matrix) take precedence when also called.</p>
+            </div>
+            <div class="member" data-text="public static byte[] getimagebytes(rmqrcodedata rmqrcodedata, skencodedimageformat format, int size = 512, int quality = 100); generate an rmqr code as image byte array with specified format. ">
+              <code>public static byte[] GetImageBytes(RmQRCodeData rmQrCodeData, SKEncodedImageFormat format, int size = 512, int quality = 100);</code>
+              <p class="doc">Generate an rMQR code as image byte array with specified format.</p>
+            </div>
+            <div class="member" data-text="public static byte[] getimagebytes(string content, skencodedimageformat format, rmqrecclevel ecclevel = 0, int size = 512, int quality = 100); generate an rmqr code as image byte array with specified format. ">
+              <code>public static byte[] GetImageBytes(string content, SKEncodedImageFormat format, RmQREccLevel eccLevel = 0, int size = 512, int quality = 100);</code>
+              <p class="doc">Generate an rMQR code as image byte array with specified format.</p>
+            </div>
+            <div class="member" data-text="public static byte[] getpngbytes(rmqrcodedata rmqrcodedata, int size = 512); generate an rmqr code as png byte array with default settings. ">
+              <code>public static byte[] GetPngBytes(RmQRCodeData rmQrCodeData, int size = 512);</code>
+              <p class="doc">Generate an rMQR code as PNG byte array with default settings.</p>
+            </div>
+            <div class="member" data-text="public static byte[] getpngbytes(string content, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code as png byte array with default settings. ">
+              <code>public static byte[] GetPngBytes(string content, RmQREccLevel eccLevel = 0, int size = 512);</code>
+              <p class="doc">Generate an rMQR code as PNG byte array with default settings.</p>
+            </div>
+            <div class="member" data-text="public static byte[] getsvgbytes(rmqrcodedata rmqrcodedata, int size = 512); generate an rmqr code as svg byte array. ">
+              <code>public static byte[] GetSvgBytes(RmQRCodeData rmQrCodeData, int size = 512);</code>
+              <p class="doc">Generate an rMQR code as SVG byte array.</p>
+            </div>
+            <div class="member" data-text="public static byte[] getsvgbytes(string content, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code as svg byte array. ">
+              <code>public static byte[] GetSvgBytes(string content, RmQREccLevel eccLevel = 0, int size = 512);</code>
+              <p class="doc">Generate an rMQR code as SVG byte array.</p>
+            </div>
+            <div class="member" data-text="public static string getsvgstring(rmqrcodedata rmqrcodedata, int size = 512); generate an rmqr code as svg string. ">
+              <code>public static string GetSvgString(RmQRCodeData rmQrCodeData, int size = 512);</code>
+              <p class="doc">Generate an rMQR code as SVG string.</p>
+            </div>
+            <div class="member" data-text="public static string getsvgstring(string content, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code as svg string. ">
+              <code>public static string GetSvgString(string content, RmQREccLevel eccLevel = 0, int size = 512);</code>
+              <p class="doc">Generate an rMQR code as SVG string.</p>
+            </div>
+            <div class="member" data-text="public static void savepng(rmqrcodedata rmqrcodedata, stream output, int size = 512); generate an rmqr code and save as png to stream. ">
+              <code>public static void SavePng(RmQRCodeData rmQrCodeData, Stream output, int size = 512);</code>
+              <p class="doc">Generate an rMQR code and save as PNG to stream.</p>
+            </div>
+            <div class="member" data-text="public static void savepng(string content, stream output, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code and save as png to stream. ">
+              <code>public static void SavePng(string content, Stream output, RmQREccLevel eccLevel = 0, int size = 512);</code>
+              <p class="doc">Generate an rMQR code and save as PNG to stream.</p>
+            </div>
+            <div class="member" data-text="public static void savesvg(rmqrcodedata rmqrcodedata, stream output, int size = 512); generate an rmqr code and save as svg to stream. ">
+              <code>public static void SaveSvg(RmQRCodeData rmQrCodeData, Stream output, int size = 512);</code>
+              <p class="doc">Generate an rMQR code and save as SVG to stream.</p>
+            </div>
+            <div class="member" data-text="public static void savesvg(string content, stream output, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code and save as svg to stream. ">
+              <code>public static void SaveSvg(string content, Stream output, RmQREccLevel eccLevel = 0, int size = 512);</code>
+              <p class="doc">Generate an rMQR code and save as SVG to stream.</p>
+            </div>
+            <div class="member" data-text="public static void writeimage(rmqrcodedata rmqrcodedata, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, int size = 512, int quality = 100); generate an rmqr code and write encoded image bytes to a buffer writer. ">
+              <code>public static void WriteImage(RmQRCodeData rmQrCodeData, IBufferWriter&lt;byte&gt; writer, SKEncodedImageFormat format, int size = 512, int quality = 100);</code>
+              <p class="doc">Generate an rMQR code and write encoded image bytes to a buffer writer.</p>
+            </div>
+            <div class="member" data-text="public static void writeimage(string content, ibufferwriter&lt;byte&gt; writer, skencodedimageformat format, rmqrecclevel ecclevel = 0, int size = 512, int quality = 100); generate an rmqr code and write encoded image bytes to a buffer writer. ">
+              <code>public static void WriteImage(string content, IBufferWriter&lt;byte&gt; writer, SKEncodedImageFormat format, RmQREccLevel eccLevel = 0, int size = 512, int quality = 100);</code>
+              <p class="doc">Generate an rMQR code and write encoded image bytes to a buffer writer.</p>
+            </div>
+            <div class="member" data-text="public static void writepng(rmqrcodedata rmqrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate an rmqr code and write png bytes to a buffer writer. ">
+              <code>public static void WritePng(RmQRCodeData rmQrCodeData, IBufferWriter&lt;byte&gt; writer, int size = 512);</code>
+              <p class="doc">Generate an rMQR code and write PNG bytes to a buffer writer.</p>
+            </div>
+            <div class="member" data-text="public static void writepng(string content, ibufferwriter&lt;byte&gt; writer, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code and write png bytes to a buffer writer. ">
+              <code>public static void WritePng(string content, IBufferWriter&lt;byte&gt; writer, RmQREccLevel eccLevel = 0, int size = 512);</code>
+              <p class="doc">Generate an rMQR code and write PNG bytes to a buffer writer.</p>
+            </div>
+            <div class="member" data-text="public static void writesvg(rmqrcodedata rmqrcodedata, ibufferwriter&lt;byte&gt; writer, int size = 512); generate an rmqr code and write the svg document to a buffer writer. ">
+              <code>public static void WriteSvg(RmQRCodeData rmQrCodeData, IBufferWriter&lt;byte&gt; writer, int size = 512);</code>
+              <p class="doc">Generate an rMQR code and write the SVG document to a buffer writer.</p>
+            </div>
+            <div class="member" data-text="public static void writesvg(string content, ibufferwriter&lt;byte&gt; writer, rmqrecclevel ecclevel = 0, int size = 512); generate an rmqr code and write the svg document to a buffer writer. ">
+              <code>public static void WriteSvg(string content, IBufferWriter&lt;byte&gt; writer, RmQREccLevel eccLevel = 0, int size = 512);</code>
+              <p class="doc">Generate an rMQR code and write the SVG document to a buffer writer.</p>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.Image.RoundedRectangleCircleFinderPatternShape" data-name="skiasharp.qrcode.image.roundedrectanglecirclefinderpatternshape" data-text="skiasharp.qrcode.image.roundedrectanglecirclefinderpatternshape public sealed class roundedrectanglecirclefinderpatternshape : finderpatternshape rounded rectangle outer with circular center finder pattern. three nested shapes: outer rounded rectangle (7×7), middle rounded rectangle (5×5), inner circle (3×3).  public static readonly roundedrectanglecirclefinderpatternshape default; gets the default instance.  public roundedrectanglecirclefinderpatternshape(float cornerradiuspercent = 0.3); initializes a new instance with the specified corner radius.  public bool requiresantialiasing { get; } requires antialiasing to prevent jagged edges on curves.  public override void draw(skcanvas canvas, skrect rect, skpaint paint);  public override void draw(skcanvas canvas, skrect rect, skpaint paint, skcolor backgroundcolor);  public override void draw(skcanvas canvas, skrect rect, skpaint paint, skpaint backgroundpaint); ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.RoundedRectangleCircleFinderPatternShape" aria-label="Link to SkiaSharp.QrCode.Image.RoundedRectangleCircleFinderPatternShape">#</a><code>public sealed class RoundedRectangleCircleFinderPatternShape : FinderPatternShape</code></h3>
+          <p class="doc">Rounded rectangle outer with circular center finder pattern. Three nested shapes: outer rounded rectangle (7×7), middle rounded rectangle (5×5), inner circle (3×3).</p>
+          <div class="members">
+            <div class="member" data-text="public static readonly roundedrectanglecirclefinderpatternshape default; gets the default instance. ">
+              <code>public static readonly RoundedRectangleCircleFinderPatternShape Default;</code>
+              <p class="doc">Gets the default instance.</p>
+            </div>
+            <div class="member" data-text="public roundedrectanglecirclefinderpatternshape(float cornerradiuspercent = 0.3); initializes a new instance with the specified corner radius. ">
+              <code>public RoundedRectangleCircleFinderPatternShape(float cornerRadiusPercent = 0.3);</code>
+              <p class="doc">Initializes a new instance with the specified corner radius.</p>
+            </div>
+            <div class="member" data-text="public bool requiresantialiasing { get; } requires antialiasing to prevent jagged edges on curves. ">
+              <code>public bool RequiresAntialiasing { get; }</code>
+              <p class="doc">Requires antialiasing to prevent jagged edges on curves.</p>
+            </div>
+            <div class="member" data-text="public override void draw(skcanvas canvas, skrect rect, skpaint paint); ">
+              <code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint);</code>
+            </div>
+            <div class="member" data-text="public override void draw(skcanvas canvas, skrect rect, skpaint paint, skcolor backgroundcolor); ">
+              <code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint, SKColor backgroundColor);</code>
+            </div>
+            <div class="member" data-text="public override void draw(skcanvas canvas, skrect rect, skpaint paint, skpaint backgroundpaint); ">
+              <code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint, SKPaint backgroundPaint);</code>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.Image.RoundedRectangleFinderPatternShape" data-name="skiasharp.qrcode.image.roundedrectanglefinderpatternshape" data-text="skiasharp.qrcode.image.roundedrectanglefinderpatternshape public sealed class roundedrectanglefinderpatternshape : finderpatternshape rounded rectangle outer with circular center finder pattern. three nested shapes: outer rounded rectangle (7×7), middle rounded rectangle (5×5), inner rounded rectangle (3×3).  public static readonly roundedrectanglefinderpatternshape default; gets the default instance.  public roundedrectanglefinderpatternshape(float cornerradiuspercent = 0.2); initializes a new instance with the specified corner radius.  public bool requiresantialiasing { get; } requires antialiasing to prevent jagged edges on curves.  public override void draw(skcanvas canvas, skrect rect, skpaint paint);  public override void draw(skcanvas canvas, skrect rect, skpaint paint, skcolor backgroundcolor);  public override void draw(skcanvas canvas, skrect rect, skpaint paint, skpaint backgroundpaint); ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.RoundedRectangleFinderPatternShape" aria-label="Link to SkiaSharp.QrCode.Image.RoundedRectangleFinderPatternShape">#</a><code>public sealed class RoundedRectangleFinderPatternShape : FinderPatternShape</code></h3>
+          <p class="doc">Rounded rectangle outer with circular center finder pattern. Three nested shapes: outer rounded rectangle (7×7), middle rounded rectangle (5×5), inner rounded rectangle (3×3).</p>
+          <div class="members">
+            <div class="member" data-text="public static readonly roundedrectanglefinderpatternshape default; gets the default instance. ">
+              <code>public static readonly RoundedRectangleFinderPatternShape Default;</code>
+              <p class="doc">Gets the default instance.</p>
+            </div>
+            <div class="member" data-text="public roundedrectanglefinderpatternshape(float cornerradiuspercent = 0.2); initializes a new instance with the specified corner radius. ">
+              <code>public RoundedRectangleFinderPatternShape(float cornerRadiusPercent = 0.2);</code>
+              <p class="doc">Initializes a new instance with the specified corner radius.</p>
+            </div>
+            <div class="member" data-text="public bool requiresantialiasing { get; } requires antialiasing to prevent jagged edges on curves. ">
+              <code>public bool RequiresAntialiasing { get; }</code>
+              <p class="doc">Requires antialiasing to prevent jagged edges on curves.</p>
+            </div>
+            <div class="member" data-text="public override void draw(skcanvas canvas, skrect rect, skpaint paint); ">
+              <code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint);</code>
+            </div>
+            <div class="member" data-text="public override void draw(skcanvas canvas, skrect rect, skpaint paint, skcolor backgroundcolor); ">
+              <code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint, SKColor backgroundColor);</code>
+            </div>
+            <div class="member" data-text="public override void draw(skcanvas canvas, skrect rect, skpaint paint, skpaint backgroundpaint); ">
+              <code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint, SKPaint backgroundPaint);</code>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.Image.RoundedRectangleModuleShape" data-name="skiasharp.qrcode.image.roundedrectanglemoduleshape" data-text="skiasharp.qrcode.image.roundedrectanglemoduleshape public sealed class roundedrectanglemoduleshape : moduleshape draws modules as rounded rectangles.  public static readonly roundedrectanglemoduleshape default; gets the default instance.  public roundedrectanglemoduleshape(float cornerradiuspercent = 0.3); initializes a new instance with the specified corner radius.  public bool requiresantialiasing { get; } requires antialiasing to prevent jagged edges on curves.  public override void draw(skcanvas canvas, skrect rect, skpaint paint); ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.RoundedRectangleModuleShape" aria-label="Link to SkiaSharp.QrCode.Image.RoundedRectangleModuleShape">#</a><code>public sealed class RoundedRectangleModuleShape : ModuleShape</code></h3>
+          <p class="doc">Draws modules as rounded rectangles.</p>
+          <div class="members">
+            <div class="member" data-text="public static readonly roundedrectanglemoduleshape default; gets the default instance. ">
+              <code>public static readonly RoundedRectangleModuleShape Default;</code>
+              <p class="doc">Gets the default instance.</p>
+            </div>
+            <div class="member" data-text="public roundedrectanglemoduleshape(float cornerradiuspercent = 0.3); initializes a new instance with the specified corner radius. ">
+              <code>public RoundedRectangleModuleShape(float cornerRadiusPercent = 0.3);</code>
+              <p class="doc">Initializes a new instance with the specified corner radius.</p>
+            </div>
+            <div class="member" data-text="public bool requiresantialiasing { get; } requires antialiasing to prevent jagged edges on curves. ">
+              <code>public bool RequiresAntialiasing { get; }</code>
+              <p class="doc">Requires antialiasing to prevent jagged edges on curves.</p>
+            </div>
+            <div class="member" data-text="public override void draw(skcanvas canvas, skrect rect, skpaint paint); ">
+              <code>public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint);</code>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.Image.TextVerticalAlignment" data-name="skiasharp.qrcode.image.textverticalalignment" data-text="skiasharp.qrcode.image.textverticalalignment public enum textverticalalignment : int specifies the vertical alignment of text relative to the icon.  bottom = 0, text is positioned below the icon (default).  center = 1, text is centered vertically with the icon.  top = 2, text is positioned above the icon. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.TextVerticalAlignment" aria-label="Link to SkiaSharp.QrCode.Image.TextVerticalAlignment">#</a><code>public enum TextVerticalAlignment : int</code></h3>
+          <p class="doc">Specifies the vertical alignment of text relative to the icon.</p>
+          <div class="members">
+            <div class="member" data-text="bottom = 0, text is positioned below the icon (default). ">
+              <code>Bottom = 0,</code>
+              <p class="doc">Text is positioned below the icon (default).</p>
+            </div>
+            <div class="member" data-text="center = 1, text is centered vertically with the icon. ">
+              <code>Center = 1,</code>
+              <p class="doc">Text is centered vertically with the icon.</p>
+            </div>
+            <div class="member" data-text="top = 2, text is positioned above the icon. ">
+              <code>Top = 2,</code>
+              <p class="doc">Text is positioned above the icon.</p>
+            </div>
+          </div>
+        </article>
+        <article class="type" id="SkiaSharp.QrCode.Image.Vector2Slim" data-name="skiasharp.qrcode.image.vector2slim" data-text="skiasharp.qrcode.image.vector2slim public readonly struct vector2slim : iequatable&lt;vector2slim&gt; int version of vector2, slim implementation ref: https://github.com/dotnet/corefx/blob/v3.1.32/src/system.numerics.vectors/src/system/numerics/vector2_intrinsics.cs public static readonly vector2slim one; returns the vector (1,1).  public static readonly vector2slim unitx; returns the vector (1,0).  public static readonly vector2slim unity; returns the vector (0,1).  public static readonly vector2slim zero; returns the vector (0,0).  public vector2slim(int value); creates a vector with both components set to the same value.  public vector2slim(int x, int y); creates a vector from its two components.  public int x { get; } the x component of the vector.  public int y { get; } the y component of the vector.  public void copyto(span&lt;int&gt; span); copies the vector elements to the specified span.  public void copyto(span&lt;int&gt; span, int index); copies the vector elements to the specified span starting at the specified index.  public void copyto(int[] array); copies the vector elements to the specified array.  public void copyto(int[] array, int index); copies the vector elements to the specified array starting at the specified index. ">
+          <h3><a class="anchor" href="#SkiaSharp.QrCode.Image.Vector2Slim" aria-label="Link to SkiaSharp.QrCode.Image.Vector2Slim">#</a><code>public readonly struct Vector2Slim : IEquatable&lt;Vector2Slim&gt;</code></h3>
+          <p class="doc">int version of Vector2, slim implementation</p>
+          <details class="notes" data-text="ref: https://github.com/dotnet/corefx/blob/v3.1.32/src/system.numerics.vectors/src/system/numerics/vector2_intrinsics.cs">
+            <summary>Notes</summary>
+            <p class="doc remarks">ref: https://github.com/dotnet/corefx/blob/v3.1.32/src/System.Numerics.Vectors/src/System/Numerics/Vector2_Intrinsics.cs</p>
+          </details>
+          <div class="members">
+            <div class="member" data-text="public static readonly vector2slim one; returns the vector (1,1). ">
+              <code>public static readonly Vector2Slim One;</code>
+              <p class="doc">Returns the vector (1,1).</p>
+            </div>
+            <div class="member" data-text="public static readonly vector2slim unitx; returns the vector (1,0). ">
+              <code>public static readonly Vector2Slim UnitX;</code>
+              <p class="doc">Returns the vector (1,0).</p>
+            </div>
+            <div class="member" data-text="public static readonly vector2slim unity; returns the vector (0,1). ">
+              <code>public static readonly Vector2Slim UnitY;</code>
+              <p class="doc">Returns the vector (0,1).</p>
+            </div>
+            <div class="member" data-text="public static readonly vector2slim zero; returns the vector (0,0). ">
+              <code>public static readonly Vector2Slim Zero;</code>
+              <p class="doc">Returns the vector (0,0).</p>
+            </div>
+            <div class="member" data-text="public vector2slim(int value); creates a vector with both components set to the same value. ">
+              <code>public Vector2Slim(int value);</code>
+              <p class="doc">Creates a vector with both components set to the same value.</p>
+            </div>
+            <div class="member" data-text="public vector2slim(int x, int y); creates a vector from its two components. ">
+              <code>public Vector2Slim(int x, int y);</code>
+              <p class="doc">Creates a vector from its two components.</p>
+            </div>
+            <div class="member" data-text="public int x { get; } the x component of the vector. ">
+              <code>public int X { get; }</code>
+              <p class="doc">The X component of the vector.</p>
+            </div>
+            <div class="member" data-text="public int y { get; } the y component of the vector. ">
+              <code>public int Y { get; }</code>
+              <p class="doc">The Y component of the vector.</p>
+            </div>
+            <div class="member" data-text="public void copyto(span&lt;int&gt; span); copies the vector elements to the specified span. ">
+              <code>public void CopyTo(Span&lt;int&gt; span);</code>
+              <p class="doc">Copies the vector elements to the specified span.</p>
+            </div>
+            <div class="member" data-text="public void copyto(span&lt;int&gt; span, int index); copies the vector elements to the specified span starting at the specified index. ">
+              <code>public void CopyTo(Span&lt;int&gt; span, int index);</code>
+              <p class="doc">Copies the vector elements to the specified span starting at the specified index.</p>
+            </div>
+            <div class="member" data-text="public void copyto(int[] array); copies the vector elements to the specified array. ">
+              <code>public void CopyTo(int[] array);</code>
+              <p class="doc">Copies the vector elements to the specified array.</p>
+            </div>
+            <div class="member" data-text="public void copyto(int[] array, int index); copies the vector elements to the specified array starting at the specified index. ">
+              <code>public void CopyTo(int[] array, int index);</code>
+              <p class="doc">Copies the vector elements to the specified array starting at the specified index.</p>
+            </div>
+          </div>
+        </article>
+      </section>
+      <p class="empty" id="empty" hidden>Nothing matches that.</p>
+    </main>
+  </div>
+
+  <script>
+    (function () {
+      var box = document.getElementById('q');
+      var count = document.getElementById('count');
+      var empty = document.getElementById('empty');
+      var types = Array.prototype.slice.call(document.querySelectorAll('.type'));
+      var sections = Array.prototype.slice.call(document.querySelectorAll('.ns'));
+      var tocItems = Array.prototype.slice.call(document.querySelectorAll('.toc-item'));
+      var tocGroups = Array.prototype.slice.call(document.querySelectorAll('.toc-ns'));
+      var notes = Array.prototype.slice.call(document.querySelectorAll('.notes'));
+      var tocByType = {};
+      tocItems.forEach(function (item) { tocByType[item.dataset.for] = item; });
+
+      function apply() {
+        var term = box.value.trim().toLowerCase();
+        var shown = 0;
+
+        types.forEach(function (type) {
+          var nameHit = !term || type.dataset.name.indexOf(term) !== -1;
+          var hit = !term || nameHit || type.dataset.text.indexOf(term) !== -1;
+          type.hidden = !hit;
+          if (hit) shown++;
+
+          var entry = tocByType[type.id];
+          if (entry) entry.hidden = !hit;
+
+          // A type matched by name keeps all of its members; matched inside one member,
+          // only that member.
+          Array.prototype.forEach.call(type.querySelectorAll('.member'), function (member) {
+            member.hidden = !!term && !nameHit && member.dataset.text.indexOf(term) === -1;
+          });
+        });
+
+        sections.forEach(function (section) {
+          section.hidden = !section.querySelector('.type:not([hidden])');
+        });
+
+        // Open a folded Notes block only when the term is in there, so a search never
+        // leaves the reader wondering where the match was. Clearing the box folds them
+        // back rather than leaving the page expanded.
+        notes.forEach(function (note) {
+          note.open = !!term && note.dataset.text.indexOf(term) !== -1;
+        });
+
+        // A namespace heading in the outline belongs to the links that follow it.
+        tocGroups.forEach(function (group) {
+          var visible = false;
+          for (var n = group.nextElementSibling; n && n.classList.contains('toc-item'); n = n.nextElementSibling) {
+            if (!n.hidden) { visible = true; break; }
+          }
+          group.hidden = !visible;
+        });
+
+        empty.hidden = shown !== 0;
+        count.textContent = term ? shown + ' of ' + types.length + ' types' : types.length + ' types';
+      }
+
+      box.addEventListener('input', apply);
+      box.addEventListener('keydown', function (e) {
+        if (e.key === 'Escape') { box.value = ''; apply(); }
+      });
+      document.addEventListener('keydown', function (e) {
+        if (e.key === '/' && document.activeElement !== box) { e.preventDefault(); box.focus(); }
+      });
+
+      // Highlight the outline entry for whatever is being read. Bottom margin keeps the
+      // choice on the upper part of the viewport rather than flipping at the fold.
+      if ('IntersectionObserver' in window) {
+        var current = null;
+        var observer = new IntersectionObserver(function (entries) {
+          entries.forEach(function (entry) {
+            if (!entry.isIntersecting) return;
+            var entryLink = tocByType[entry.target.id];
+            if (!entryLink || entryLink === current) return;
+            if (current) current.classList.remove('current');
+            entryLink.classList.add('current');
+            current = entryLink;
+          });
+        }, { rootMargin: '0px 0px -75% 0px' });
+        types.forEach(function (type) { observer.observe(type); });
+      }
+
+      apply();
+    })();
+  </script>
+</body>
+
+</html>

--- a/src/SkiaSharp.QrCode.Playground/wwwroot/index.html
+++ b/src/SkiaSharp.QrCode.Playground/wwwroot/index.html
@@ -57,7 +57,10 @@
         <a id="playground-version" class="version-badge" hidden target="_blank" rel="noopener noreferrer"
           href="https://github.com/guitarrapc/SkiaSharp.QrCode/releases"
           aria-label="Playground build version, GitHub releases"></a>
-        <a class="version-badge" href="api/" aria-label="Public API listing">API</a>
+        <!-- Spelled out rather than "api/": the dev server has no default document for a
+             subdirectory and falls back to this page, so "api/" silently re-serves the
+             Playground. GitHub Pages resolves either form. -->
+        <a class="version-badge" href="api/index.html" aria-label="Public API listing">API</a>
       </div>
       <p class="tagline">QR codes with gradients, shapes and logos, rendered by Skia in your browser</p>
     </header>

--- a/src/SkiaSharp.QrCode.Playground/wwwroot/index.html
+++ b/src/SkiaSharp.QrCode.Playground/wwwroot/index.html
@@ -57,6 +57,7 @@
         <a id="playground-version" class="version-badge" hidden target="_blank" rel="noopener noreferrer"
           href="https://github.com/guitarrapc/SkiaSharp.QrCode/releases"
           aria-label="Playground build version, GitHub releases"></a>
+        <a class="version-badge" href="api/" aria-label="Public API listing">API</a>
       </div>
       <p class="tagline">QR codes with gradients, shapes and logos, rendered by Skia in your browser</p>
     </header>

--- a/tools/public_api.cs
+++ b/tools/public_api.cs
@@ -71,9 +71,9 @@ else
 }
 return 0;
 
-(int Rank, string Text, string DocId)[] MemberEntries(Type type) => type.IsEnum
+(int Rank, string Kind, string Name, string Text, string DocId)[] MemberEntries(Type type) => type.IsEnum
     ? [.. type.GetFields(BindingFlags.Public | BindingFlags.Static)
-        .Select(f => (0, $"{f.Name} = {Convert.ToInt64(f.GetRawConstantValue())},", DocIdOfField(f)))]
+        .Select(f => (0, "value", f.Name, $"{f.Name} = {Convert.ToInt64(f.GetRawConstantValue())},", DocIdOfField(f)))]
     : [.. Members(type)];
 
 // Documentation IDs, as the compiler spells them in the XML file: nested types join with a
@@ -231,9 +231,14 @@ string RenderHtml()
             // data-name matches the type alone, data-text matches its members and their doc
             // text too. The filter needs both: a hit on the type name keeps every member, a
             // hit inside one member keeps only that member.
-            var haystack = $"{type.Name} {type.Header} {Summary(type.DocId)} {string.Join(" ", type.Members.Select(m => m.Text + " " + Summary(m.DocId)))}";
+            var haystack = $"{type.Name} {type.Header} {Summary(type.DocId)} {string.Join(" ", type.Members.Select(m => m.Kind + " " + m.Text + " " + Summary(m.DocId)))}";
             body.AppendLine($"""        <article class="type" id="{id}" data-name="{Escape(type.Name.ToLowerInvariant())}" data-text="{Escape(haystack.ToLowerInvariant())}">""");
-            body.AppendLine($"""          <h3><a class="anchor" href="#{id}" aria-label="Link to {id}">#</a><code>{Escape(type.Header)}</code>{Tag(type.Obsolete)}</h3>""");
+
+            // Kind first, then the name, then the declaration. Reading "method" or "property"
+            // off a heading beats inferring it from whether the signature ends in parentheses
+            // or in an accessor list.
+            body.AppendLine($"""          <h3><a class="anchor" href="#{id}" aria-label="Link to {id}">#</a><span class="kind">{TypeKind(type.Type)}</span> <span class="name">{Escape(BareName(type.Type))}</span>{Tag(type.Obsolete)}</h3>""");
+            body.AppendLine($"""          <pre class="sig"><code>{Escape(type.Header)}</code></pre>""");
             body.Append(Doc(type.DocId, "          "));
 
             if (type.Members.Length > 0)
@@ -243,9 +248,21 @@ string RenderHtml()
                 {
                     var obsolete = member.Text.StartsWith("[Obsolete] ", StringComparison.Ordinal);
                     var text = obsolete ? member.Text["[Obsolete] ".Length..] : member.Text;
-                    var searchable = $"{text} {Summary(member.DocId)}".ToLowerInvariant();
+                    var searchable = $"{member.Kind} {text} {Summary(member.DocId)}".ToLowerInvariant();
                     body.AppendLine($"""            <div class="member" data-text="{Escape(searchable)}">""");
-                    body.AppendLine($"""              <code>{Escape(text)}</code>{Tag(obsolete)}""");
+
+                    // An enum value is its own heading - "value Deflate" above "Deflate = 1,"
+                    // would say the same thing twice - so it keeps the compact form.
+                    if (member.Kind != "value")
+                    {
+                        body.AppendLine($"""              <h4><span class="kind">{member.Kind}</span> <span class="name">{Escape(member.Name)}</span>{Tag(obsolete)}</h4>""");
+                        body.AppendLine($"""              <pre class="sig"><code>{Escape(text)}</code></pre>""");
+                    }
+                    else
+                    {
+                        body.AppendLine($"""              <pre class="sig"><code>{Escape(text)}</code></pre>{Tag(obsolete)}""");
+                    }
+
                     body.Append(Doc(member.DocId, "              "));
                     body.AppendLine("            </div>");
                 }
@@ -289,25 +306,25 @@ string RenderHtml()
 // Members of one type, sorted so the listing is stable across builds. Reflection makes no
 // promise about declaration order, so an unsorted dump would churn on every rebuild and
 // the diff would stop meaning anything.
-IEnumerable<(int Rank, string Text, string DocId)> Members(Type type)
+IEnumerable<(int Rank, string Kind, string Name, string Text, string DocId)> Members(Type type)
 {
     const BindingFlags Scope = BindingFlags.Public | BindingFlags.NonPublic
         | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;
 
-    var lines = new List<(int Rank, string Text, string DocId)>();
+    var lines = new List<(int Rank, string Kind, string Name, string Text, string DocId)>();
 
     foreach (var field in type.GetFields(Scope))
     {
         if (!Visible(field.IsPublic, field.IsFamily, field.IsFamilyOrAssembly) || Generated(field)) continue;
         var modifier = field.IsLiteral ? "const" : field.IsStatic ? "static" : null;
         var readOnly = field.IsInitOnly ? "readonly" : null;
-        lines.Add((0, Line(field, Access(field.IsPublic), modifier, readOnly, TypeName(field.FieldType, FieldNullability(field)), field.Name) + ";", DocIdOfField(field)));
+        lines.Add((0, field.IsLiteral ? "constant" : "field", field.Name, Line(field, Access(field.IsPublic), modifier, readOnly, TypeName(field.FieldType, FieldNullability(field)), field.Name) + ";", DocIdOfField(field)));
     }
 
     foreach (var ctor in type.GetConstructors(Scope))
     {
         if (!Visible(ctor.IsPublic, ctor.IsFamily, ctor.IsFamilyOrAssembly) || Generated(ctor)) continue;
-        lines.Add((1, Line(ctor, Access(ctor.IsPublic), null, null, null, $"{BareName(type)}({Parameters(ctor)})") + ";", DocIdOfMethod(ctor)));
+        lines.Add((1, "constructor", BareName(type), Line(ctor, Access(ctor.IsPublic), null, null, null, $"{BareName(type)}({Parameters(ctor)})") + ";", DocIdOfMethod(ctor)));
     }
 
     foreach (var property in type.GetProperties(Scope))
@@ -326,14 +343,14 @@ IEnumerable<(int Rank, string Text, string DocId)> Members(Type type)
 
         var anchor = readable ? getter! : setter!;
         var name = property.GetIndexParameters().Length > 0 ? $"this[{Parameters(anchor)}]" : property.Name;
-        lines.Add((2, Line(property, Access(anchor.IsPublic), anchor.IsStatic ? "static" : null, null,
+        lines.Add((2, property.GetIndexParameters().Length > 0 ? "indexer" : "property", name, Line(property, Access(anchor.IsPublic), anchor.IsStatic ? "static" : null, null,
             TypeName(property.PropertyType, PropertyNullability(property)), $"{name} {accessors}"), DocIdOfProperty(property)));
     }
 
     foreach (var evt in type.GetEvents(Scope))
     {
         if (evt.AddMethod is not { } add || !Visible(add.IsPublic, add.IsFamily, add.IsFamilyOrAssembly)) continue;
-        lines.Add((3, Line(evt, Access(add.IsPublic), add.IsStatic ? "static" : null, null,
+        lines.Add((3, "event", evt.Name, Line(evt, Access(add.IsPublic), add.IsStatic ? "static" : null, null,
             TypeName(evt.EventHandlerType!, null), $"{evt.Name} {{ add; remove; }}"), DocIdOfEvent(evt)));
     }
 
@@ -346,7 +363,7 @@ IEnumerable<(int Rank, string Text, string DocId)> Members(Type type)
             : method.IsVirtual && !method.IsFinal ? "virtual"
             : null;
         var name = $"{method.Name}{GenericSuffix(method.GetGenericArguments())}({Parameters(method)})";
-        lines.Add((4, Line(method, Access(method.IsPublic), modifier, null,
+        lines.Add((4, method.Name.StartsWith("op_", StringComparison.Ordinal) ? "operator" : "method", method.Name, Line(method, Access(method.IsPublic), modifier, null,
             TypeName(method.ReturnType, ParameterNullability(method.ReturnParameter)), name) + ";", DocIdOfMethod(method)));
     }
 
@@ -359,13 +376,15 @@ string Line(MemberInfo member, string access, string? modifier, string? readOnly
     return (IsObsolete(member) ? "[Obsolete] " : "") + string.Join(" ", parts);
 }
 
+string TypeKind(Type type) => type.IsEnum ? "enum"
+    : type.IsInterface ? "interface"
+    : typeof(Delegate).IsAssignableFrom(type) ? "delegate"
+    : type.IsValueType ? "struct"
+    : "class";
+
 string TypeHeader(Type type)
 {
-    var kind = type.IsEnum ? "enum"
-        : type.IsInterface ? "interface"
-        : typeof(Delegate).IsAssignableFrom(type) ? "delegate"
-        : type.IsValueType ? "struct"
-        : "class";
+    var kind = TypeKind(type);
 
     var modifiers = new List<string> { type.IsPublic || type.IsNestedPublic ? "public" : "protected" };
     if (type is { IsAbstract: true, IsSealed: true, IsEnum: false, IsInterface: false }) modifiers.Add("static");
@@ -653,12 +672,29 @@ string Shell(string outline, string content) => $$"""
         .type:last-child { border-bottom: 0; }
         .type[hidden], .member[hidden], .ns[hidden], .toc-item[hidden], .toc-ns[hidden] { display: none; }
 
-        .type > h3 {
+        .type > h3, .member > h4 {
+          margin: 0 0 0.35rem;
+          font-size: 0.95rem;
+          font-weight: 600;
+        }
+        .member > h4 { font-size: 0.88rem; }
+
+        /* The kind is the word a reader is looking for when scanning, so it leads; the name
+           carries the accent because that is what they are looking *for*. */
+        .kind { color: var(--text-muted); font-weight: 400; }
+        .name { color: var(--accent); }
+
+        /* Signatures wrap instead of scrolling: a horizontal scrollbar per signature hides
+           the end of every long one and makes the reader work for it. C# breaks cleanly at
+           the spaces after commas, and the hanging indent keeps continuations distinct. */
+        .sig {
           margin: 0;
-          font-weight: 500;
-          overflow-x: auto;
-          white-space: nowrap;
-          padding-bottom: 0.15rem;
+          padding: 0.35rem 0.6rem 0.35rem 2.4rem;
+          text-indent: -1.8rem;
+          background: var(--sig-bg);
+          border-radius: 4px;
+          white-space: pre-wrap;
+          overflow-wrap: break-word;
         }
 
         .anchor {
@@ -706,19 +742,11 @@ string Shell(string outline, string content) => $$"""
         .members { margin-top: 1rem; }
 
         .member {
-          padding: 0.5rem 0 0.5rem 0.9rem;
+          padding: 0.5rem 0 0.6rem 0.9rem;
           border-left: 2px solid var(--panel-border);
-          margin-bottom: 0.15rem;
+          margin-bottom: 0.35rem;
         }
         .member:hover { border-left-color: var(--accent); }
-        .member > code {
-          display: block;
-          padding: 0.28rem 0.55rem;
-          background: var(--sig-bg);
-          border-radius: 4px;
-          overflow-x: auto;
-          white-space: nowrap;
-        }
 
         .tag {
           display: inline-block;

--- a/tools/public_api.cs
+++ b/tools/public_api.cs
@@ -6,8 +6,11 @@
 #:property EnableSingleFileAnalyzer=false
 
 using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 using System.Runtime.CompilerServices;
 using System.Text;
+using System.Text.Json;
 
 // Prints the exported surface of SkiaSharp.QrCode as a sorted, diffable listing.
 //
@@ -37,6 +40,12 @@ var nullability = new NullabilityInfoContext();
 // Doc text, keyed by the documentation ID the compiler emits.
 var docs = LoadDocs();
 
+// Source links are opt-in because they are only trustworthy at release. SourceLink pins the
+// commit that was built, so a page generated from an unpushed local commit would link to a
+// SHA GitHub has never seen. The release workflow builds at the tag and passes the flag.
+var pdb = args.Contains("--source-links") ? LoadPdb() : null;
+var sourceCommit = pdb is null ? null : ShortCommit();
+
 var keywords = new Dictionary<Type, string>
 {
     [typeof(void)] = "void", [typeof(bool)] = "bool", [typeof(byte)] = "byte", [typeof(sbyte)] = "sbyte",
@@ -53,7 +62,14 @@ var types = assembly.GetExportedTypes()
 // Both renderers read the same model, so the page and the text listing can never disagree
 // about what the surface is.
 var model = types
-    .Select(t => (Type: t, Name: FullName(t), Header: TypeHeader(t), Obsolete: IsObsolete(t), DocId: DocIdOfType(t), Members: MemberEntries(t)))
+    .Select(t => MemberEntries(t) is var members
+        ? (Type: t, Name: FullName(t), Header: TypeHeader(t), Obsolete: IsObsolete(t), DocId: DocIdOfType(t),
+           // A type has no sequence points of its own, so it borrows the file its first member
+           // is in and drops the line: the right file, without claiming to know the exact line
+           // the declaration starts on.
+           Href: members.Select(m => m.Href).FirstOrDefault(h => h is not null)?.Split('#')[0],
+           Members: members)
+        : default)
     .ToArray();
 
 var rendered = wantsHtml ? RenderHtml() : RenderText();
@@ -71,9 +87,9 @@ else
 }
 return 0;
 
-(int Rank, string Kind, string Name, string Text, string DocId)[] MemberEntries(Type type) => type.IsEnum
+(int Rank, string Kind, string Name, string Text, string DocId, string? Href)[] MemberEntries(Type type) => type.IsEnum
     ? [.. type.GetFields(BindingFlags.Public | BindingFlags.Static)
-        .Select(f => (0, "value", f.Name, $"{f.Name} = {Convert.ToInt64(f.GetRawConstantValue())},", DocIdOfField(f)))]
+        .Select(f => (0, "value", f.Name, $"{f.Name} = {Convert.ToInt64(f.GetRawConstantValue())},", DocIdOfField(f), (string?)null))]
     : [.. Members(type)];
 
 // Documentation IDs, as the compiler spells them in the XML file: nested types join with a
@@ -119,6 +135,89 @@ string DocParam(Type type)
     }
 
     return DocTypeName(type);
+}
+
+// The PDB, plus the SourceLink document map read out of it. SourceLink is on by default in the
+// .NET SDK, so this needs no package: the map is one entry, a local path prefix to a
+// raw.githubusercontent URL carrying the commit that was built.
+(MetadataReader Reader, (string Prefix, string Template)[] Map)? LoadPdb()
+{
+    var path = Path.ChangeExtension(assembly.Location, ".pdb");
+    if (!File.Exists(path))
+    {
+        Console.Error.WriteLine($"No PDB beside {Path.GetFileName(assembly.Location)}; source links are omitted.");
+        return null;
+    }
+
+    // The provider owns the memory the reader points into, so it deliberately outlives this
+    // method rather than being disposed here.
+    var reader = MetadataReaderProvider.FromPortablePdbStream(File.OpenRead(path)).GetMetadataReader();
+    var kind = new Guid("CC110556-A091-4D38-9FEC-25AB9A351A6A");
+
+    foreach (var handle in reader.GetCustomDebugInformation(EntityHandle.ModuleDefinition))
+    {
+        var info = reader.GetCustomDebugInformation(handle);
+        if (reader.GetGuid(info.Kind) != kind) continue;
+
+        using var json = JsonDocument.Parse(reader.GetBlobBytes(info.Value));
+        var map = json.RootElement.GetProperty("documents").EnumerateObject()
+            .Select(e => (Prefix: e.Name, Template: e.Value.GetString() ?? ""))
+            .ToArray();
+        if (map.Length > 0) return (reader, map);
+    }
+
+    Console.Error.WriteLine("The PDB carries no SourceLink map; source links are omitted.");
+    return null;
+}
+
+string? ShortCommit()
+{
+    var template = pdb!.Value.Map[0].Template;
+    var parts = template.Replace("https://raw.githubusercontent.com/", "").Split('/');
+    return parts.Length >= 3 && parts[2].Length >= 7 ? parts[2][..7] : null;
+}
+
+// Where a member is declared, as a GitHub blob URL for the built commit. Only members with IL
+// have sequence points, so fields and enum values have no location and get no link.
+string? SourceHref(MethodBase? method)
+{
+    if (pdb is null || method is null) return null;
+
+    try
+    {
+        var (reader, _) = pdb.Value;
+        var debug = reader.GetMethodDebugInformation(MetadataTokens.MethodDebugInformationHandle(method.MetadataToken & 0xFFFFFF));
+        if (debug.Document.IsNil) return null;
+
+        var file = reader.GetString(reader.GetDocument(debug.Document).Name);
+        var line = debug.GetSequencePoints().Where(p => !p.IsHidden).Select(p => p.StartLine).FirstOrDefault();
+        var blob = BlobUrl(file);
+        return blob is null ? null : line > 0 ? $"{blob}#L{line}" : blob;
+    }
+    catch
+    {
+        // A token with no row in the PDB's debug table: no location, not a failure.
+        return null;
+    }
+}
+
+// raw.githubusercontent serves the file; github.com/blob is the page a reader wants, and the
+// only one of the two that honours a #L line anchor.
+string? BlobUrl(string documentPath)
+{
+    foreach (var (prefix, template) in pdb!.Value.Map)
+    {
+        var head = prefix.TrimEnd('*');
+        if (!documentPath.StartsWith(head, StringComparison.OrdinalIgnoreCase)) continue;
+
+        var raw = template.Replace("*", documentPath[head.Length..].Replace('\\', '/'));
+        const string RawHost = "https://raw.githubusercontent.com/";
+        if (!raw.StartsWith(RawHost, StringComparison.Ordinal)) return raw;
+
+        var parts = raw[RawHost.Length..].Split('/', 4);
+        return parts.Length < 4 ? raw : $"https://github.com/{parts[0]}/{parts[1]}/blob/{parts[2]}/{parts[3]}";
+    }
+    return null;
 }
 
 Dictionary<string, (string Summary, string Remarks)> LoadDocs()
@@ -237,7 +336,7 @@ string RenderHtml()
             // Kind first, then the name, then the declaration. Reading "method" or "property"
             // off a heading beats inferring it from whether the signature ends in parentheses
             // or in an accessor list.
-            body.AppendLine($"""          <h3><a class="anchor" href="#{id}" aria-label="Link to {id}">#</a><span class="kind">{TypeKind(type.Type)}</span> <span class="name">{Escape(BareName(type.Type))}</span>{Tag(type.Obsolete)}</h3>""");
+            body.AppendLine($"""          <h3><a class="anchor" href="#{id}" aria-label="Link to {id}">#</a><span class="kind">{TypeKind(type.Type)}</span> {Named(BareName(type.Type), type.Href, "source file")}{Tag(type.Obsolete)}</h3>""");
             body.AppendLine($"""          <pre class="sig"><code>{Escape(type.Header)}</code></pre>""");
             body.Append(Doc(type.DocId, "          "));
 
@@ -255,7 +354,7 @@ string RenderHtml()
                     // would say the same thing twice - so it keeps the compact form.
                     if (member.Kind != "value")
                     {
-                        body.AppendLine($"""              <h4><span class="kind">{member.Kind}</span> <span class="name">{Escape(member.Name)}</span>{Tag(obsolete)}</h4>""");
+                        body.AppendLine($"""              <h4><span class="kind">{member.Kind}</span> {Named(member.Name, member.Href, "source")}{Tag(obsolete)}</h4>""");
                         body.AppendLine($"""              <pre class="sig"><code>{Escape(text)}</code></pre>""");
                     }
                     else
@@ -278,6 +377,12 @@ string RenderHtml()
     return Shell(outline.ToString().TrimEnd(), body.ToString().TrimEnd());
 
     static string Tag(bool obsolete) => obsolete ? """ <span class="tag">obsolete</span>""" : "";
+
+    // The name is a link to the declaration when a location is known, and plain text when it
+    // is not, so a reader never clicks a name that goes nowhere.
+    static string Named(string name, string? href, string what) => href is null
+        ? $"""<span class="name">{Escape(name)}</span>"""
+        : $"""<a class="name" href="{Escape(href)}" title="View {what} on GitHub" target="_blank" rel="noopener noreferrer">{Escape(name)}</a>""";
 
     // Summaries are what a reader scans, so they are always shown. Remarks are the reasoning
     // behind them and often run several times longer, which buries the signatures when left
@@ -306,25 +411,25 @@ string RenderHtml()
 // Members of one type, sorted so the listing is stable across builds. Reflection makes no
 // promise about declaration order, so an unsorted dump would churn on every rebuild and
 // the diff would stop meaning anything.
-IEnumerable<(int Rank, string Kind, string Name, string Text, string DocId)> Members(Type type)
+IEnumerable<(int Rank, string Kind, string Name, string Text, string DocId, string? Href)> Members(Type type)
 {
     const BindingFlags Scope = BindingFlags.Public | BindingFlags.NonPublic
         | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;
 
-    var lines = new List<(int Rank, string Kind, string Name, string Text, string DocId)>();
+    var lines = new List<(int Rank, string Kind, string Name, string Text, string DocId, string? Href)>();
 
     foreach (var field in type.GetFields(Scope))
     {
         if (!Visible(field.IsPublic, field.IsFamily, field.IsFamilyOrAssembly) || Generated(field)) continue;
         var modifier = field.IsLiteral ? "const" : field.IsStatic ? "static" : null;
         var readOnly = field.IsInitOnly ? "readonly" : null;
-        lines.Add((0, field.IsLiteral ? "constant" : "field", field.Name, Line(field, Access(field.IsPublic), modifier, readOnly, TypeName(field.FieldType, FieldNullability(field)), field.Name) + ";", DocIdOfField(field)));
+        lines.Add((0, field.IsLiteral ? "constant" : "field", field.Name, Line(field, Access(field.IsPublic), modifier, readOnly, TypeName(field.FieldType, FieldNullability(field)), field.Name) + ";", DocIdOfField(field), null));
     }
 
     foreach (var ctor in type.GetConstructors(Scope))
     {
         if (!Visible(ctor.IsPublic, ctor.IsFamily, ctor.IsFamilyOrAssembly) || Generated(ctor)) continue;
-        lines.Add((1, "constructor", BareName(type), Line(ctor, Access(ctor.IsPublic), null, null, null, $"{BareName(type)}({Parameters(ctor)})") + ";", DocIdOfMethod(ctor)));
+        lines.Add((1, "constructor", BareName(type), Line(ctor, Access(ctor.IsPublic), null, null, null, $"{BareName(type)}({Parameters(ctor)})") + ";", DocIdOfMethod(ctor), SourceHref(ctor)));
     }
 
     foreach (var property in type.GetProperties(Scope))
@@ -344,14 +449,14 @@ IEnumerable<(int Rank, string Kind, string Name, string Text, string DocId)> Mem
         var anchor = readable ? getter! : setter!;
         var name = property.GetIndexParameters().Length > 0 ? $"this[{Parameters(anchor)}]" : property.Name;
         lines.Add((2, property.GetIndexParameters().Length > 0 ? "indexer" : "property", name, Line(property, Access(anchor.IsPublic), anchor.IsStatic ? "static" : null, null,
-            TypeName(property.PropertyType, PropertyNullability(property)), $"{name} {accessors}"), DocIdOfProperty(property)));
+            TypeName(property.PropertyType, PropertyNullability(property)), $"{name} {accessors}"), DocIdOfProperty(property), SourceHref(anchor)));
     }
 
     foreach (var evt in type.GetEvents(Scope))
     {
         if (evt.AddMethod is not { } add || !Visible(add.IsPublic, add.IsFamily, add.IsFamilyOrAssembly)) continue;
         lines.Add((3, "event", evt.Name, Line(evt, Access(add.IsPublic), add.IsStatic ? "static" : null, null,
-            TypeName(evt.EventHandlerType!, null), $"{evt.Name} {{ add; remove; }}"), DocIdOfEvent(evt)));
+            TypeName(evt.EventHandlerType!, null), $"{evt.Name} {{ add; remove; }}"), DocIdOfEvent(evt), SourceHref(add)));
     }
 
     foreach (var method in type.GetMethods(Scope))
@@ -364,7 +469,7 @@ IEnumerable<(int Rank, string Kind, string Name, string Text, string DocId)> Mem
             : null;
         var name = $"{method.Name}{GenericSuffix(method.GetGenericArguments())}({Parameters(method)})";
         lines.Add((4, method.Name.StartsWith("op_", StringComparison.Ordinal) ? "operator" : "method", method.Name, Line(method, Access(method.IsPublic), modifier, null,
-            TypeName(method.ReturnType, ParameterNullability(method.ReturnParameter)), name) + ";", DocIdOfMethod(method)));
+            TypeName(method.ReturnType, ParameterNullability(method.ReturnParameter)), name) + ";", DocIdOfMethod(method), SourceHref(method)));
     }
 
     return lines.OrderBy(l => l.Rank).ThenBy(l => l.Text, StringComparer.Ordinal);
@@ -683,6 +788,9 @@ string Shell(string outline, string content) => $$"""
            carries the accent because that is what they are looking *for*. */
         .kind { color: var(--text-muted); font-weight: 400; }
         .name { color: var(--accent); }
+        a.name { text-decoration: none; }
+        a.name:hover { text-decoration: underline; }
+        a.name:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 
         /* Signatures wrap instead of scrolling: a horizontal scrollbar per signature hides
            the end of every long one and makes the reader work for it. C# breaks cleanly at
@@ -773,7 +881,7 @@ string Shell(string outline, string content) => $$"""
       <header class="bar">
         <a class="back" href="../">&#8592; Playground</a>
         <h1>SkiaSharp.QrCode API</h1>
-        <span class="meta">{{assembly.GetName().Version}} &middot; <span id="count">{{model.Length}} types</span></span>
+        <span class="meta">{{assembly.GetName().Version}} &middot; <span id="count">{{model.Length}} types</span>{{(sourceCommit is null ? "" : $" &middot; source {sourceCommit}")}}</span>
       </header>
 
       <div class="layout">

--- a/tools/public_api.cs
+++ b/tools/public_api.cs
@@ -4,6 +4,8 @@
 #:property EnableAotAnalyzer=false
 #:property EnableTrimAnalyzer=false
 #:property EnableSingleFileAnalyzer=false
+#:property GenerateDocumentationFile=true
+#:property NoWarn=CS1573,CS1591,CS0419,CS1572
 
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -11,21 +13,32 @@ using System.Text;
 
 // Prints the exported surface of SkiaSharp.QrCode as a sorted, diffable listing.
 //
-//   dotnet run tools/public_api.cs                 to stdout
-//   dotnet run tools/public_api.cs -- -o api.txt   to a file
+//   dotnet run tools/public_api.cs                    plain text, to stdout
+//   dotnet run tools/public_api.cs -- -o api.txt      plain text, to a file
+//   dotnet run tools/public_api.cs -- --html -o p     a filterable page, to a file
 //
-// This is a viewer, not a gate. Nothing in CI runs it and nothing fails when the surface
-// changes: breaking changes are already caught by package validation against the released
-// baseline, which is the only surface check worth failing a build over.
+// Write the page into the Playground's wwwroot and one output serves both ways of looking
+// at it: it is there when the Playground runs locally, and publish copies it to the Pages
+// site. That path is generated, so it is gitignored rather than committed:
+//
+//   dotnet run tools/public_api.cs -- --html -o src/SkiaSharp.QrCode.Playground/wwwroot/api/index.html
+//
+// This is a viewer, not a gate. Nothing in CI validates it and nothing fails when the
+// surface changes: breaking changes are already caught by package validation against the
+// released baseline, which is the only surface check worth failing a build over.
 //
 // One target framework is enough. No exported type has a framework-conditional member -
 // the conditional compilation in the library all sits on internal types - so net10.0
 // represents netstandard2.0, netstandard2.1 and net8.0 as well.
 
 var outputPath = GetOutputPath(args);
+var wantsHtml = args.Contains("--html");
 var assembly = typeof(SkiaSharp.QrCode.QRCodeData).Assembly;
 var nullability = new NullabilityInfoContext();
-var sb = new StringBuilder();
+
+// Doc text, keyed by the documentation ID the compiler emits. See LoadDocs: the library does
+// not ship an XML documentation file, so this builds one for the tool's own use.
+var docs = LoadDocs();
 
 var keywords = new Dictionary<Type, string>
 {
@@ -40,79 +53,301 @@ var types = assembly.GetExportedTypes()
     .ThenBy(FullName, StringComparer.Ordinal)
     .ToArray();
 
-sb.AppendLine($"// {assembly.GetName().Name} {assembly.GetName().Version}");
-sb.AppendLine($"// {types.Length} exported types");
+// Both renderers read the same model, so the page and the text listing can never disagree
+// about what the surface is.
+var model = types
+    .Select(t => (Type: t, Name: FullName(t), Header: TypeHeader(t), Obsolete: IsObsolete(t), DocId: DocIdOfType(t), Members: MemberEntries(t)))
+    .ToArray();
 
-foreach (var byNamespace in types.GroupBy(t => t.Namespace).OrderBy(g => g.Key, StringComparer.Ordinal))
-{
-    sb.AppendLine();
-    sb.AppendLine($"namespace {byNamespace.Key}");
-    sb.AppendLine("{");
-    foreach (var type in byNamespace)
-    {
-        WriteType(type);
-    }
-    sb.AppendLine("}");
-}
+var rendered = wantsHtml ? RenderHtml() : RenderText();
 
 if (outputPath is null)
 {
-    Console.Out.Write(sb.ToString());
+    Console.Out.Write(rendered);
 }
 else
 {
-    File.WriteAllText(outputPath, sb.ToString());
-    Console.Error.WriteLine($"{types.Length} exported types written to {outputPath}");
+    var full = Path.GetFullPath(outputPath);
+    Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+    File.WriteAllText(full, rendered);
+    Console.Error.WriteLine($"{model.Length} exported types written to {full}");
 }
 return 0;
 
-void WriteType(Type type)
+(int Rank, string Text, string DocId)[] MemberEntries(Type type) => type.IsEnum
+    ? [.. type.GetFields(BindingFlags.Public | BindingFlags.Static)
+        .Select(f => (0, $"{f.Name} = {Convert.ToInt64(f.GetRawConstantValue())},", DocIdOfField(f)))]
+    : [.. Members(type)];
+
+// Documentation IDs, as the compiler spells them in the XML file: nested types join with a
+// dot rather than reflection's plus, byref is a trailing @, a constructed generic uses braces,
+// and a conversion operator carries its return type after a tilde because the parameter list
+// alone does not tell two of them apart.
+string DocIdOfType(Type type) => $"T:{DocTypeName(type)}";
+string DocIdOfField(FieldInfo field) => $"F:{DocTypeName(field.DeclaringType!)}.{field.Name}";
+string DocIdOfEvent(EventInfo evt) => $"E:{DocTypeName(evt.DeclaringType!)}.{evt.Name}";
+
+string DocIdOfProperty(PropertyInfo property)
 {
-    sb.AppendLine();
-    if (IsObsolete(type)) sb.AppendLine("    [Obsolete]");
-    sb.AppendLine($"    {TypeHeader(type)}");
-    sb.AppendLine("    {");
+    var indexers = property.GetIndexParameters();
+    var arguments = indexers.Length == 0 ? "" : $"({string.Join(",", indexers.Select(p => DocParam(p.ParameterType)))})";
+    return $"P:{DocTypeName(property.DeclaringType!)}.{property.Name}{arguments}";
+}
 
-    if (type.IsEnum)
+string DocIdOfMethod(MethodBase method)
+{
+    var name = method is ConstructorInfo ? "#ctor" : method.Name;
+    var arity = method.IsGenericMethodDefinition ? $"``{method.GetGenericArguments().Length}" : "";
+    var parameters = method.GetParameters();
+    var arguments = parameters.Length == 0 ? "" : $"({string.Join(",", parameters.Select(p => DocParam(p.ParameterType)))})";
+    var conversion = method is MethodInfo { Name: "op_Implicit" or "op_Explicit" } m ? $"~{DocParam(m.ReturnType)}" : "";
+    return $"M:{DocTypeName(method.DeclaringType!)}.{name}{arity}{arguments}{conversion}";
+}
+
+string DocTypeName(Type type) => (type.FullName ?? type.Name).Replace('+', '.');
+
+string DocParam(Type type)
+{
+    if (type.IsByRef) return $"{DocParam(type.GetElementType()!)}@";
+    if (type.IsPointer) return $"{DocParam(type.GetElementType()!)}*";
+    if (type.IsArray) return $"{DocParam(type.GetElementType()!)}[{new string(',', type.GetArrayRank() - 1)}]";
+    if (type.IsGenericParameter) return type.DeclaringMethod is null ? $"`{type.GenericParameterPosition}" : $"``{type.GenericParameterPosition}";
+
+    if (type.IsConstructedGenericType)
     {
-        foreach (var field in type.GetFields(BindingFlags.Public | BindingFlags.Static))
+        var bare = DocTypeName(type.GetGenericTypeDefinition());
+        var tick = bare.IndexOf('`');
+        if (tick >= 0) bare = bare[..tick];
+        return $"{bare}{{{string.Join(",", type.GetGenericArguments().Select(DocParam))}}}";
+    }
+
+    return DocTypeName(type);
+}
+
+Dictionary<string, (string Summary, string Remarks)> LoadDocs()
+{
+    // The library does not ship an XML documentation file - GenerateDocumentationFile is off,
+    // so the package carries no IntelliSense docs either - and the directives at the top of
+    // this script do not reach a referenced project. So build the library once with the
+    // property set and read the file that produces. The build is incremental, so repeat runs
+    // pay almost nothing for it.
+    var root = Path.GetFullPath(Path.Combine(ScriptDirectory(), ".."));
+    var project = Path.Combine(root, "src", "SkiaSharp.QrCode", "SkiaSharp.QrCode.csproj");
+    var path = Path.Combine(root, "src", "SkiaSharp.QrCode", "bin", "Release", "net10.0", "SkiaSharp.QrCode.xml");
+
+    if (!BuildDocumentation(project) || !File.Exists(path))
+    {
+        Console.Error.WriteLine("No XML documentation was produced; signatures will carry no doc text.");
+        return [];
+    }
+
+    var map = new Dictionary<string, (string Summary, string Remarks)>(StringComparer.Ordinal);
+    foreach (var member in System.Xml.Linq.XDocument.Load(path).Descendants("member"))
+    {
+        var id = member.Attribute("name")?.Value;
+        if (id is null) continue;
+
+        // Remarks carry most of the reasoning in this codebase - why a status is distinct,
+        // why a default is what it is - so dropping them would leave the page unable to
+        // answer the questions a reader actually arrives with.
+        var summary = member.Element("summary") is { } s ? FlattenDoc(s) : "";
+        var remarks = member.Element("remarks") is { } r ? FlattenDoc(r) : "";
+        if (summary.Length > 0 || remarks.Length > 0) map[id] = (summary, remarks);
+    }
+    return map;
+}
+
+// The four suppressed warnings are all doc-completeness complaints (an undocumented member,
+// a missing or stale param tag, an ambiguous cref). They are worth fixing, but in their own
+// pass; they must not stop this tool from reading the docs that do exist.
+bool BuildDocumentation(string project)
+{
+    try
+    {
+        using var build = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo("dotnet")
         {
-            sb.AppendLine($"        {field.Name} = {Convert.ToInt64(field.GetRawConstantValue())},");
+            ArgumentList =
+            {
+                "build", project, "-c", "Release", "-f", "net10.0", "--nologo", "-v", "quiet",
+                "-p:GenerateDocumentationFile=true",
+                "-p:NoWarn=CS1573%3BCS1591%3BCS0419%3BCS1572",
+            },
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        });
+
+        if (build is null) return false;
+        build.WaitForExit();
+        if (build.ExitCode == 0) return true;
+
+        Console.Error.WriteLine(build.StandardOutput.ReadToEnd().Trim());
+        return false;
+    }
+    catch (Exception e)
+    {
+        Console.Error.WriteLine($"Could not build the documentation file: {e.Message}");
+        return false;
+    }
+}
+
+// Anchors the repo-relative paths above to this file rather than to the current directory,
+// so the tool works from anywhere.
+static string ScriptDirectory([System.Runtime.CompilerServices.CallerFilePath] string path = "")
+    => Path.GetDirectoryName(path)!;
+
+// Doc XML is mixed content. Keep the prose, and render the references a reader cares about
+// as the short name they would type, dropping the ID prefix the compiler adds.
+string FlattenDoc(System.Xml.Linq.XElement element)
+{
+    var sb = new StringBuilder();
+    Walk(element);
+    return string.Join(" ", sb.ToString().Split((char[])[' ', '\t', '\r', '\n'], StringSplitOptions.RemoveEmptyEntries));
+
+    void Walk(System.Xml.Linq.XElement node)
+    {
+        foreach (var child in node.Nodes())
+        {
+            switch (child)
+            {
+                case System.Xml.Linq.XText text:
+                    sb.Append(text.Value);
+                    break;
+                case System.Xml.Linq.XElement e when e.Name == "see" || e.Name == "seealso":
+                    var reference = e.Attribute("cref")?.Value ?? e.Attribute("langword")?.Value ?? "";
+                    var colon = reference.IndexOf(':');
+                    if (colon == 1) reference = reference[(colon + 1)..];
+                    // Drop the parameter list before taking the last segment. Without this a
+                    // method cref ends at the last dot inside its own arguments, which reads
+                    // as a stray parameter type rather than the method being pointed at.
+                    var paren = reference.IndexOf('(');
+                    if (paren >= 0) reference = reference[..paren];
+                    var tick = reference.IndexOf('`');
+                    if (tick >= 0) reference = reference[..tick];
+                    sb.Append(' ').Append(reference[(reference.LastIndexOf('.') + 1)..]).Append(' ');
+                    break;
+                case System.Xml.Linq.XElement e when e.Name == "paramref" || e.Name == "typeparamref":
+                    sb.Append(' ').Append(e.Attribute("name")?.Value ?? "").Append(' ');
+                    break;
+                case System.Xml.Linq.XElement e:
+                    Walk(e);
+                    break;
+            }
         }
     }
-    else
+}
+
+string RenderText()
+{
+    var sb = new StringBuilder();
+    sb.AppendLine($"// {assembly.GetName().Name} {assembly.GetName().Version}");
+    sb.AppendLine($"// {model.Length} exported types");
+
+    foreach (var group in model.GroupBy(m => m.Type.Namespace).OrderBy(g => g.Key, StringComparer.Ordinal))
     {
-        foreach (var member in Members(type))
+        sb.AppendLine();
+        sb.AppendLine($"namespace {group.Key}");
+        sb.AppendLine("{");
+        foreach (var type in group)
         {
-            sb.AppendLine($"        {member}");
+            sb.AppendLine();
+            if (type.Obsolete) sb.AppendLine("    [Obsolete]");
+            sb.AppendLine($"    {type.Header}");
+            sb.AppendLine("    {");
+            foreach (var member in type.Members) sb.AppendLine($"        {member.Text}");
+            sb.AppendLine("    }");
         }
+        sb.AppendLine("}");
     }
 
-    sb.AppendLine("    }");
+    return sb.ToString();
+}
+
+string RenderHtml()
+{
+    var outline = new StringBuilder();
+    var body = new StringBuilder();
+
+    foreach (var group in model.GroupBy(m => m.Type.Namespace).OrderBy(g => g.Key, StringComparer.Ordinal))
+    {
+        outline.AppendLine($"""        <p class="toc-ns">{Escape(group.Key!)}</p>""");
+        body.AppendLine($"""      <section class="ns">""");
+        body.AppendLine($"""        <h2>namespace {Escape(group.Key!)}</h2>""");
+
+        foreach (var type in group)
+        {
+            var id = Escape(type.Name);
+            outline.AppendLine($"""        <a class="toc-item" href="#{id}" data-for="{id}">{Escape(BareName(type.Type))}</a>""");
+
+            // data-name matches the type alone, data-text matches its members and their doc
+            // text too. The filter needs both: a hit on the type name keeps every member, a
+            // hit inside one member keeps only that member.
+            var haystack = $"{type.Name} {type.Header} {Summary(type.DocId)} {string.Join(" ", type.Members.Select(m => m.Text + " " + Summary(m.DocId)))}";
+            body.AppendLine($"""        <article class="type" id="{id}" data-name="{Escape(type.Name.ToLowerInvariant())}" data-text="{Escape(haystack.ToLowerInvariant())}">""");
+            body.AppendLine($"""          <h3><a class="anchor" href="#{id}" aria-label="Link to {id}">#</a><code>{Escape(type.Header)}</code>{Tag(type.Obsolete)}</h3>""");
+            body.Append(Doc(type.DocId, "          "));
+
+            if (type.Members.Length > 0)
+            {
+                body.AppendLine("""          <div class="members">""");
+                foreach (var member in type.Members)
+                {
+                    var obsolete = member.Text.StartsWith("[Obsolete] ", StringComparison.Ordinal);
+                    var text = obsolete ? member.Text["[Obsolete] ".Length..] : member.Text;
+                    var searchable = $"{text} {Summary(member.DocId)}".ToLowerInvariant();
+                    body.AppendLine($"""            <div class="member" data-text="{Escape(searchable)}">""");
+                    body.AppendLine($"""              <code>{Escape(text)}</code>{Tag(obsolete)}""");
+                    body.Append(Doc(member.DocId, "              "));
+                    body.AppendLine("            </div>");
+                }
+                body.AppendLine("          </div>");
+            }
+
+            body.AppendLine("        </article>");
+        }
+
+        body.AppendLine("      </section>");
+    }
+
+    return Shell(outline.ToString().TrimEnd(), body.ToString().TrimEnd());
+
+    static string Tag(bool obsolete) => obsolete ? """ <span class="tag">obsolete</span>""" : "";
+
+    string Doc(string docId, string indent)
+    {
+        if (!docs.TryGetValue(docId, out var text)) return "";
+        var sb = new StringBuilder();
+        if (text.Summary.Length > 0) sb.AppendLine($"""{indent}<p class="doc">{Escape(text.Summary)}</p>""");
+        if (text.Remarks.Length > 0) sb.AppendLine($"""{indent}<p class="doc remarks">{Escape(text.Remarks)}</p>""");
+        return sb.ToString();
+    }
+
+    // Everything on the page is searchable, remarks included: the filter must not know less
+    // than the reader can see.
+    string Summary(string docId) => docs.TryGetValue(docId, out var text) ? $"{text.Summary} {text.Remarks}" : "";
 }
 
 // Members of one type, sorted so the listing is stable across builds. Reflection makes no
 // promise about declaration order, so an unsorted dump would churn on every rebuild and
 // the diff would stop meaning anything.
-IEnumerable<string> Members(Type type)
+IEnumerable<(int Rank, string Text, string DocId)> Members(Type type)
 {
     const BindingFlags Scope = BindingFlags.Public | BindingFlags.NonPublic
         | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;
 
-    var lines = new List<(int Rank, string Text)>();
+    var lines = new List<(int Rank, string Text, string DocId)>();
 
     foreach (var field in type.GetFields(Scope))
     {
         if (!Visible(field.IsPublic, field.IsFamily, field.IsFamilyOrAssembly) || Generated(field)) continue;
         var modifier = field.IsLiteral ? "const" : field.IsStatic ? "static" : null;
         var readOnly = field.IsInitOnly ? "readonly" : null;
-        lines.Add((0, Line(field, Access(field.IsPublic), modifier, readOnly, TypeName(field.FieldType, FieldNullability(field)), field.Name) + ";"));
+        lines.Add((0, Line(field, Access(field.IsPublic), modifier, readOnly, TypeName(field.FieldType, FieldNullability(field)), field.Name) + ";", DocIdOfField(field)));
     }
 
     foreach (var ctor in type.GetConstructors(Scope))
     {
         if (!Visible(ctor.IsPublic, ctor.IsFamily, ctor.IsFamilyOrAssembly) || Generated(ctor)) continue;
-        lines.Add((1, Line(ctor, Access(ctor.IsPublic), null, null, null, $"{BareName(type)}({Parameters(ctor)})") + ";"));
+        lines.Add((1, Line(ctor, Access(ctor.IsPublic), null, null, null, $"{BareName(type)}({Parameters(ctor)})") + ";", DocIdOfMethod(ctor)));
     }
 
     foreach (var property in type.GetProperties(Scope))
@@ -132,14 +367,14 @@ IEnumerable<string> Members(Type type)
         var anchor = readable ? getter! : setter!;
         var name = property.GetIndexParameters().Length > 0 ? $"this[{Parameters(anchor)}]" : property.Name;
         lines.Add((2, Line(property, Access(anchor.IsPublic), anchor.IsStatic ? "static" : null, null,
-            TypeName(property.PropertyType, PropertyNullability(property)), $"{name} {accessors}")));
+            TypeName(property.PropertyType, PropertyNullability(property)), $"{name} {accessors}"), DocIdOfProperty(property)));
     }
 
     foreach (var evt in type.GetEvents(Scope))
     {
         if (evt.AddMethod is not { } add || !Visible(add.IsPublic, add.IsFamily, add.IsFamilyOrAssembly)) continue;
         lines.Add((3, Line(evt, Access(add.IsPublic), add.IsStatic ? "static" : null, null,
-            TypeName(evt.EventHandlerType!, null), $"{evt.Name} {{ add; remove; }}")));
+            TypeName(evt.EventHandlerType!, null), $"{evt.Name} {{ add; remove; }}"), DocIdOfEvent(evt)));
     }
 
     foreach (var method in type.GetMethods(Scope))
@@ -152,10 +387,10 @@ IEnumerable<string> Members(Type type)
             : null;
         var name = $"{method.Name}{GenericSuffix(method.GetGenericArguments())}({Parameters(method)})";
         lines.Add((4, Line(method, Access(method.IsPublic), modifier, null,
-            TypeName(method.ReturnType, ParameterNullability(method.ReturnParameter)), name) + ";"));
+            TypeName(method.ReturnType, ParameterNullability(method.ReturnParameter)), name) + ";", DocIdOfMethod(method)));
     }
 
-    return lines.OrderBy(l => l.Rank).ThenBy(l => l.Text, StringComparer.Ordinal).Select(l => l.Text);
+    return lines.OrderBy(l => l.Rank).ThenBy(l => l.Text, StringComparer.Ordinal);
 }
 
 string Line(MemberInfo member, string access, string? modifier, string? readOnly, string? returnType, string name)
@@ -270,6 +505,369 @@ static string Literal(object? value) => value switch
     bool b => b ? "true" : "false",
     _ => Convert.ToString(value, System.Globalization.CultureInfo.InvariantCulture) ?? "?",
 };
+
+static string Escape(string value) => value
+    .Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;").Replace("\"", "&quot;");
+
+// Self-contained page: it sits next to a fingerprinted Blazor stylesheet it cannot link to,
+// so it carries its own. The colours, the three theme states and the storage key are copied
+// from the Playground on purpose, so a theme chosen there still applies here.
+string Shell(string outline, string content) => $$"""
+    <!DOCTYPE html>
+    <html lang="en">
+
+    <head>
+      <meta charset="utf-8" />
+      <title>SkiaSharp.QrCode API</title>
+      <meta name="description" content="Every public type in SkiaSharp.QrCode {{assembly.GetName().Version}}" />
+      <meta name="viewport" content="width=device-width, initial-scale=1" />
+      <meta name="color-scheme" id="meta-color-scheme" content="light dark" />
+      <link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+      <script>
+        (function () {
+          var key = 'skqr-playground-color-mode';
+          var meta = document.getElementById('meta-color-scheme');
+          try {
+            var v = localStorage.getItem(key);
+            if (v === 'light' || v === 'dark') {
+              document.documentElement.setAttribute('data-theme', v);
+              if (meta) meta.setAttribute('content', v);
+            }
+          } catch (e) { /* private mode, cleared storage: the default is fine */ }
+        })();
+      </script>
+      <style>
+        :root {
+          color-scheme: light dark;
+          --accent: #d62976;
+          --bg: #f6f7fb;
+          --panel-bg: #ffffff;
+          --panel-border: #e3e6ee;
+          --text: #1f2430;
+          --text-muted: #5b6474;
+          --input-bg: #ffffff;
+          --input-border: #c9cfdd;
+          --tag-bg: #fbe7f0;
+          --tag-text: #a3306a;
+          --sig-bg: #f0f2f8;
+          --shadow: 0 1px 3px rgba(16, 24, 40, 0.08);
+        }
+
+        @media (prefers-color-scheme: dark) {
+          :root:not([data-theme="light"]) {
+            --bg: #12141c;
+            --panel-bg: #1a1d28;
+            --panel-border: #2a2f40;
+            --text: #e6e9f2;
+            --text-muted: #98a1b5;
+            --input-bg: #12141c;
+            --input-border: #3a4157;
+            --tag-bg: #3a1f2e;
+            --tag-text: #f19ac2;
+            --sig-bg: #222634;
+            --shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+          }
+        }
+
+        :root[data-theme="dark"] {
+          --bg: #12141c;
+          --panel-bg: #1a1d28;
+          --panel-border: #2a2f40;
+          --text: #e6e9f2;
+          --text-muted: #98a1b5;
+          --input-bg: #12141c;
+          --input-border: #3a4157;
+          --tag-bg: #3a1f2e;
+          --tag-text: #f19ac2;
+          --sig-bg: #222634;
+          --shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+        }
+
+        * { box-sizing: border-box; }
+
+        body {
+          margin: 0;
+          background: var(--bg);
+          color: var(--text);
+          font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+          line-height: 1.65;
+        }
+
+        code {
+          font-family: ui-monospace, "Cascadia Mono", "SFMono-Regular", Consolas, monospace;
+          font-size: 0.84rem;
+        }
+
+        .bar {
+          position: sticky;
+          top: 0;
+          z-index: 20;
+          display: flex;
+          align-items: baseline;
+          gap: 0.9rem;
+          flex-wrap: wrap;
+          padding: 0.7rem clamp(1rem, 3vw, 2rem);
+          background: var(--panel-bg);
+          border-bottom: 1px solid var(--panel-border);
+        }
+        .bar h1 { font-size: 1rem; margin: 0; }
+        .back { color: var(--accent); text-decoration: none; font-size: 0.85rem; white-space: nowrap; }
+        .back:hover { text-decoration: underline; }
+        .meta { color: var(--text-muted); font-size: 0.8rem; font-variant-numeric: tabular-nums; }
+
+        .layout {
+          display: grid;
+          grid-template-columns: minmax(0, 1fr);
+          gap: 0 2rem;
+          max-width: 1240px;
+          margin-inline: auto;
+          padding: 0 clamp(1rem, 3vw, 2rem) 4rem;
+        }
+
+        @media (min-width: 60rem) {
+          .layout { grid-template-columns: 17rem minmax(0, 1fr); }
+          .sidebar {
+            position: sticky;
+            top: 3.4rem;
+            align-self: start;
+            max-height: calc(100vh - 4.5rem);
+            overflow-y: auto;
+          }
+        }
+
+        .sidebar { padding-top: 1.5rem; }
+
+        #q {
+          width: 100%;
+          padding: 0.45rem 0.7rem;
+          margin-bottom: 1rem;
+          background: var(--input-bg);
+          color: var(--text);
+          border: 1px solid var(--input-border);
+          border-radius: 6px;
+          font: inherit;
+          font-size: 0.86rem;
+        }
+        #q:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+
+        .toc-ns {
+          margin: 1rem 0 0.4rem;
+          font-size: 0.7rem;
+          letter-spacing: 0.11em;
+          text-transform: uppercase;
+          color: var(--text-muted);
+        }
+        .toc-ns:first-of-type { margin-top: 0; }
+
+        .toc-item {
+          display: block;
+          padding: 0.13rem 0.55rem;
+          border-left: 2px solid transparent;
+          color: var(--text-muted);
+          text-decoration: none;
+          font-size: 0.82rem;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+        .toc-item:hover { color: var(--text); }
+        .toc-item.current { border-left-color: var(--accent); color: var(--accent); }
+
+        main { padding-top: 1.5rem; min-width: 0; }
+
+        .ns > h2 {
+          margin: 0 0 1rem;
+          padding-bottom: 0.4rem;
+          border-bottom: 1px solid var(--panel-border);
+          font-size: 0.95rem;
+          font-weight: 600;
+          color: var(--text-muted);
+        }
+
+        .type {
+          padding-bottom: 1.6rem;
+          margin-bottom: 1.6rem;
+          border-bottom: 1px solid var(--panel-border);
+          scroll-margin-top: 4rem;
+        }
+        .type:last-child { border-bottom: 0; }
+        .type[hidden], .member[hidden], .ns[hidden], .toc-item[hidden], .toc-ns[hidden] { display: none; }
+
+        .type > h3 {
+          margin: 0;
+          font-weight: 500;
+          overflow-x: auto;
+          white-space: nowrap;
+          padding-bottom: 0.15rem;
+        }
+
+        .anchor {
+          color: var(--text-muted);
+          text-decoration: none;
+          margin-right: 0.45rem;
+          opacity: 0;
+        }
+        .type:hover > h3 .anchor, .anchor:focus-visible { opacity: 1; }
+
+        /* Doc text is prose, so it gets prose width and the body face; signatures stay mono. */
+        .doc {
+          margin: 0.4rem 0 0;
+          max-width: 74ch;
+          font-size: 0.86rem;
+          color: var(--text-muted);
+        }
+        .type > .doc { margin-bottom: 0.2rem; }
+
+        /* Remarks are the reasoning behind the summary, so they sit a step back from it. */
+        .remarks {
+          padding-left: 0.7rem;
+          border-left: 1px solid var(--panel-border);
+          font-size: 0.82rem;
+          opacity: 0.85;
+        }
+
+        .members { margin-top: 1rem; }
+
+        .member {
+          padding: 0.5rem 0 0.5rem 0.9rem;
+          border-left: 2px solid var(--panel-border);
+          margin-bottom: 0.15rem;
+        }
+        .member:hover { border-left-color: var(--accent); }
+        .member > code {
+          display: block;
+          padding: 0.28rem 0.55rem;
+          background: var(--sig-bg);
+          border-radius: 4px;
+          overflow-x: auto;
+          white-space: nowrap;
+        }
+
+        .tag {
+          display: inline-block;
+          margin-left: 0.5rem;
+          padding: 0.02rem 0.4rem;
+          border-radius: 999px;
+          background: var(--tag-bg);
+          color: var(--tag-text);
+          font-size: 0.65rem;
+          letter-spacing: 0.04em;
+          text-transform: uppercase;
+        }
+
+        .empty { color: var(--text-muted); }
+        .empty[hidden] { display: none; }
+
+        @media (prefers-reduced-motion: no-preference) {
+          html { scroll-behavior: smooth; }
+        }
+      </style>
+    </head>
+
+    <body>
+      <header class="bar">
+        <a class="back" href="../">&#8592; Playground</a>
+        <h1>SkiaSharp.QrCode API</h1>
+        <span class="meta">{{assembly.GetName().Version}} &middot; <span id="count">{{model.Length}} types</span></span>
+      </header>
+
+      <div class="layout">
+        <aside class="sidebar">
+          <input id="q" type="search" placeholder="Filter (press /)" autocomplete="off" spellcheck="false"
+            aria-label="Filter types and members" />
+          <nav id="toc" aria-label="Types">
+    {{outline}}
+          </nav>
+        </aside>
+
+        <main>
+    {{content}}
+          <p class="empty" id="empty" hidden>Nothing matches that.</p>
+        </main>
+      </div>
+
+      <script>
+        (function () {
+          var box = document.getElementById('q');
+          var count = document.getElementById('count');
+          var empty = document.getElementById('empty');
+          var types = Array.prototype.slice.call(document.querySelectorAll('.type'));
+          var sections = Array.prototype.slice.call(document.querySelectorAll('.ns'));
+          var tocItems = Array.prototype.slice.call(document.querySelectorAll('.toc-item'));
+          var tocGroups = Array.prototype.slice.call(document.querySelectorAll('.toc-ns'));
+          var tocByType = {};
+          tocItems.forEach(function (item) { tocByType[item.dataset.for] = item; });
+
+          function apply() {
+            var term = box.value.trim().toLowerCase();
+            var shown = 0;
+
+            types.forEach(function (type) {
+              var nameHit = !term || type.dataset.name.indexOf(term) !== -1;
+              var hit = !term || nameHit || type.dataset.text.indexOf(term) !== -1;
+              type.hidden = !hit;
+              if (hit) shown++;
+
+              var entry = tocByType[type.id];
+              if (entry) entry.hidden = !hit;
+
+              // A type matched by name keeps all of its members; matched inside one member,
+              // only that member.
+              Array.prototype.forEach.call(type.querySelectorAll('.member'), function (member) {
+                member.hidden = !!term && !nameHit && member.dataset.text.indexOf(term) === -1;
+              });
+            });
+
+            sections.forEach(function (section) {
+              section.hidden = !section.querySelector('.type:not([hidden])');
+            });
+
+            // A namespace heading in the outline belongs to the links that follow it.
+            tocGroups.forEach(function (group) {
+              var visible = false;
+              for (var n = group.nextElementSibling; n && n.classList.contains('toc-item'); n = n.nextElementSibling) {
+                if (!n.hidden) { visible = true; break; }
+              }
+              group.hidden = !visible;
+            });
+
+            empty.hidden = shown !== 0;
+            count.textContent = term ? shown + ' of ' + types.length + ' types' : types.length + ' types';
+          }
+
+          box.addEventListener('input', apply);
+          box.addEventListener('keydown', function (e) {
+            if (e.key === 'Escape') { box.value = ''; apply(); }
+          });
+          document.addEventListener('keydown', function (e) {
+            if (e.key === '/' && document.activeElement !== box) { e.preventDefault(); box.focus(); }
+          });
+
+          // Highlight the outline entry for whatever is being read. Bottom margin keeps the
+          // choice on the upper part of the viewport rather than flipping at the fold.
+          if ('IntersectionObserver' in window) {
+            var current = null;
+            var observer = new IntersectionObserver(function (entries) {
+              entries.forEach(function (entry) {
+                if (!entry.isIntersecting) return;
+                var entryLink = tocByType[entry.target.id];
+                if (!entryLink || entryLink === current) return;
+                if (current) current.classList.remove('current');
+                entryLink.classList.add('current');
+                current = entryLink;
+              });
+            }, { rootMargin: '0px 0px -75% 0px' });
+            types.forEach(function (type) { observer.observe(type); });
+          }
+
+          apply();
+        })();
+      </script>
+    </body>
+
+    </html>
+
+    """;
 
 static string? GetOutputPath(string[] args)
 {

--- a/tools/public_api.cs
+++ b/tools/public_api.cs
@@ -4,8 +4,6 @@
 #:property EnableAotAnalyzer=false
 #:property EnableTrimAnalyzer=false
 #:property EnableSingleFileAnalyzer=false
-#:property GenerateDocumentationFile=true
-#:property NoWarn=CS1573,CS1591,CS0419,CS1572
 
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -36,8 +34,7 @@ var wantsHtml = args.Contains("--html");
 var assembly = typeof(SkiaSharp.QrCode.QRCodeData).Assembly;
 var nullability = new NullabilityInfoContext();
 
-// Doc text, keyed by the documentation ID the compiler emits. See LoadDocs: the library does
-// not ship an XML documentation file, so this builds one for the tool's own use.
+// Doc text, keyed by the documentation ID the compiler emits.
 var docs = LoadDocs();
 
 var keywords = new Dictionary<Type, string>
@@ -126,18 +123,12 @@ string DocParam(Type type)
 
 Dictionary<string, (string Summary, string Remarks)> LoadDocs()
 {
-    // The library does not ship an XML documentation file - GenerateDocumentationFile is off,
-    // so the package carries no IntelliSense docs either - and the directives at the top of
-    // this script do not reach a referenced project. So build the library once with the
-    // property set and read the file that produces. The build is incremental, so repeat runs
-    // pay almost nothing for it.
-    var root = Path.GetFullPath(Path.Combine(ScriptDirectory(), ".."));
-    var project = Path.Combine(root, "src", "SkiaSharp.QrCode", "SkiaSharp.QrCode.csproj");
-    var path = Path.Combine(root, "src", "SkiaSharp.QrCode", "bin", "Release", "net10.0", "SkiaSharp.QrCode.xml");
-
-    if (!BuildDocumentation(project) || !File.Exists(path))
+    // The library generates its documentation file and ships it in the package, and a project
+    // reference copies it next to the assembly, so there is nothing to build here.
+    var path = Path.ChangeExtension(assembly.Location, ".xml");
+    if (!File.Exists(path))
     {
-        Console.Error.WriteLine("No XML documentation was produced; signatures will carry no doc text.");
+        Console.Error.WriteLine($"No XML documentation beside {Path.GetFileName(assembly.Location)}; signatures will carry no doc text.");
         return [];
     }
 
@@ -147,53 +138,12 @@ Dictionary<string, (string Summary, string Remarks)> LoadDocs()
         var id = member.Attribute("name")?.Value;
         if (id is null) continue;
 
-        // Remarks carry most of the reasoning in this codebase - why a status is distinct,
-        // why a default is what it is - so dropping them would leave the page unable to
-        // answer the questions a reader actually arrives with.
         var summary = member.Element("summary") is { } s ? FlattenDoc(s) : "";
         var remarks = member.Element("remarks") is { } r ? FlattenDoc(r) : "";
         if (summary.Length > 0 || remarks.Length > 0) map[id] = (summary, remarks);
     }
     return map;
 }
-
-// The four suppressed warnings are all doc-completeness complaints (an undocumented member,
-// a missing or stale param tag, an ambiguous cref). They are worth fixing, but in their own
-// pass; they must not stop this tool from reading the docs that do exist.
-bool BuildDocumentation(string project)
-{
-    try
-    {
-        using var build = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo("dotnet")
-        {
-            ArgumentList =
-            {
-                "build", project, "-c", "Release", "-f", "net10.0", "--nologo", "-v", "quiet",
-                "-p:GenerateDocumentationFile=true",
-                "-p:NoWarn=CS1573%3BCS1591%3BCS0419%3BCS1572",
-            },
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-        });
-
-        if (build is null) return false;
-        build.WaitForExit();
-        if (build.ExitCode == 0) return true;
-
-        Console.Error.WriteLine(build.StandardOutput.ReadToEnd().Trim());
-        return false;
-    }
-    catch (Exception e)
-    {
-        Console.Error.WriteLine($"Could not build the documentation file: {e.Message}");
-        return false;
-    }
-}
-
-// Anchors the repo-relative paths above to this file rather than to the current directory,
-// so the tool works from anywhere.
-static string ScriptDirectory([System.Runtime.CompilerServices.CallerFilePath] string path = "")
-    => Path.GetDirectoryName(path)!;
 
 // Doc XML is mixed content. Keep the prose, and render the references a reader cares about
 // as the short name they would type, dropping the ID prefix the compiler adds.
@@ -312,12 +262,22 @@ string RenderHtml()
 
     static string Tag(bool obsolete) => obsolete ? """ <span class="tag">obsolete</span>""" : "";
 
+    // Summaries are what a reader scans, so they are always shown. Remarks are the reasoning
+    // behind them and often run several times longer, which buries the signatures when left
+    // open, so they fold away behind a toggle. The filter opens the ones it matched inside.
     string Doc(string docId, string indent)
     {
         if (!docs.TryGetValue(docId, out var text)) return "";
+
         var sb = new StringBuilder();
         if (text.Summary.Length > 0) sb.AppendLine($"""{indent}<p class="doc">{Escape(text.Summary)}</p>""");
-        if (text.Remarks.Length > 0) sb.AppendLine($"""{indent}<p class="doc remarks">{Escape(text.Remarks)}</p>""");
+        if (text.Remarks.Length > 0)
+        {
+            sb.AppendLine($"""{indent}<details class="notes" data-text="{Escape(text.Remarks.ToLowerInvariant())}">""");
+            sb.AppendLine($"""{indent}  <summary>Notes</summary>""");
+            sb.AppendLine($"""{indent}  <p class="doc remarks">{Escape(text.Remarks)}</p>""");
+            sb.AppendLine($"""{indent}</details>""");
+        }
         return sb.ToString();
     }
 
@@ -719,7 +679,24 @@ string Shell(string outline, string content) => $$"""
         .type > .doc { margin-bottom: 0.2rem; }
 
         /* Remarks are the reasoning behind the summary, so they sit a step back from it. */
+        .notes { margin-top: 0.3rem; }
+        .notes > summary {
+          display: inline-block;
+          cursor: pointer;
+          font-size: 0.74rem;
+          letter-spacing: 0.05em;
+          text-transform: uppercase;
+          color: var(--text-muted);
+          list-style: none;
+        }
+        .notes > summary::-webkit-details-marker { display: none; }
+        .notes > summary::before { content: "\25B8"; display: inline-block; margin-right: 0.35rem; }
+        .notes[open] > summary::before { content: "\25BE"; }
+        .notes > summary:hover { color: var(--accent); }
+        .notes > summary:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
         .remarks {
+          margin-top: 0.3rem;
           padding-left: 0.7rem;
           border-left: 1px solid var(--panel-border);
           font-size: 0.82rem;
@@ -795,6 +772,7 @@ string Shell(string outline, string content) => $$"""
           var sections = Array.prototype.slice.call(document.querySelectorAll('.ns'));
           var tocItems = Array.prototype.slice.call(document.querySelectorAll('.toc-item'));
           var tocGroups = Array.prototype.slice.call(document.querySelectorAll('.toc-ns'));
+          var notes = Array.prototype.slice.call(document.querySelectorAll('.notes'));
           var tocByType = {};
           tocItems.forEach(function (item) { tocByType[item.dataset.for] = item; });
 
@@ -820,6 +798,13 @@ string Shell(string outline, string content) => $$"""
 
             sections.forEach(function (section) {
               section.hidden = !section.querySelector('.type:not([hidden])');
+            });
+
+            // Open a folded Notes block only when the term is in there, so a search never
+            // leaves the reader wondering where the match was. Clearing the box folds them
+            // back rather than leaving the page expanded.
+            notes.forEach(function (note) {
+              note.open = !!term && note.dataset.text.indexOf(term) !== -1;
             });
 
             // A namespace heading in the outline belongs to the links that follow it.


### PR DESCRIPTION
## Summary

Adds a browsable public API listing at `/api/index.html`, linked from the Playground header.

The page shows every exported type and member as **kind → signature → doc text**, following pkg.go.dev: a heading naming the kind (`method`, `property`, `field`, …) and the symbol, the full declaration below it, then the documentation. Doc text comes from the XML file the library now ships, so it matches what a consumer sees in IntelliSense. `<summary>` is always visible; `<remarks>` folds behind a **Notes** toggle, since it usually runs several times longer than the summary it explains. A sidebar filter searches types, members and doc text, and opens only the Notes it matched inside.